### PR TITLE
Harden Digitalogic REST route permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -75,6 +75,9 @@ jobs:
       
     - name: Check PHP syntax
       run: find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
+
+    - name: Run PHPUnit tests
+      run: composer test
       
   security:
     name: Security Check

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,8 @@ ehthumbs.db
 Thumbs.db
 
 # Test
-/tests/
 phpunit.xml
+.phpunit.result.cache
 
 # Temporary files
 *.tmp

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,7 +6,14 @@ Base URL: `https://yoursite.com/wp-json/digitalogic/v1`
 
 ### Authentication
 
-All endpoints require authentication using WooCommerce REST API credentials:
+All management endpoints require an authenticated WordPress user with the
+`manage_woocommerce` capability. This normally includes administrators and shop
+managers, but excludes subscriber and customer accounts.
+
+The API accepts WordPress cookie authentication with a REST nonce, WordPress
+Application Passwords, and WooCommerce REST API consumer keys. A WooCommerce
+consumer key must belong to a user with `manage_woocommerce`; its configured
+read/write permission is also enforced for the HTTP method.
 
 ```bash
 # Using Basic Auth
@@ -16,6 +23,42 @@ curl -u consumer_key:consumer_secret https://yoursite.com/wp-json/digitalogic/v1
 curl -H "Authorization: Basic $(echo -n 'consumer_key:consumer_secret' | base64)" \
   https://yoursite.com/wp-json/digitalogic/v1/products
 ```
