### PR TITLE
Avoid global lookup rebuilds after product saves

### DIFF
--- a/includes/admin/class-product-table.php
+++ b/includes/admin/class-product-table.php
@@ -32,14 +32,30 @@ class Digitalogic_Product_Table {
      */
     public function regenerate_lookup_tables($product_ids = array()) {
         if (empty($product_ids)) {
-            // Update all products
+            // This is an explicit maintenance action. The WooCommerce helper
+            // rebuilds the entire catalog and does not accept a product ID.
             wc_update_product_lookup_tables();
-        } else {
-            // Update specific products
-            foreach ($product_ids as $product_id) {
-                wc_update_product_lookup_tables($product_id);
-            }
+
+            return true;
         }
+
+        $product_ids = array_values(array_unique(array_filter(array_map('absint', $product_ids))));
+        if (empty($product_ids)) {
+            return true;
+        }
+
+        $data_store = WC_Data_Store::load('product');
+        if (is_callable(array($data_store, 'refresh_product_lookup_table'))) {
+            foreach ($product_ids as $product_id) {
+                $data_store->refresh_product_lookup_table($product_id);
+            }
+
+            return true;
+        }
+
+        // WooCommerce versions before the per-product refresh API can only
+        // schedule a full lookup rebuild. Run it once, never once per ID.
+        wc_update_product_lookup_tables();
         
         return true;
     }

--- a/includes/class-patris-feed.php
+++ b/includes/class-patris-feed.php
@@ -397,7 +397,6 @@ class Digitalogic_Patris_Feed {
         }
 
         $product->save();
-        wc_update_product_lookup_tables($product->get_id());
     }
 
     private function clean_string($value) {

--- a/includes/class-pricing.php
+++ b/includes/class-pricing.php
@@ -149,9 +149,6 @@ class Digitalogic_Pricing {
         // Save all product changes (meta data + price)
         $product->save();
         
-        // Update product lookup tables
-        wc_update_product_lookup_tables($product_id);
-        
         return true;
     }
     

--- a/includes/class-product-manager.php
+++ b/includes/class-product-manager.php
@@ -398,9 +398,6 @@ class Digitalogic_Product_Manager {
             // Save product
             $product->save();
             
-            // Update product lookup tables
-            wc_update_product_lookup_tables($product_id);
-            
             // Log the change
             Digitalogic_Logger::instance()->log(
                 'update_product',


### PR DESCRIPTION
## Summary

- rely on `WC_Product::save()` for normal per-product lookup maintenance
- remove unsupported calls that pass a product ID to WooCommerce's catalog-wide rebuild helper
- retain the explicit maintenance helper, using WooCommerce 10.8's per-product refresh API when available and one full rebuild fallback on older supported versions

## Validation

- PHP syntax checks for all four changed files
- isolated behavior test covering deduplicated per-product refresh, explicit full rebuild, and legacy fallback
- `git diff --check`
- repository scan confirms the catalog-wide helper remains only in the explicit maintenance class

Closes #38
