### PR TITLE
Expose Digitalogic runtime and PWA manifests

### DIFF
--- a/assets/js/digitalogic-pwa.js
+++ b/assets/js/digitalogic-pwa.js
@@ -1,0 +1,14 @@
+(function(window) {
+    'use strict';
+
+    var runtime = window.DigitalogicRuntime;
+    if (!runtime) {
+        return;
+    }
+
+    runtime.registerServiceWorker('/digitalogic-service-worker.js', {scope: '/'}).catch(function(error) {
+        if (window.console && window.console.debug) {
+            window.console.debug('Digitalogic service worker registration failed', error);
+        }
+    });
+})(window);

--- a/assets/js/digitalogic-runtime.js
+++ b/assets/js/digitalogic-runtime.js
@@ -1,0 +1,234 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.DigitalogicRuntime = factory();
+  }
+})(typeof self !== 'undefined' ? self : this, function() {
+  'use strict';
+
+  var DEFAULTS = {
+    appName: 'Digitalogic',
+    apiBase: 'https://digitalogic.ir/wp-json/digitalogic/v1',
+    automationBase: 'https://automation.digitalogic.ir',
+    panelBase: 'https://digitalogic.ir/panel',
+    desktopManifest: 'https://digitalogic.ir/wp-json/digitalogic/v1/desktop/manifest',
+    extensionManifest: 'https://digitalogic.ir/wp-json/digitalogic/v1/extension/manifest',
+    cacheName: 'digitalogic-runtime-v1',
+    cacheAssets: [],
+    usefulLinkRules: [
+      /digitalogic\.ir/i,
+      /automation\.digitalogic\.ir/i,
+      /meet\.digitalogic\.ir/i,
+      /wp-admin/i,
+      /\/panel\//i,
+      /\.(pdf|docx?|xlsx?|csv|zip)(\?|#|$)/i
+    ]
+  };
+
+  function mergeConfig(config) {
+    return Object.assign({}, DEFAULTS, config || {});
+  }
+
+  function normalizeUrl(url, base) {
+    try {
+      return new URL(url, base || (typeof location !== 'undefined' ? location.href : DEFAULTS.panelBase)).toString();
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function createApiClient(config, fetchImpl) {
+    var options = mergeConfig(config);
+    var transport = fetchImpl || (typeof fetch !== 'undefined' ? fetch.bind(typeof self !== 'undefined' ? self : window) : null);
+
+    function request(path, requestOptions) {
+      if (!transport) return Promise.reject(new Error('Fetch is not available in this runtime'));
+      var url = /^https?:\/\//i.test(path) ? path : options.apiBase.replace(/\/+$/, '') + '/' + String(path || '').replace(/^\/+/, '');
+      var headers = Object.assign({
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'X-Digitalogic-Client': options.clientName || options.appName
+      }, requestOptions && requestOptions.headers ? requestOptions.headers : {});
+      if (options.token) headers.Authorization = 'Bearer ' + options.token;
+
+      return transport(url, Object.assign({}, requestOptions || {}, { headers: headers })).then(function(response) {
+        if (!response.ok) {
+          var error = new Error('Digitalogic API request failed with ' + response.status);
+          error.status = response.status;
+          throw error;
+        }
+        var contentType = response.headers && response.headers.get ? response.headers.get('content-type') : '';
+        return contentType && contentType.indexOf('application/json') !== -1 ? response.json() : response.text();
+      });
+    }
+
+    return {
+      request: request,
+      manifest: function(kind) {
+        return request(kind === 'extension' ? options.extensionManifest : options.desktopManifest, { method: 'GET' });
+      },
+      notify: function(payload) {
+        return request('/notifications', { method: 'POST', body: JSON.stringify(payload || {}) });
+      },
+      enqueueAutomation: function(payload) {
+        return request('/automation/jobs', { method: 'POST', body: JSON.stringify(payload || {}) });
+      },
+      captureLinks: function(payload) {
+        return request('/links/capture', { method: 'POST', body: JSON.stringify(payload || {}) });
+      }
+    };
+  }
+
+  function createStorage(adapter) {
+    adapter = adapter || {};
+    return {
+      get: function(keys) {
+        if (adapter.get) return adapter.get(keys);
+        var result = {};
+        [].concat(keys || []).forEach(function(key) {
+          try {
+            result[key] = JSON.parse(localStorage.getItem(key));
+          } catch (_) {
+            result[key] = localStorage.getItem(key);
+          }
+        });
+        return Promise.resolve(result);
+      },
+      set: function(values) {
+        if (adapter.set) return adapter.set(values);
+        Object.keys(values || {}).forEach(function(key) {
+          localStorage.setItem(key, JSON.stringify(values[key]));
+        });
+        return Promise.resolve();
+      }
+    };
+  }
+
+  function isUsefulLink(href, config) {
+    var options = mergeConfig(config);
+    return options.usefulLinkRules.some(function(rule) {
+      return rule.test(href);
+    });
+  }
+
+  function extractUsefulLinks(input, config) {
+    var pageUrl = input && input.url ? input.url : (typeof location !== 'undefined' ? location.href : '');
+    var title = input && input.title ? input.title : (typeof document !== 'undefined' ? document.title : '');
+    var anchors = input && input.anchors ? input.anchors : [];
+    if (!anchors.length && typeof document !== 'undefined') {
+      anchors = Array.prototype.slice.call(document.querySelectorAll('a[href]')).map(function(anchor) {
+        return {
+          href: anchor.getAttribute('href'),
+          text: anchor.textContent,
+          rel: anchor.getAttribute('rel') || '',
+          type: anchor.getAttribute('type') || ''
+        };
+      });
+    }
+
+    var seen = {};
+    return anchors.map(function(anchor) {
+      var href = normalizeUrl(anchor.href, pageUrl);
+      if (!href || seen[href] || !isUsefulLink(href, config)) return null;
+      seen[href] = true;
+      return {
+        url: href,
+        text: String(anchor.text || '').replace(/\s+/g, ' ').trim().slice(0, 160),
+        sourceUrl: pageUrl,
+        sourceTitle: title,
+        rel: anchor.rel || '',
+        type: anchor.type || ''
+      };
+    }).filter(Boolean).slice(0, 80);
+  }
+
+  function registerServiceWorker(scriptUrl, options) {
+    if (typeof navigator === 'undefined' || !navigator.serviceWorker) {
+      return Promise.resolve(null);
+    }
+    return navigator.serviceWorker.register(scriptUrl || '/digitalogic-service-worker.js', options || { scope: '/' });
+  }
+
+  function installServiceWorkerHandlers(config) {
+    var options = mergeConfig(config);
+    if (typeof self === 'undefined' || !self.addEventListener) return;
+
+    self.addEventListener('install', function(event) {
+      event.waitUntil(caches.open(options.cacheName).then(function(cache) {
+        return options.cacheAssets && options.cacheAssets.length ? cache.addAll(options.cacheAssets) : Promise.resolve();
+      }).then(function() {
+        return self.skipWaiting && self.skipWaiting();
+      }));
+    });
+
+    self.addEventListener('activate', function(event) {
+      event.waitUntil(caches.keys().then(function(keys) {
+        return Promise.all(keys.filter(function(key) {
+          return key.indexOf('digitalogic-runtime-') === 0 && key !== options.cacheName;
+        }).map(function(key) {
+          return caches.delete(key);
+        }));
+      }).then(function() {
+        return self.clients && self.clients.claim ? self.clients.claim() : null;
+      }));
+    });
+
+    self.addEventListener('fetch', function(event) {
+      var request = event.request;
+      if (!request || request.method !== 'GET') return;
+      var url = normalizeUrl(request.url);
+      if (!/digitalogic\.ir|automation\.digitalogic\.ir|meet\.digitalogic\.ir/i.test(url)) return;
+
+      event.respondWith(fetch(request).then(function(response) {
+        var copy = response.clone();
+        caches.open(options.cacheName).then(function(cache) {
+          cache.put(request, copy);
+        });
+        return response;
+      }).catch(function() {
+        return caches.match(request);
+      }));
+    });
+
+    self.addEventListener('message', function(event) {
+      var data = event.data || {};
+      if (data.type === 'DIGITALOGIC_PING') {
+        event.source && event.source.postMessage({ type: 'DIGITALOGIC_PONG', appName: options.appName });
+      }
+      if (data.type === 'DIGITALOGIC_EXTRACT_LINKS') {
+        var links = extractUsefulLinks(data.payload || {}, options);
+        event.source && event.source.postMessage({ type: 'DIGITALOGIC_LINKS', links: links });
+      }
+      if (data.type === 'DIGITALOGIC_SHOW_NOTIFICATION' && self.registration && self.registration.showNotification) {
+        self.registration.showNotification(data.title || options.appName, data.options || {});
+      }
+    });
+
+    self.addEventListener('push', function(event) {
+      var payload = {};
+      try {
+        payload = event.data ? event.data.json() : {};
+      } catch (_) {
+        payload = { title: options.appName, body: event.data ? event.data.text() : '' };
+      }
+      event.waitUntil(self.registration.showNotification(payload.title || options.appName, {
+        body: payload.body || '',
+        icon: payload.icon || '/digitalogic-icon-192.png',
+        badge: payload.badge || '/digitalogic-icon-96.png',
+        data: payload.data || {}
+      }));
+    });
+  }
+
+  return {
+    defaults: DEFAULTS,
+    mergeConfig: mergeConfig,
+    normalizeUrl: normalizeUrl,
+    createApiClient: createApiClient,
+    createStorage: createStorage,
+    extractUsefulLinks: extractUsefulLinks,
+    registerServiceWorker: registerServiceWorker,
+    installServiceWorkerHandlers: installServiceWorkerHandlers
+  };
+});

--- a/assets/js/digitalogic-service-worker.js
+++ b/assets/js/digitalogic-service-worker.js
@@ -1,0 +1,10 @@
+importScripts('/wp-content/plugins/digitalogic-wp/assets/js/digitalogic-runtime.js');
+
+self.DigitalogicRuntime.installServiceWorkerHandlers({
+  appName: 'Digitalogic',
+  cacheName: 'digitalogic-runtime-v1',
+  cacheAssets: [
+    '/wp-content/plugins/digitalogic-wp/assets/js/digitalogic-runtime.js',
+    '/wp-content/plugins/digitalogic-wp/assets/css/desktop-app.css'
+  ]
+});

--- a/includes/integrations/class-desktop-app.php
+++ b/includes/integrations/class-desktop-app.php
@@ -31,6 +31,7 @@ class Digitalogic_Desktop_App {
         add_action('wp_enqueue_scripts', array($this, 'enqueue_panel_assets'), 100);
         add_action('rest_api_init', array($this, 'register_rest_routes'));
         add_action('send_headers', array($this, 'send_desktop_headers'));
+        add_action('template_redirect', array($this, 'serve_runtime_files'), 0);
     }
 
     public function remember_desktop_context() {
@@ -48,6 +49,8 @@ class Digitalogic_Desktop_App {
             return;
         }
 
+        $this->enqueue_runtime_assets();
+
         wp_enqueue_style(
             'digitalogic-desktop-app',
             DIGITALOGIC_PLUGIN_URL . 'assets/css/desktop-app.css',
@@ -58,7 +61,7 @@ class Digitalogic_Desktop_App {
         wp_enqueue_script(
             'digitalogic-desktop-app',
             DIGITALOGIC_PLUGIN_URL . 'assets/js/desktop-app.js',
-            array(),
+            array('digitalogic-runtime'),
             filemtime(DIGITALOGIC_PLUGIN_DIR . 'assets/js/desktop-app.js') ?: DIGITALOGIC_VERSION,
             true
         );
@@ -69,6 +72,8 @@ class Digitalogic_Desktop_App {
             return;
         }
 
+        $this->enqueue_runtime_assets();
+
         wp_enqueue_style(
             'digitalogic-desktop-app',
             DIGITALOGIC_PLUGIN_URL . 'assets/css/desktop-app.css',
@@ -79,8 +84,26 @@ class Digitalogic_Desktop_App {
         wp_enqueue_script(
             'digitalogic-desktop-app',
             DIGITALOGIC_PLUGIN_URL . 'assets/js/desktop-app.js',
-            array('digitalogic-panel'),
+            array('digitalogic-panel', 'digitalogic-runtime'),
             filemtime(DIGITALOGIC_PLUGIN_DIR . 'assets/js/desktop-app.js') ?: DIGITALOGIC_VERSION,
+            true
+        );
+    }
+
+    private function enqueue_runtime_assets() {
+        wp_enqueue_script(
+            'digitalogic-runtime',
+            DIGITALOGIC_PLUGIN_URL . 'assets/js/digitalogic-runtime.js',
+            array(),
+            filemtime(DIGITALOGIC_PLUGIN_DIR . 'assets/js/digitalogic-runtime.js') ?: DIGITALOGIC_VERSION,
+            true
+        );
+
+        wp_enqueue_script(
+            'digitalogic-pwa',
+            DIGITALOGIC_PLUGIN_URL . 'assets/js/digitalogic-pwa.js',
+            array('digitalogic-runtime'),
+            filemtime(DIGITALOGIC_PLUGIN_DIR . 'assets/js/digitalogic-pwa.js') ?: DIGITALOGIC_VERSION,
             true
         );
     }
@@ -113,6 +136,18 @@ class Digitalogic_Desktop_App {
             'callback' => array($this, 'manifest'),
             'permission_callback' => '__return_true',
         ));
+
+        register_rest_route('digitalogic/v1', '/extension/manifest', array(
+            'methods' => 'GET',
+            'callback' => array($this, 'extension_manifest'),
+            'permission_callback' => '__return_true',
+        ));
+
+        register_rest_route('digitalogic/v1', '/runtime/config', array(
+            'methods' => 'GET',
+            'callback' => array($this, 'runtime_config'),
+            'permission_callback' => '__return_true',
+        ));
     }
 
     public function manifest() {
@@ -133,6 +168,83 @@ class Digitalogic_Desktop_App {
         }
 
         return rest_ensure_response($manifest);
+    }
+
+    public function extension_manifest() {
+        $manifest_file = ABSPATH . 'digitalogic-wp/latest/extension-manifest.json';
+        $manifest = array(
+            'version' => self::VERSION,
+            'name' => 'Digitalogic Browser Extension',
+            'api_url' => home_url('/wp-json/digitalogic/v1'),
+            'automation_url' => 'https://automation.digitalogic.ir',
+            'panel_url' => home_url('/panel/products/'),
+            'icon_url' => 'https://meet.digitalogic.ir/images/watermark.svg?v=2026062715',
+            'download_url' => home_url('/digitalogic-wp/latest/Digitalogic-Browser-Extension.zip'),
+        );
+
+        if (file_exists($manifest_file)) {
+            $decoded = json_decode((string) file_get_contents($manifest_file), true);
+            if (is_array($decoded)) {
+                $manifest = array_merge($manifest, $decoded);
+            }
+        }
+
+        return rest_ensure_response($manifest);
+    }
+
+    public function runtime_config() {
+        return rest_ensure_response(array(
+            'apiBase' => home_url('/wp-json/digitalogic/v1'),
+            'automationBase' => 'https://automation.digitalogic.ir',
+            'panelBase' => home_url('/panel'),
+            'desktopManifest' => home_url('/wp-json/digitalogic/v1/desktop/manifest'),
+            'extensionManifest' => home_url('/wp-json/digitalogic/v1/extension/manifest'),
+            'serviceWorker' => home_url('/digitalogic-service-worker.js'),
+            'webManifest' => home_url('/digitalogic.webmanifest'),
+            'brand' => array(
+                'name' => 'Digitalogic',
+                'icon' => 'https://meet.digitalogic.ir/images/watermark.svg?v=2026062715',
+            ),
+        ));
+    }
+
+    public function serve_runtime_files() {
+        $path = isset($_SERVER['REQUEST_URI']) ? (string) wp_unslash($_SERVER['REQUEST_URI']) : '';
+        $path = strtok($path, '?');
+
+        if ($path === '/digitalogic-service-worker.js') {
+            $file = DIGITALOGIC_PLUGIN_DIR . 'assets/js/digitalogic-service-worker.js';
+            if (!file_exists($file)) {
+                status_header(404);
+                exit;
+            }
+            header('Content-Type: application/javascript; charset=utf-8');
+            header('Service-Worker-Allowed: /');
+            header('Cache-Control: no-cache');
+            readfile($file);
+            exit;
+        }
+
+        if ($path === '/digitalogic.webmanifest') {
+            header('Content-Type: application/manifest+json; charset=utf-8');
+            echo wp_json_encode(array(
+                'name' => 'Digitalogic',
+                'short_name' => 'Digitalogic',
+                'start_url' => home_url('/panel/products/?source=pwa'),
+                'scope' => home_url('/'),
+                'display' => 'standalone',
+                'background_color' => '#f4f8fb',
+                'theme_color' => '#0168cd',
+                'icons' => array(
+                    array(
+                        'src' => 'https://meet.digitalogic.ir/images/watermark.svg?v=2026062715',
+                        'sizes' => 'any',
+                        'type' => 'image/svg+xml',
+                    ),
+                ),
+            ));
+            exit;
+        }
     }
 
     public function send_desktop_headers() {


### PR DESCRIPTION
## Summary
- add runtime, PWA, and service worker JavaScript assets
- expose extension/PWA manifests through the Digitalogic desktop app integration

## Validation
- php -l includes/integrations/class-desktop-app.php
- node --check assets/js/digitalogic-pwa.js
- node --check assets/js/digitalogic-runtime.js
- node --check assets/js/digitalogic-service-worker.js
- git diff --check origin/main..HEAD