+
+Use a `read` or `read/write` WooCommerce key for GET routes. POST and PUT routes
+require a `write` or `read/write` key.
+
+Routes use three explicit permission scopes:
+
+- `read`: product and currency GET routes
+- `write`: product/currency updates, recalculation, and Patris pull-sync
+- `diagnostic`: reports and exports
+
+Trusted integrations that do not authenticate as a WooCommerce manager can
+continue using the legacy permission filter, but access is denied by default.
+The callback must explicitly return the boolean `true` for only the scopes it
+supports:
+
+```php
+add_filter(
+    'digitalogic_rest_api_permission',
+    function ($allowed, $scope, $request) {
+        if (!my_integration_authenticates_request($request)) {
+            return false;
+        }
+
+        return in_array($scope, array('read', 'write'), true);
+    },
+    10,
+    3
+);
+```
+
+For backward compatibility, a one-argument callback still works, but returning
+`true` from it grants all three scopes. Update legacy callbacks to accept the
+scope and request arguments before using them for least-privilege access.
+
+`POST /patris/push` is not controlled by this filter. It retains its dedicated
+Patris request verifier and token policy.
 
 ---
 

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -22,6 +22,84 @@ class Digitalogic_REST_API {
     
     private function __construct() {
         add_action('rest_api_init', array($this, 'register_routes'));
+        add_filter(
+            'woocommerce_rest_is_request_to_rest_api',
+            array($this, 'allow_woocommerce_rest_authentication')
+        );
+    }
+
+    /**
+     * Let WooCommerce authenticate API keys for this plugin's REST namespace.
+     *
+     * WooCommerce only recognizes its own wc/* and wc-* namespaces by default.
+     * Preserve requests already recognized by WooCommerce and opt in only the
+     * exact digitalogic/v1 namespace (including installations in a subdirectory
+     * or using the rest_route query parameter).
+     *
+     * @param bool $is_request Whether WooCommerce already recognizes the request.
+     * @return bool
+     */
+    public function allow_woocommerce_rest_authentication($is_request) {
+        if ($is_request) {
+            return true;
+        }
+
+        if (empty($_SERVER['REQUEST_URI'])) {
+            return false;
+        }
+
+        $request_uri = wp_unslash($_SERVER['REQUEST_URI']);
+        $request_path = wp_parse_url($request_uri, PHP_URL_PATH);
+        $api_url = rest_url('digitalogic/v1');
+        $api_path = wp_parse_url($api_url, PHP_URL_PATH);
+        $api_query = wp_parse_url($api_url, PHP_URL_QUERY);
+
+        if (is_string($api_query) && '' !== $api_query) {
+            parse_str($api_query, $api_query_params);
+            if (isset($api_query_params['rest_route'])) {
+                if (!is_string($request_path) || !is_string($api_path)) {
+                    return false;
+                }
+
+                if (rtrim($request_path, '/') !== rtrim($api_path, '/')) {
+                    return false;
+                }
+
+                return $this->query_targets_digitalogic_namespace($request_uri);
+            }
+        }
+
+        if (is_string($request_path) && is_string($api_path) && '/' !== $api_path) {
+            $api_path = rtrim($api_path, '/');
+            if ($request_path === $api_path || str_starts_with($request_path, $api_path . '/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check a rest_route query parameter against the Digitalogic namespace.
+     *
+     * @param string $request_uri Current request URI.
+     * @return bool
+     */
+    private function query_targets_digitalogic_namespace($request_uri) {
+
+        $request_query = wp_parse_url($request_uri, PHP_URL_QUERY);
+        if (!is_string($request_query) || '' === $request_query) {
+            return false;
+        }
+
+        parse_str($request_query, $query_params);
+        if (!isset($query_params['rest_route']) || !is_string($query_params['rest_route'])) {
+            return false;
+        }
+
+        $route = '/' . trim($query_params['rest_route'], '/');
+
+        return '/digitalogic/v1' === $route || str_starts_with($route, '/digitalogic/v1/');
     }
     
     /**
@@ -32,64 +110,64 @@ class Digitalogic_REST_API {
         register_rest_route('digitalogic/v1', '/products', array(
             'methods' => 'GET',
             'callback' => array($this, 'get_products'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_read_permission')
         ));
         
         register_rest_route('digitalogic/v1', '/products/(?P<id>\d+)', array(
             'methods' => 'GET',
             'callback' => array($this, 'get_product'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_read_permission')
         ));
         
         register_rest_route('digitalogic/v1', '/products/(?P<id>\d+)', array(
             'methods' => 'PUT',
             'callback' => array($this, 'update_product'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_write_permission')
         ));
         
         register_rest_route('digitalogic/v1', '/products/batch', array(
             'methods' => 'POST',
             'callback' => array($this, 'batch_update_products'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_write_permission')
         ));
         
         // Currency endpoints
         register_rest_route('digitalogic/v1', '/currency', array(
             'methods' => 'GET',
             'callback' => array($this, 'get_currency'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_read_permission')
         ));
         
         register_rest_route('digitalogic/v1', '/currency', array(
             'methods' => 'POST',
             'callback' => array($this, 'update_currency'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_write_permission')
         ));
         
         // Pricing endpoints
         register_rest_route('digitalogic/v1', '/pricing/recalculate', array(
             'methods' => 'POST',
             'callback' => array($this, 'recalculate_prices'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_write_permission')
         ));
         
         // Export endpoint
         register_rest_route('digitalogic/v1', '/export', array(
             'methods' => 'GET',
             'callback' => array($this, 'export_products'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_diagnostic_permission')
         ));
 
         register_rest_route('digitalogic/v1', '/reports', array(
             'methods' => 'GET',
             'callback' => array($this, 'get_reports'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_diagnostic_permission')
         ));
 
         register_rest_route('digitalogic/v1', '/patris/sync', array(
             'methods' => 'POST',
             'callback' => array($this, 'sync_patris'),
-            'permission_callback' => array($this, 'check_permission')
+            'permission_callback' => array($this, 'check_write_permission')
         ));
 
         register_rest_route('digitalogic/v1', '/patris/push', array(
@@ -100,21 +178,78 @@ class Digitalogic_REST_API {
     }
     
     /**
-     * Check API permission
+     * Backward-compatible permission check for existing integrations.
+     *
+     * This alias deliberately uses the write scope, matching the broad access
+     * historically associated with this method without restoring read-level
+     * authorization for management routes.
+     *
+     * @deprecated Use check_read_permission(), check_write_permission(), or
+     *             check_diagnostic_permission() for an explicit route scope.
+     *
+     * @param WP_REST_Request|null $request Current REST request.
+     * @return bool
      */
-    public function check_permission() {
-        // Check if user is logged in with proper capabilities
+    public function check_permission($request = null) {
+        return $this->check_write_permission($request);
+    }
+
+    /**
+     * Check access to read-only catalog and currency routes.
+     *
+     * @param WP_REST_Request|null $request Current REST request.
+     * @return bool
+     */
+    public function check_read_permission($request = null) {
+        return $this->check_scoped_permission('read', $request);
+    }
+
+    /**
+     * Check access to routes that mutate products, settings, or sync state.
+     *
+     * @param WP_REST_Request|null $request Current REST request.
+     * @return bool
+     */
+    public function check_write_permission($request = null) {
+        return $this->check_scoped_permission('write', $request);
+    }
+
+    /**
+     * Check access to reports and exports that expose operational data.
+     *
+     * @param WP_REST_Request|null $request Current REST request.
+     * @return bool
+     */
+    public function check_diagnostic_permission($request = null) {
+        return $this->check_scoped_permission('diagnostic', $request);
+    }
+
+    /**
+     * Resolve a REST permission scope.
+     *
+     * The legacy filter remains available for explicit integrations. Its
+     * default is deliberately false; callbacks must return the boolean true.
+     * The second argument lets integrations grant only the required scope.
+     *
+     * @param string               $scope   One of read, write, or diagnostic.
+     * @param WP_REST_Request|null $request Current REST request.
+     * @return bool
+     */
+    private function check_scoped_permission($scope, $request = null) {
         if (current_user_can('manage_woocommerce')) {
             return true;
         }
-        
-        // Check for WooCommerce REST API authentication
-        if (defined('REST_REQUEST') && REST_REQUEST) {
-            // WooCommerce handles its own authentication
-            return apply_filters('digitalogic_rest_api_permission', current_user_can('read'));
-        }
-        
-        return false;
+
+        /**
+         * Filter access to a Digitalogic REST API scope.
+         *
+         * @param bool                 $allowed Denied by default.
+         * @param string               $scope   Permission scope.
+         * @param WP_REST_Request|null $request Current REST request.
+         */
+        $allowed = apply_filters('digitalogic_rest_api_permission', false, $scope, $request);
+
+        return true === $allowed;
     }
 
     public function check_patris_push_permission(WP_REST_Request $request) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,20 @@
 <?xml version="1.0"?>
-<phpunit
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     bootstrap="tests/bootstrap.php"
     backupGlobals="false"
     colors="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    >
+    convertWarningsToExceptions="true">
     <testsuites>
         <testsuite name="Digitalogic Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">includes</directory>
-            <exclude>
-                <directory suffix=".php">vendor</directory>
-                <directory suffix=".php">tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <const name="WP_TESTS_PHPUNIT_POLYFILLS_PATH" value="vendor/yoast/phpunit-polyfills" />
-    </php>
+        </include>
+    </coverage>
 </phpunit>

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -1,0 +1,219 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class RestApiPermissionsTest extends TestCase {
+    /** @var Digitalogic_REST_API */
+    private $api;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $GLOBALS['digitalogic_test_capabilities'] = array();
+        $GLOBALS['digitalogic_test_filters'] = array();
+        $GLOBALS['digitalogic_test_routes'] = array();
+        $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/wp-json/';
+        unset($_SERVER['REQUEST_URI']);
+
+        $instance = new ReflectionProperty(Digitalogic_REST_API::class, 'instance');
+        $instance->setAccessible(true);
+        $instance->setValue(null, null);
+        $this->api = Digitalogic_REST_API::instance();
+    }
+
+    /**
+     * @dataProvider rolePolicyProvider
+     */
+    public function test_role_capability_policy($role, $capabilities, $expected) {
+        $GLOBALS['digitalogic_test_capabilities'] = $capabilities;
+        $request = new WP_REST_Request();
+
+        $this->assertSame($expected, $this->api->check_read_permission($request), $role . ' read access');
+        $this->assertSame($expected, $this->api->check_write_permission($request), $role . ' write access');
+        $this->assertSame($expected, $this->api->check_diagnostic_permission($request), $role . ' diagnostic access');
+    }
+
+    public static function rolePolicyProvider() {
+        return array(
+            'subscriber' => array('subscriber', array('read' => true), false),
+            'customer' => array('customer', array('read' => true), false),
+            'shop manager' => array('shop_manager', array('read' => true, 'manage_woocommerce' => true), true),
+            'administrator' => array('administrator', array('read' => true, 'manage_woocommerce' => true), true),
+        );
+    }
+
+    /**
+     * @dataProvider restRequestProvider
+     */
+    public function test_woocommerce_authentication_recognizes_only_digitalogic_routes($request_uri, $already_recognized, $expected) {
+        $_SERVER['REQUEST_URI'] = $request_uri;
+
+        $this->assertSame(
+            $expected,
+            apply_filters('woocommerce_rest_is_request_to_rest_api', $already_recognized),
+            $request_uri
+        );
+    }
+
+    public static function restRequestProvider() {
+        return array(
+            'namespace root' => array('/wp-json/digitalogic/v1', false, true),
+            'namespace route and query' => array('/wp-json/digitalogic/v1/products?consumer_key=ck_example', false, true),
+            'namespace lookalike' => array('/wp-json/digitalogic/v10/products', false, false),
+            'namespace suffix lookalike' => array('/wp-json/digitalogic/v1-unsafe/products', false, false),
+            'unrelated route' => array('/wp-json/example/v1/products', false, false),
+            'existing WooCommerce route remains recognized' => array('/wp-json/wc/v3/products', true, true),
+        );
+    }
+
+    public function test_woocommerce_authentication_recognizes_subdirectory_install() {
+        $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/store/wp-json/';
+        $_SERVER['REQUEST_URI'] = '/store/wp-json/digitalogic/v1/products';
+
+        $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+    }
+
+    public function test_woocommerce_authentication_recognizes_rest_route_query() {
+        $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/?rest_route=/';
+        $_SERVER['REQUEST_URI'] = '/?rest_route=%2Fdigitalogic%2Fv1%2Fproducts';
+
+        $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+
+        $_SERVER['REQUEST_URI'] = '/?rest_route=%2Fdigitalogic%2Fv10%2Fproducts';
+        $this->assertFalse(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+    }
+
+    public function test_rest_route_query_does_not_authenticate_unrelated_subdirectory_request() {
+        $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/store/?rest_route=/';
+        $_SERVER['REQUEST_URI'] = '/store/?unrelated=1';
+
+        $this->assertFalse(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+
+        $_SERVER['REQUEST_URI'] = '/store/?rest_route=%2Fdigitalogic%2Fv1%2Fproducts';
+        $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+    }
+
+    public function test_woocommerce_route_recognition_does_not_bypass_capability_policy() {
+        $_SERVER['REQUEST_URI'] = '/wp-json/digitalogic/v1/products';
+        $request = new WP_REST_Request();
+
+        $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+
+        $GLOBALS['digitalogic_test_capabilities'] = array('read' => true);
+        $this->assertFalse($this->api->check_read_permission($request));
+        $this->assertFalse($this->api->check_write_permission($request));
+
+        $GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
+
+        $this->assertTrue($this->api->check_read_permission($request));
+        $this->assertTrue($this->api->check_write_permission($request));
+    }
+
+    public function test_legacy_filter_is_denied_by_default_and_receives_scope_and_request() {
+        $calls = array();
+        $request = new WP_REST_Request();
+
+        add_filter(
+            'digitalogic_rest_api_permission',
+            function($allowed, $scope, $filtered_request) use (&$calls) {
+                $calls[] = array($allowed, $scope, $filtered_request);
+
+                return 'read' === $scope;
+            },
+            10,
+            3
+        );
+
+        $this->assertTrue($this->api->check_read_permission($request));
+        $this->assertFalse($this->api->check_write_permission($request));
+        $this->assertFalse($this->api->check_diagnostic_permission($request));
+        $this->assertCount(3, $calls);
+
+        foreach ($calls as $call) {
+            $this->assertFalse($call[0]);
+            $this->assertSame($request, $call[2]);
+        }
+
+        $this->assertSame(array('read', 'write', 'diagnostic'), array_column($calls, 1));
+    }
+
+    public function test_legacy_one_argument_filter_remains_compatible_for_all_scopes() {
+        add_filter(
+            'digitalogic_rest_api_permission',
+            function($allowed) {
+                $this->assertFalse($allowed);
+
+                return true;
+            }
+        );
+
+        $this->assertTrue($this->api->check_read_permission(new WP_REST_Request()));
+        $this->assertTrue($this->api->check_write_permission(new WP_REST_Request()));
+        $this->assertTrue($this->api->check_diagnostic_permission(new WP_REST_Request()));
+    }
+
+    public function test_legacy_filter_must_return_boolean_true() {
+        add_filter(
+            'digitalogic_rest_api_permission',
+            function() {
+                return 'true';
+            }
+        );
+
+        $this->assertFalse($this->api->check_read_permission(new WP_REST_Request()));
+    }
+
+    public function test_legacy_public_check_permission_alias_uses_write_scope() {
+        $scope_seen = null;
+        $request = new WP_REST_Request();
+
+        $this->assertFalse($this->api->check_permission($request));
+
+        add_filter(
+            'digitalogic_rest_api_permission',
+            function($allowed, $scope) use (&$scope_seen) {
+                $scope_seen = $scope;
+
+                return 'write' === $scope;
+            },
+            10,
+            2
+        );
+
+        $this->assertTrue($this->api->check_permission($request));
+        $this->assertSame('write', $scope_seen);
+    }
+
+    public function test_every_route_has_the_expected_permission_policy() {
+        $this->api->register_routes();
+
+        $actual = array();
+        foreach ($GLOBALS['digitalogic_test_routes'] as $registration) {
+            $permission_callback = $registration['args']['permission_callback'];
+            $actual[$registration['args']['methods'] . ' ' . $registration['route']] = $permission_callback[1];
+        }
+
+        $expected = array(
+            'GET /products' => 'check_read_permission',
+            'GET /products/(?P<id>\d+)' => 'check_read_permission',
+            'PUT /products/(?P<id>\d+)' => 'check_write_permission',
+            'POST /products/batch' => 'check_write_permission',
+            'GET /currency' => 'check_read_permission',
+            'POST /currency' => 'check_write_permission',
+            'POST /pricing/recalculate' => 'check_write_permission',
+            'GET /export' => 'check_diagnostic_permission',
+            'GET /reports' => 'check_diagnostic_permission',
+            'POST /patris/sync' => 'check_write_permission',
+            'POST /patris/push' => 'check_patris_push_permission',
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function test_patris_push_delegates_to_its_scoped_verifier() {
+        $request = new WP_REST_Request();
+
+        $this->assertSame('patris-verifier-result', $this->api->check_patris_push_permission($request));
+        $this->assertSame($request, Digitalogic_Patris_Feed::instance()->verified_request);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Lightweight WordPress stubs for unit-testing REST permission policy.
+ */
+
+define('ABSPATH', __DIR__ . '/');
+
+$GLOBALS['digitalogic_test_capabilities'] = array();
+$GLOBALS['digitalogic_test_filters'] = array();
+$GLOBALS['digitalogic_test_routes'] = array();
+$GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/wp-json/';
+
+class WP_REST_Request {
+}
+
+class Digitalogic_Patris_Feed {
+    private static $instance;
+
+    public $verified_request;
+
+    public static function instance() {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function verify_push_request($request) {
+        $this->verified_request = $request;
+
+        return 'patris-verifier-result';
+    }
+}
+
+function add_action($hook_name, $callback, $priority = 10, $accepted_args = 1) {
+}
+
+function current_user_can($capability) {
+    return !empty($GLOBALS['digitalogic_test_capabilities'][$capability]);
+}
+
+function add_filter($hook_name, $callback, $priority = 10, $accepted_args = 1) {
+    $GLOBALS['digitalogic_test_filters'][$hook_name][] = array(
+        'callback' => $callback,
+        'accepted_args' => $accepted_args,
+    );
+
+    return true;
+}
+
+function remove_all_filters($hook_name) {
+    unset($GLOBALS['digitalogic_test_filters'][$hook_name]);
+
+    return true;
+}
+
+function apply_filters($hook_name, $value, ...$args) {
+    if (empty($GLOBALS['digitalogic_test_filters'][$hook_name])) {
+        return $value;
+    }
+
+    foreach ($GLOBALS['digitalogic_test_filters'][$hook_name] as $filter) {
+        $parameters = array_merge(array($value), $args);
+        $parameters = array_slice($parameters, 0, $filter['accepted_args']);
+        $value = call_user_func_array($filter['callback'], $parameters);
+    }
+
+    return $value;
+}
+
+function register_rest_route($namespace, $route, $args = array(), $override = false) {
+    $GLOBALS['digitalogic_test_routes'][] = array(
+        'namespace' => $namespace,
+        'route' => $route,
+        'args' => $args,
+    );
+
+    return true;
+}
+
+function wp_unslash($value) {
+    return $value;
+}
+
+function wp_parse_url($url, $component = -1) {
+    return parse_url($url, $component);
+}
+
+function rest_url($path = '') {
+    $base = $GLOBALS['digitalogic_test_rest_url'];
+
+    return rtrim($base, '/') . '/' . ltrim($path, '/');
+}
+
+require_once dirname(__DIR__) . '/includes/api/class-rest-api.php';


### PR DESCRIPTION
## Summary

- require WooCommerce-management capability for Digitalogic read, write, and diagnostic routes
- keep the legacy integration filter denied by default and make its requested scope explicit
- preserve the independently authenticated Patris push route
- narrowly enable WooCommerce consumer-key authentication for the exact `digitalogic/v1` namespace
- add a tracked PHPUnit permission-policy suite and run it in CI

## Compatibility

Cookie/nonce, WordPress Application Password, and WooCommerce consumer-key clients remain supported. WooCommerce key read/write restrictions and the owning user's capabilities are both enforced.

## Validation

- 20 PHPUnit tests, 52 assertions
- full non-vendor PHP syntax check
- live, rollback-only authentication matrix: manager key allowed; invalid secret and low-privilege owner denied; read/write key methods constrained
- public-tree backup guard
- `git diff --check`

This is a security hardening change. Detailed impact and release metadata are tracked privately until the patched release is deployed.
