### PR TITLE
Stabilize WebSocket event delivery

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -76,6 +76,9 @@ jobs:
     - name: Check PHP syntax
       run: find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
 
+    - name: Check panel JavaScript syntax
+      run: node --check assets/js/panel-app.js
+
     - name: Run PHPUnit tests
       run: composer test
       

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ Thumbs.db
 
 # Test
 phpunit.xml
-.phpunit.result.cache
+/.phpunit.result.cache
 
 # Temporary files
 *.tmp

--- a/assets/js/panel-app.js
+++ b/assets/js/panel-app.js
@@ -320,7 +320,7 @@
                 saveTimers: {},
                 userSaveTimers: {},
                 saveState: {},
-                lastEventId: 0,
+                lastEventId: Number(config.event_cursor || 0),
                 eventTimer: null,
                 toasts: [],
                 toastId: 0
@@ -745,6 +745,7 @@
             },
             handleTransportEvent: function(event) {
                 if (event && event.event && event.event !== 'connected' && event.event !== 'response') {
+                    this.lastEventId = Math.max(this.lastEventId, Number(event.id || 0));
                     this.handlePanelEvent(event.name || event.event, event.data || {});
                 }
             },

--- a/docs/WEBSOCKET-LARAVEL.md
+++ b/docs/WEBSOCKET-LARAVEL.md
@@ -27,6 +27,33 @@ wp digitalogic websocket serve --host=127.0.0.1 --port=8090 --allow-root
 
 Run it under `systemd` or Supervisor in production. Keep it bound to `127.0.0.1` and expose it through Apache at `/wordpress-ws`.
 
+Panel updates are first stored in the bounded WordPress event queue with a
+strictly increasing ID, then the same envelope is published to Redis. Product,
+currency, user, and toast events therefore share one delivery path. The browser
+keeps polling the stored queue every five seconds, so Redis or WebSocket downtime
+does not remove the manual/polling fallback.
+
+The default Redis endpoint is `127.0.0.1:6379`, database unset, channel
+`digitalogic_panel_events`. Deployments that need authentication, a different
+database, or a different endpoint can configure the server-side filter below.
+The password is never included in browser configuration or logs.
+
+```php
+add_filter('digitalogic_panel_redis_config', function ($config) {
+    $config['host'] = '127.0.0.1';
+    $config['port'] = 6379;
+    $config['timeout'] = 0.5;
+    $config['password'] = getenv('DIGITALOGIC_REDIS_PASSWORD') ?: '';
+    $config['database'] = 2;
+    $config['channel'] = 'digitalogic_panel_events';
+    return $config;
+});
+```
+
+The WP-CLI process only marks Redis healthy after successful connection and
+validated `AUTH`, `SELECT`, and `SUBSCRIBE` replies. Failed setup or a dropped
+subscription is retried while clients continue using the queue-backed fallback.
+
 ## Apache
 
 ```apache

--- a/includes/cli/class-cli-commands.php
+++ b/includes/cli/class-cli-commands.php
@@ -483,7 +483,7 @@ class Digitalogic_CLI_Commands {
         try {
             $server = new Digitalogic_WebSocket_Server();
             $server->run($host, $port);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             WP_CLI::error($e->getMessage());
         }
     }

--- a/includes/panel/class-panel.php
+++ b/includes/panel/class-panel.php
@@ -15,6 +15,11 @@ class Digitalogic_Panel {
     private const REWRITE_VERSION_OPTION = 'digitalogic_panel_rewrite_version';
     private const REWRITE_VERSION = '20260617-panel';
     private const EVENT_OPTION = 'digitalogic_panel_events';
+    private const EVENT_SEQUENCE_OPTION = 'digitalogic_panel_event_sequence';
+    private const EVENT_LOCK_NAME = 'digitalogic_panel_events_v1';
+    private const EVENT_LIMIT = 200;
+
+    private static $reported_delivery_failures = array();
 
     private static $instance = null;
 
@@ -159,6 +164,7 @@ class Digitalogic_Panel {
             'theme_mode' => $this->current_theme_mode(),
             'admin_color' => $this->current_admin_color(),
             'theme_storage_key' => 'digitalogic-admin-theme',
+            'event_cursor' => self::get_latest_event_id(),
             'user' => array(
                 'id' => $user->ID,
                 'login' => $user->user_login,
@@ -494,12 +500,75 @@ class Digitalogic_Panel {
     }
 
     public static function get_events_since($since = 0) {
+        self::refresh_event_option_cache();
         $events = get_option(self::EVENT_OPTION, array());
         $events = is_array($events) ? $events : array();
 
         return array_values(array_filter($events, function($event) use ($since) {
                 return isset($event['id']) && absint($event['id']) > $since;
         }));
+    }
+
+    /**
+     * Return the newest stored panel event ID.
+     *
+     * @return int
+     */
+    public static function get_latest_event_id() {
+        self::refresh_event_option_cache();
+        $events = get_option(self::EVENT_OPTION, array());
+        $latest_id = absint(get_option(self::EVENT_SEQUENCE_OPTION, 0));
+
+        if (is_array($events)) {
+            foreach ($events as $event) {
+                if (!is_array($event) || !isset($event['id'])) {
+                    continue;
+                }
+
+                $latest_id = max($latest_id, absint($event['id']));
+            }
+        }
+
+        return $latest_id;
+    }
+
+    /**
+     * Return normalized server-side Redis settings for panel event delivery.
+     *
+     * The password is intentionally limited to server-side consumers. Do not
+     * pass this configuration to client settings or write it to logs.
+     *
+     * @return array{host:string,port:int,timeout:float,password:string,database:?int,channel:string}
+     */
+    public static function get_redis_config() {
+        $defaults = array(
+            'host' => '127.0.0.1',
+            'port' => 6379,
+            'timeout' => 0.2,
+            'password' => '',
+            'database' => null,
+            'channel' => 'digitalogic_panel_events',
+        );
+        $filtered = apply_filters('digitalogic_panel_redis_config', $defaults);
+        $config = is_array($filtered) ? array_merge($defaults, $filtered) : $defaults;
+
+        $host = is_scalar($config['host']) ? trim((string) $config['host']) : '';
+        $port = (int) $config['port'];
+        $timeout = (float) $config['timeout'];
+        $password = is_scalar($config['password']) ? (string) $config['password'] : '';
+        $database = $config['database'] === null || $config['database'] === ''
+            ? null
+            : max(0, (int) $config['database']);
+        $channel = is_scalar($config['channel']) ? trim((string) $config['channel']) : '';
+
+        return array(
+            'host' => $host !== '' ? $host : $defaults['host'],
+            'port' => $port > 0 && $port <= 65535 ? $port : $defaults['port'],
+            'timeout' => $timeout > 0 ? $timeout : $defaults['timeout'],
+            'password' => $password,
+            'database' => $database,
+            'channel' => $channel !== '' ? $channel : $defaults['channel'],
+        );
     }
 
     public function record_product_event($product_id) {
@@ -517,21 +586,189 @@ class Digitalogic_Panel {
     }
 
     public static function record_event($event, $data = array()) {
-        $events = get_option(self::EVENT_OPTION, array());
-        $events = is_array($events) ? $events : array();
-        $events[] = array(
-            'id' => (int) round(microtime(true) * 1000),
-            'event' => sanitize_key(str_replace('.', '_', $event)),
-            'name' => sanitize_text_field($event),
-            'data' => is_array($data) ? $data : array(),
-            'time' => current_time('mysql'),
-        );
-
-        if (count($events) > 200) {
-            $events = array_slice($events, -200);
+        $lock = self::acquire_event_lock();
+        if ($lock === false) {
+            self::report_event_delivery_failure('Could not acquire the database event lock; the event was not recorded.');
+            return null;
         }
 
-        update_option(self::EVENT_OPTION, $events, false);
+        $stored = false;
+        $event_envelope = null;
+
+        try {
+            self::refresh_event_option_cache(true);
+            $events = get_option(self::EVENT_OPTION, array());
+            $events = is_array($events) ? $events : array();
+            $latest_id = absint(get_option(self::EVENT_SEQUENCE_OPTION, 0));
+
+            foreach ($events as $stored_event) {
+                if (is_array($stored_event) && isset($stored_event['id'])) {
+                    $latest_id = max($latest_id, absint($stored_event['id']));
+                }
+            }
+
+            $event_id = max((int) round(microtime(true) * 1000), $latest_id + 1);
+            $event_envelope = array(
+                'id' => $event_id,
+                'event' => sanitize_key(str_replace('.', '_', $event)),
+                'name' => sanitize_text_field($event),
+                'data' => is_array($data) ? $data : array(),
+                'time' => current_time('mysql'),
+            );
+            $events[] = $event_envelope;
+
+            if (count($events) > self::EVENT_LIMIT) {
+                $events = array_slice($events, -self::EVENT_LIMIT);
+            }
+
+            if (!update_option(self::EVENT_SEQUENCE_OPTION, $event_id, false)) {
+                self::report_event_delivery_failure('The durable event sequence could not be updated.');
+            }
+
+            $stored = update_option(self::EVENT_OPTION, $events, false);
+        } finally {
+            self::release_event_lock($lock);
+        }
+
+        if (!$stored || !is_array($event_envelope)) {
+            self::report_event_delivery_failure('The panel event queue could not be updated; Redis publication was skipped.');
+            return null;
+        }
+
+        self::publish_event($event_envelope);
+
+        return $event_envelope;
+    }
+
+    /**
+     * Acquire a database-wide lock around sequence allocation and queue writes.
+     *
+     * MySQL advisory locks serialize all PHP workers that use this writer, so
+     * IDs remain strictly increasing and concurrent option updates cannot drop
+     * an event through a read-modify-write race.
+     *
+     * @return string|false
+     */
+    private static function acquire_event_lock() {
+        global $wpdb;
+
+        if (!is_object($wpdb) || !method_exists($wpdb, 'prepare') || !method_exists($wpdb, 'get_var')) {
+            return 'process';
+        }
+
+        $query = $wpdb->prepare('SELECT GET_LOCK(%s, %d)', self::EVENT_LOCK_NAME, 5);
+        return (string) $wpdb->get_var($query) === '1' ? 'database' : false;
+    }
+
+    /**
+     * Release an event lock acquired by acquire_event_lock().
+     *
+     * @param string $lock Lock provider.
+     */
+    private static function release_event_lock($lock) {
+        global $wpdb;
+
+        if ($lock !== 'database' || !is_object($wpdb) || !method_exists($wpdb, 'prepare') || !method_exists($wpdb, 'get_var')) {
+            return;
+        }
+
+        $wpdb->get_var($wpdb->prepare('SELECT RELEASE_LOCK(%s)', self::EVENT_LOCK_NAME));
+    }
+
+    /**
+     * Avoid stale option values in the long-running WP-CLI WebSocket process.
+     */
+    private static function refresh_event_option_cache($force = false) {
+        if (
+            !function_exists('wp_cache_delete')
+            || (!$force && (!defined('WP_CLI') || !WP_CLI))
+        ) {
+            return;
+        }
+
+        wp_cache_delete(self::EVENT_OPTION, 'options');
+        wp_cache_delete(self::EVENT_SEQUENCE_OPTION, 'options');
+    }
+
+    /**
+     * Publish the already-persisted envelope to Redis for immediate delivery.
+     *
+     * A zero subscriber count is a successful Redis PUBLISH reply. Any false
+     * connection/auth/select/publish response is reported while the option
+     * queue and the browser's polling loop remain the delivery fallback.
+     *
+     * @param array $event_envelope Stored event envelope.
+     * @return bool
+     */
+    private static function publish_event($event_envelope) {
+        $redis = apply_filters('digitalogic_panel_redis_client', null);
+        if ($redis === null) {
+            if (!class_exists('Redis')) {
+                return false;
+            }
+
+            $redis = new Redis();
+        }
+
+        if (!is_object($redis)) {
+            self::report_event_delivery_failure('The Redis publisher factory returned an invalid client.');
+            return false;
+        }
+
+        $config = self::get_redis_config();
+
+        try {
+            if (!method_exists($redis, 'connect') || $redis->connect($config['host'], $config['port'], $config['timeout']) !== true) {
+                throw new RuntimeException('Redis connection failed.');
+            }
+
+            if ($config['password'] !== '' && (!method_exists($redis, 'auth') || $redis->auth($config['password']) !== true)) {
+                throw new RuntimeException('Redis authentication failed.');
+            }
+
+            if ($config['database'] !== null && (!method_exists($redis, 'select') || $redis->select($config['database']) !== true)) {
+                throw new RuntimeException('Redis database selection failed.');
+            }
+
+            $payload = wp_json_encode($event_envelope);
+            if (!is_string($payload)) {
+                throw new RuntimeException('The panel event could not be JSON encoded.');
+            }
+
+            if (!method_exists($redis, 'publish') || $redis->publish($config['channel'], $payload) === false) {
+                throw new RuntimeException('Redis publication failed.');
+            }
+
+            return true;
+        } catch (Throwable $error) {
+            self::report_event_delivery_failure($error->getMessage());
+            return false;
+        } finally {
+            if (method_exists($redis, 'close')) {
+                try {
+                    $redis->close();
+                } catch (Throwable $error) {
+                    // Connection teardown does not change delivery outcome.
+                }
+            }
+        }
+    }
+
+    /**
+     * Report a transport/storage failure and coalesce repeats in this process.
+     *
+     * @param string $message Failure summary without credentials.
+     */
+    private static function report_event_delivery_failure($message) {
+        $message = sanitize_text_field((string) $message);
+        do_action('digitalogic_panel_event_delivery_failed', $message);
+
+        $signature = md5($message);
+        $now = time();
+        if (!isset(self::$reported_delivery_failures[$signature]) || ($now - self::$reported_delivery_failures[$signature]) >= 60) {
+            self::$reported_delivery_failures[$signature] = $now;
+            error_log('[Digitalogic panel events] ' . $message);
+        }
     }
 
     public static function broadcast_panel_message($data = array()) {
@@ -540,22 +777,7 @@ class Digitalogic_Panel {
             $data['message'] = __('Panel notification', 'digitalogic');
         }
 
-        self::record_event('panel.toast', $data);
-
-        if (class_exists('Redis')) {
-            try {
-                $redis = new Redis();
-                $redis->connect('127.0.0.1', 6379, 0.2);
-                $redis->publish('digitalogic_panel_events', wp_json_encode(array(
-                    'event' => 'panel.toast',
-                    'data' => $data,
-                    'time' => current_time('mysql'),
-                )));
-                $redis->close();
-            } catch (Throwable $e) {
-                // The option-backed event queue remains the reliable fallback.
-            }
-        }
+        return self::record_event('panel.toast', $data);
     }
 
     private function format_user($user) {

--- a/includes/websocket/class-websocket-server.php
+++ b/includes/websocket/class-websocket-server.php
@@ -23,7 +23,7 @@ class Digitalogic_WebSocket_Server {
 
         stream_set_blocking($server, false);
         if (defined('WP_CLI') && WP_CLI) {
-            WP_CLI::success('Digitalogic WebSocket server listening on ' . $host . ':' . $port);
+            WP_CLI::log('Digitalogic WebSocket server listening on ' . $host . ':' . $port);
         }
 
         $this->connect_redis_subscriber();
@@ -298,41 +298,140 @@ class Digitalogic_WebSocket_Server {
     private function connect_redis_subscriber() {
         $this->close_redis_subscriber();
 
-        $config = class_exists('Digitalogic_Panel') ? Digitalogic_Panel::get_redis_config() : array();
-        $host = isset($config['host']) ? (string) $config['host'] : '127.0.0.1';
-        $port = isset($config['port']) ? (int) $config['port'] : 6379;
-        $timeout = isset($config['timeout']) ? (float) $config['timeout'] : 0.2;
-        $password = isset($config['password']) ? (string) $config['password'] : '';
-        $database = array_key_exists('database', $config) && $config['database'] !== null ? (int) $config['database'] : null;
-        $this->redis_channel = !empty($config['channel']) ? (string) $config['channel'] : 'digitalogic_panel_events';
+        $config = Digitalogic_Panel::get_redis_config();
+        $host = $config['host'];
+        $port = $config['port'];
+        $timeout = $config['timeout'];
+        $password = $config['password'];
+        $database = $config['database'];
+        $this->redis_channel = $config['channel'];
 
         $socket = @stream_socket_client('tcp://' . $host . ':' . $port, $errno, $errstr, $timeout);
         if (!is_resource($socket)) {
-            $this->redis_next_connect_at = microtime(true) + 5;
-            if (defined('WP_CLI') && WP_CLI) {
-                WP_CLI::warning('Digitalogic WebSocket Redis subscriber unavailable: ' . $errstr);
-            }
+            $this->schedule_redis_retry('Redis connection failed: ' . $errstr, 5);
             return;
         }
 
-        stream_set_blocking($socket, false);
+        stream_set_blocking($socket, true);
+        $timeout_seconds = (int) floor($timeout);
+        $timeout_microseconds = (int) (($timeout - $timeout_seconds) * 1000000);
+        stream_set_timeout($socket, $timeout_seconds, $timeout_microseconds);
         $this->redis_socket = $socket;
         $this->redis_buffer = '';
+
+        try {
+            if ($password !== '') {
+                $auth_reply = $this->send_redis_setup_command(array('AUTH', $password), $timeout);
+                if ((string) $auth_reply !== 'OK') {
+                    throw new RuntimeException('Redis AUTH was rejected.');
+                }
+            }
+
+            if ($database !== null) {
+                $select_reply = $this->send_redis_setup_command(array('SELECT', (string) $database), $timeout);
+                if ((string) $select_reply !== 'OK') {
+                    throw new RuntimeException('Redis SELECT was rejected.');
+                }
+            }
+
+            $subscribe_reply = $this->send_redis_setup_command(array('SUBSCRIBE', $this->redis_channel), $timeout);
+            if (
+                !is_array($subscribe_reply)
+                || count($subscribe_reply) < 3
+                || strtolower((string) $subscribe_reply[0]) !== 'subscribe'
+                || (string) $subscribe_reply[1] !== $this->redis_channel
+                || (int) $subscribe_reply[2] < 1
+            ) {
+                throw new RuntimeException('Redis SUBSCRIBE acknowledgement was invalid.');
+            }
+        } catch (Throwable $error) {
+            $this->schedule_redis_retry($error->getMessage(), 5);
+            return;
+        }
+
+        stream_set_blocking($this->redis_socket, false);
+        stream_set_timeout($this->redis_socket, 0);
         $this->redis_next_connect_at = 0;
-
-        if ($password !== '') {
-            @fwrite($this->redis_socket, $this->redis_encode_command(array('AUTH', $password)));
-        }
-
-        if ($database !== null) {
-            @fwrite($this->redis_socket, $this->redis_encode_command(array('SELECT', (string) $database)));
-        }
-
-        @fwrite($this->redis_socket, $this->redis_encode_command(array('SUBSCRIBE', $this->redis_channel)));
         $this->send_missed_panel_events();
+        $this->process_redis_buffer();
 
         if (defined('WP_CLI') && WP_CLI) {
             WP_CLI::log('Digitalogic WebSocket subscribed to Redis channel ' . $this->redis_channel . '.');
+        }
+    }
+
+    /**
+     * Schedule a clean Redis reconnect after setup or I/O failure.
+     *
+     * @param string $message Failure summary without credentials.
+     * @param int    $delay Retry delay in seconds.
+     */
+    private function schedule_redis_retry($message, $delay = 5) {
+        $this->close_redis_subscriber();
+        $this->redis_next_connect_at = microtime(true) + max(1, (int) $delay);
+
+        if (defined('WP_CLI') && WP_CLI) {
+            WP_CLI::warning('Digitalogic WebSocket Redis subscriber unavailable: ' . sanitize_text_field($message));
+        }
+    }
+
+    /**
+     * Write a complete Redis command and synchronously read its setup reply.
+     *
+     * @param array $parts Redis command parts.
+     * @param float $timeout Read timeout in seconds.
+     * @return mixed
+     */
+    private function send_redis_setup_command($parts, $timeout) {
+        $payload = $this->redis_encode_command($parts);
+        $length = strlen($payload);
+        $written = 0;
+
+        while ($written < $length) {
+            $result = @fwrite($this->redis_socket, substr($payload, $written));
+            if ($result === false || $result === 0) {
+                throw new RuntimeException('Redis command write failed.');
+            }
+
+            $written += $result;
+        }
+
+        return $this->read_redis_setup_reply($timeout);
+    }
+
+    /**
+     * Read exactly one complete RESP reply during subscriber setup.
+     *
+     * @param float $timeout Read timeout in seconds.
+     * @return mixed
+     */
+    private function read_redis_setup_reply($timeout) {
+        $deadline = microtime(true) + max(0.1, (float) $timeout);
+
+        while (true) {
+            if ($this->redis_buffer !== '') {
+                list($complete, $reply) = $this->pop_redis_reply();
+                if ($complete) {
+                    return $reply;
+                }
+            }
+
+            $chunk = @fread($this->redis_socket, 8192);
+            if (is_string($chunk) && $chunk !== '') {
+                $this->redis_buffer .= $chunk;
+                continue;
+            }
+
+            $metadata = stream_get_meta_data($this->redis_socket);
+            if (!empty($metadata['timed_out']) || microtime(true) >= $deadline) {
+                throw new RuntimeException('Redis setup reply timed out.');
+            }
+
+            if (!empty($metadata['eof'])) {
+                throw new RuntimeException('Redis closed the setup connection.');
+            }
+
+            usleep(10000);
         }
     }
 
@@ -353,13 +452,19 @@ class Digitalogic_WebSocket_Server {
         $chunk = @fread($this->redis_socket, 8192);
         if ($chunk === '' || $chunk === false) {
             if (feof($this->redis_socket)) {
-                $this->close_redis_subscriber();
-                $this->redis_next_connect_at = microtime(true) + 1;
+                $this->schedule_redis_retry('Redis closed the subscription connection.', 1);
             }
             return;
         }
 
         $this->redis_buffer .= $chunk;
+        $this->process_redis_buffer();
+    }
+
+    /**
+     * Process all complete Redis replies already buffered in userspace.
+     */
+    private function process_redis_buffer() {
         while ($this->redis_buffer !== '') {
             list($complete, $reply) = $this->pop_redis_reply();
             if (!$complete) {
@@ -381,7 +486,15 @@ class Digitalogic_WebSocket_Server {
         }
 
         $event = json_decode((string) $reply[2], true);
-        if (!is_array($event)) {
+        if (
+            !is_array($event)
+            || empty($event['id'])
+            || empty($event['name'])
+            || !isset($event['data'])
+            || !is_array($event['data'])
+            || !isset($event['time'])
+            || !is_string($event['time'])
+        ) {
             return;
         }
 

--- a/tests/WebSocketLifecycleTest.php
+++ b/tests/WebSocketLifecycleTest.php
@@ -1,0 +1,453 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class WebSocketLifecycleTest extends TestCase {
+
+    /** @var Digitalogic_Test_Redis_Client */
+    private $redis;
+
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_options'] = array();
+        $GLOBALS['digitalogic_test_filters'] = array();
+        $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_cache_deletes'] = array();
+        $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
+        WP_CLI::$errors = array();
+        WP_CLI::$warnings = array();
+        WP_CLI::$logs = array();
+
+        $this->redis = new Digitalogic_Test_Redis_Client();
+        $redis = $this->redis;
+        $GLOBALS['digitalogic_test_filters']['digitalogic_panel_redis_client'] = static function() use ($redis) {
+            return $redis;
+        };
+    }
+
+    public function test_latest_event_id_uses_queue_and_durable_sequence(): void {
+        $GLOBALS['digitalogic_test_options']['digitalogic_panel_events'] = array(
+            array('id' => 120),
+            array('id' => '450'),
+            array('name' => 'missing.id'),
+            'invalid event',
+            array('id' => 310),
+        );
+        $GLOBALS['digitalogic_test_options']['digitalogic_panel_event_sequence'] = 700;
+
+        $this->assertSame(700, Digitalogic_Panel::get_latest_event_id());
+        $this->assertNotEmpty($GLOBALS['digitalogic_test_cache_deletes']);
+    }
+
+    public function test_latest_event_id_defaults_to_zero_for_invalid_storage(): void {
+        $GLOBALS['digitalogic_test_options']['digitalogic_panel_events'] = 'invalid';
+
+        $this->assertSame(0, Digitalogic_Panel::get_latest_event_id());
+    }
+
+    public function test_redis_config_uses_existing_delivery_defaults(): void {
+        $this->assertSame(array(
+            'host' => '127.0.0.1',
+            'port' => 6379,
+            'timeout' => 0.2,
+            'password' => '',
+            'database' => null,
+            'channel' => 'digitalogic_panel_events',
+        ), Digitalogic_Panel::get_redis_config());
+    }
+
+    public function test_redis_config_normalizes_filtered_server_settings(): void {
+        $GLOBALS['digitalogic_test_filters']['digitalogic_panel_redis_config'] = static function() {
+            return array(
+                'host' => ' redis.internal ',
+                'port' => '6380',
+                'timeout' => '1.5',
+                'password' => 'server-secret',
+                'database' => '4',
+                'channel' => ' panel.events ',
+            );
+        };
+
+        $this->assertSame(array(
+            'host' => 'redis.internal',
+            'port' => 6380,
+            'timeout' => 1.5,
+            'password' => 'server-secret',
+            'database' => 4,
+            'channel' => 'panel.events',
+        ), Digitalogic_Panel::get_redis_config());
+    }
+
+    public function test_record_event_persists_and_publishes_the_exact_same_envelope(): void {
+        $event = Digitalogic_Panel::record_event('product.updated', array('id' => 42));
+
+        $this->assertIsArray($event);
+        $this->assertSame($event, $GLOBALS['digitalogic_test_options']['digitalogic_panel_events'][0]);
+        $this->assertSame($event['id'], $GLOBALS['digitalogic_test_options']['digitalogic_panel_event_sequence']);
+        $this->assertCount(1, $this->redis->published);
+        $this->assertSame('digitalogic_panel_events', $this->redis->published[0][0]);
+        $this->assertSame($event, json_decode($this->redis->published[0][1], true));
+        $this->assertSame(1, $GLOBALS['wpdb']->acquire_count);
+        $this->assertSame(1, $GLOBALS['wpdb']->release_count);
+    }
+
+    public function test_every_panel_event_producer_uses_the_shared_durable_publisher(): void {
+        $panel = (new ReflectionClass(Digitalogic_Panel::class))->newInstanceWithoutConstructor();
+
+        $panel->record_product_event(101);
+        $panel->record_user_event(202);
+        $panel->record_option_event('yuan_price', '10', '11');
+        Digitalogic_Panel::broadcast_panel_message(array('message' => 'Finished', 'level' => 'success'));
+
+        $events = $GLOBALS['digitalogic_test_options']['digitalogic_panel_events'];
+        $this->assertSame(
+            array('product.updated', 'user.updated', 'currency.updated', 'panel.toast'),
+            array_column($events, 'name')
+        );
+        $this->assertCount(4, $this->redis->published);
+
+        foreach ($events as $index => $event) {
+            $this->assertSame($event, json_decode($this->redis->published[$index][1], true));
+        }
+    }
+
+    public function test_event_ids_are_strictly_monotonic_even_when_clock_is_behind(): void {
+        $seed = (int) round(microtime(true) * 1000) + 10000;
+        $GLOBALS['digitalogic_test_options']['digitalogic_panel_event_sequence'] = $seed;
+
+        $first = Digitalogic_Panel::record_event('first.event');
+        $second = Digitalogic_Panel::record_event('second.event');
+
+        $this->assertSame($seed + 1, $first['id']);
+        $this->assertSame($seed + 2, $second['id']);
+    }
+
+    public function test_event_is_not_written_without_the_database_lock(): void {
+        $GLOBALS['wpdb']->acquire_result = 0;
+
+        $event = Digitalogic_Panel::record_event('product.updated', array('id' => 1));
+
+        $this->assertNull($event);
+        $this->assertArrayNotHasKey('digitalogic_panel_events', $GLOBALS['digitalogic_test_options']);
+        $this->assertCount(0, $this->redis->published);
+        $this->assertStringContainsString('database event lock', $this->delivery_failure_messages()[0]);
+    }
+
+    public function test_queue_write_failure_skips_redis_but_reports_the_fallback_failure(): void {
+        $GLOBALS['digitalogic_test_update_failures'][] = 'digitalogic_panel_events';
+
+        $event = Digitalogic_Panel::record_event('product.updated', array('id' => 1));
+
+        $this->assertNull($event);
+        $this->assertCount(0, $this->redis->published);
+        $messages = $this->delivery_failure_messages();
+        $this->assertStringContainsString('queue could not be updated', end($messages));
+    }
+
+    public function test_publisher_reports_connection_auth_select_and_publish_failures(): void {
+        $scenarios = array(
+            array('connect_result', false, array(), 'connection failed'),
+            array('auth_result', false, array('password' => 'secret'), 'authentication failed'),
+            array('select_result', false, array('database' => 2), 'database selection failed'),
+            array('publish_result', false, array(), 'publication failed'),
+        );
+
+        foreach ($scenarios as $index => $scenario) {
+            $GLOBALS['digitalogic_test_actions'] = array();
+            $client = new Digitalogic_Test_Redis_Client();
+            $client->{$scenario[0]} = $scenario[1];
+            $GLOBALS['digitalogic_test_filters']['digitalogic_panel_redis_client'] = static function() use ($client) {
+                return $client;
+            };
+            $config_override = $scenario[2];
+            $GLOBALS['digitalogic_test_filters']['digitalogic_panel_redis_config'] = static function() use ($config_override) {
+                return $config_override;
+            };
+
+            $event = Digitalogic_Panel::record_event('test.failure.' . $index);
+
+            $this->assertIsArray($event, 'The polling queue must survive Redis failure.');
+            $messages = $this->delivery_failure_messages();
+            $this->assertStringContainsString($scenario[3], strtolower(end($messages)));
+        }
+    }
+
+    public function test_zero_subscribers_is_a_successful_publish_reply(): void {
+        $this->redis->publish_result = 0;
+
+        $event = Digitalogic_Panel::record_event('panel.toast', array('message' => 'No listeners yet'));
+
+        $this->assertIsArray($event);
+        $this->assertSame(array(), $this->delivery_failure_messages());
+        $this->assertCount(1, $this->redis->published);
+    }
+
+    public function test_subscriber_validates_auth_select_and_subscribe_before_becoming_healthy(): void {
+        $channel = 'panel.integration.events';
+        list($port, $pid) = $this->start_redis_server(array(
+            "+OK\r\n",
+            "+OK\r\n",
+            $this->subscribe_reply($channel),
+        ));
+        $this->set_subscriber_config($port, $channel, 'secret', 3);
+        $server = new Digitalogic_WebSocket_Server();
+
+        $this->invoke_private($server, 'connect_redis_subscriber');
+
+        $this->assertIsResource($this->read_private($server, 'redis_socket'));
+        $this->assertSame(0, $this->read_private($server, 'redis_next_connect_at'));
+        $this->assertSame(array(), WP_CLI::$warnings);
+        $logs = WP_CLI::$logs;
+        $this->assertStringContainsString($channel, end($logs));
+
+        $this->invoke_private($server, 'close_redis_subscriber');
+        $this->wait_for_child($pid);
+    }
+
+    public function test_subscriber_rejects_bad_setup_and_retries_with_a_new_connection(): void {
+        list($bad_port, $bad_pid) = $this->start_redis_server(array("-ERR invalid password\r\n"));
+        $this->set_subscriber_config($bad_port, 'panel.retry.events', 'bad-secret', null);
+        $server = new Digitalogic_WebSocket_Server();
+
+        $this->invoke_private($server, 'connect_redis_subscriber');
+
+        $this->assertNull($this->read_private($server, 'redis_socket'));
+        $this->assertGreaterThan(microtime(true), $this->read_private($server, 'redis_next_connect_at'));
+        $warnings = WP_CLI::$warnings;
+        $this->assertStringContainsString('AUTH was rejected', end($warnings));
+        $this->wait_for_child($bad_pid);
+
+        $channel = 'panel.retry.events';
+        list($good_port, $good_pid) = $this->start_redis_server(array($this->subscribe_reply($channel)));
+        $this->set_subscriber_config($good_port, $channel, '', null);
+        $this->write_private($server, 'redis_next_connect_at', 0);
+
+        $this->invoke_private($server, 'maybe_connect_redis_subscriber');
+
+        $this->assertIsResource($this->read_private($server, 'redis_socket'));
+        $this->invoke_private($server, 'close_redis_subscriber');
+        $this->wait_for_child($good_pid);
+    }
+
+    public function test_subscriber_rejects_an_invalid_subscribe_acknowledgement(): void {
+        list($port, $pid) = $this->start_redis_server(array($this->subscribe_reply('wrong.channel')));
+        $this->set_subscriber_config($port, 'expected.channel', '', null);
+        $server = new Digitalogic_WebSocket_Server();
+
+        $this->invoke_private($server, 'connect_redis_subscriber');
+
+        $this->assertNull($this->read_private($server, 'redis_socket'));
+        $warnings = WP_CLI::$warnings;
+        $this->assertStringContainsString('SUBSCRIBE acknowledgement was invalid', end($warnings));
+        $this->wait_for_child($pid);
+    }
+
+    public function test_subscriber_broadcasts_valid_durable_envelopes_and_suppresses_duplicates(): void {
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        $this->assertIsArray($pair);
+        stream_set_timeout($pair[1], 1);
+
+        $server = new Digitalogic_WebSocket_Server();
+        $this->write_private($server, 'clients', array(
+            42 => array(
+                'socket' => $pair[0],
+                'handshake' => true,
+                'last_event_id' => 0,
+            ),
+        ));
+        $event = array(
+            'id' => 1700000000001,
+            'event' => 'product_updated',
+            'name' => 'product.updated',
+            'data' => array('id' => 55),
+            'time' => '2026-07-16 12:00:00',
+        );
+        $reply = array('message', 'digitalogic_panel_events', wp_json_encode($event));
+
+        $this->invoke_private($server, 'handle_redis_reply', array($reply));
+        $payload = $this->decode_websocket_frame(fread($pair[1], 8192));
+
+        $this->assertSame($event['id'], $payload['id']);
+        $this->assertSame($event['name'], $payload['name']);
+        $this->assertSame($event['data'], $payload['data']);
+        $this->assertSame($event['time'], $payload['time']);
+
+        stream_set_blocking($pair[1], false);
+        $this->invoke_private($server, 'handle_redis_reply', array($reply));
+        usleep(10000);
+        $this->assertSame('', fread($pair[1], 8192));
+
+        fclose($pair[0]);
+        fclose($pair[1]);
+    }
+
+    public function test_websocket_cli_catches_engine_errors_without_terminating_phpunit(): void {
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertIsResource($listener);
+        $address = stream_socket_get_name($listener, false);
+        $port = (int) substr(strrchr($address, ':'), 1);
+
+        $commands = new Digitalogic_CLI_Commands();
+        $commands->websocket_serve(array(), array('host' => '127.0.0.1', 'port' => $port));
+
+        $this->assertNotEmpty(WP_CLI::$errors);
+        fclose($listener);
+    }
+
+    public function test_browser_advances_polling_cursor_for_websocket_events(): void {
+        $source = file_get_contents(dirname(__DIR__) . '/assets/js/panel-app.js');
+
+        $this->assertStringContainsString(
+            'lastEventId: Number(config.event_cursor || 0)',
+            $source
+        );
+        $this->assertStringContainsString(
+            'this.lastEventId = Math.max(this.lastEventId, Number(event.id || 0));',
+            $source
+        );
+    }
+
+    private function delivery_failure_messages(): array {
+        $calls = $GLOBALS['digitalogic_test_actions']['digitalogic_panel_event_delivery_failed'] ?? array();
+        return array_map(static function($args) {
+            return (string) ($args[0] ?? '');
+        }, $calls);
+    }
+
+    private function set_subscriber_config($port, $channel, $password, $database): void {
+        $GLOBALS['digitalogic_test_filters']['digitalogic_panel_redis_config'] = static function() use ($port, $channel, $password, $database) {
+            return array(
+                'host' => '127.0.0.1',
+                'port' => $port,
+                'timeout' => 1.0,
+                'password' => $password,
+                'database' => $database,
+                'channel' => $channel,
+            );
+        };
+    }
+
+    private function start_redis_server(array $replies): array {
+        if (!function_exists('pcntl_fork')) {
+            $this->markTestSkipped('pcntl is required for the TCP Redis protocol test.');
+        }
+
+        $listener = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertIsResource($listener, $errstr);
+        $address = stream_socket_get_name($listener, false);
+        $port = (int) substr(strrchr($address, ':'), 1);
+        $pid = pcntl_fork();
+        $this->assertNotSame(-1, $pid);
+
+        if ($pid === 0) {
+            $client = @stream_socket_accept($listener, 5);
+            if (!is_resource($client)) {
+                exit(2);
+            }
+
+            foreach ($replies as $reply) {
+                self::read_redis_command($client);
+                self::write_all($client, $reply);
+            }
+
+            usleep(100000);
+            fclose($client);
+            fclose($listener);
+            exit(0);
+        }
+
+        fclose($listener);
+        return array($port, $pid);
+    }
+
+    private static function read_redis_command($socket): void {
+        $header = self::read_line($socket);
+        if ($header === '' || $header[0] !== '*') {
+            exit(3);
+        }
+
+        $parts = (int) substr($header, 1);
+        for ($index = 0; $index < $parts; $index++) {
+            $length_line = self::read_line($socket);
+            if ($length_line === '' || $length_line[0] !== '$') {
+                exit(4);
+            }
+
+            self::read_exact($socket, (int) substr($length_line, 1) + 2);
+        }
+    }
+
+    private static function read_line($socket): string {
+        $line = stream_get_line($socket, 8192, "\r\n");
+        return is_string($line) ? $line : '';
+    }
+
+    private static function read_exact($socket, $length): string {
+        $buffer = '';
+        while (strlen($buffer) < $length) {
+            $chunk = fread($socket, $length - strlen($buffer));
+            if ($chunk === false || $chunk === '') {
+                exit(5);
+            }
+            $buffer .= $chunk;
+        }
+        return $buffer;
+    }
+
+    private static function write_all($socket, $payload): void {
+        $written = 0;
+        while ($written < strlen($payload)) {
+            $result = fwrite($socket, substr($payload, $written));
+            if ($result === false || $result === 0) {
+                exit(6);
+            }
+            $written += $result;
+        }
+    }
+
+    private function subscribe_reply($channel): string {
+        return '*3' . "\r\n" . '$9' . "\r\nsubscribe\r\n" . '$' . strlen($channel) . "\r\n" . $channel . "\r\n:1\r\n";
+    }
+
+    private function wait_for_child($pid): void {
+        $status = 0;
+        pcntl_waitpid($pid, $status);
+        $this->assertTrue(pcntl_wifexited($status));
+        $this->assertSame(0, pcntl_wexitstatus($status));
+    }
+
+    private function invoke_private($object, $method, array $arguments = array()) {
+        $reflection = new ReflectionMethod($object, $method);
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($object, $arguments);
+    }
+
+    private function read_private($object, $property) {
+        $reflection = new ReflectionProperty($object, $property);
+        $reflection->setAccessible(true);
+        return $reflection->getValue($object);
+    }
+
+    private function write_private($object, $property, $value): void {
+        $reflection = new ReflectionProperty($object, $property);
+        $reflection->setAccessible(true);
+        $reflection->setValue($object, $value);
+    }
+
+    private function decode_websocket_frame($frame): array {
+        $this->assertNotSame('', $frame);
+        $length = ord($frame[1]) & 127;
+        $offset = 2;
+
+        if ($length === 126) {
+            $length = unpack('n', substr($frame, $offset, 2))[1];
+            $offset += 2;
+        } elseif ($length === 127) {
+            $parts = unpack('N2', substr($frame, $offset, 8));
+            $length = ($parts[1] * 4294967296) + $parts[2];
+            $offset += 8;
+        }
+
+        return json_decode(substr($frame, $offset, $length), true);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,11 @@
 <?php
+
 /**
- * Lightweight WordPress stubs for unit-testing REST permission policy.
+ * Lightweight WordPress, Redis, and WP-CLI stubs shared by plugin unit tests.
  */
 
 define('ABSPATH', __DIR__ . '/');
+define('WP_CLI', true);
 
 $GLOBALS['digitalogic_test_capabilities'] = array();
 $GLOBALS['digitalogic_test_filters'] = array();
@@ -11,8 +13,14 @@ $GLOBALS['digitalogic_test_routes'] = array();
 $GLOBALS['digitalogic_test_rest_prefix'] = 'wp-json';
 $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
 $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
+$GLOBALS['digitalogic_test_options'] = array();
+$GLOBALS['digitalogic_test_actions'] = array();
+$GLOBALS['digitalogic_test_update_failures'] = array();
+$GLOBALS['digitalogic_test_cache_deletes'] = array();
 
 class WP_REST_Request {
+    public function __construct($method = '', $route = '') {
+    }
 }
 
 class Digitalogic_Patris_Feed {
@@ -36,6 +44,7 @@ class Digitalogic_Patris_Feed {
 }
 
 function add_action($hook_name, $callback, $priority = 10, $accepted_args = 1) {
+    return true;
 }
 
 function current_user_can($capability) {
@@ -45,6 +54,10 @@ function current_user_can($capability) {
 }
 
 function add_filter($hook_name, $callback, $priority = 10, $accepted_args = 1) {
+    if (!isset($GLOBALS['digitalogic_test_filters'][$hook_name]) || !is_array($GLOBALS['digitalogic_test_filters'][$hook_name])) {
+        $GLOBALS['digitalogic_test_filters'][$hook_name] = array();
+    }
+
     $GLOBALS['digitalogic_test_filters'][$hook_name][] = array(
         'callback' => $callback,
         'accepted_args' => $accepted_args,
@@ -60,17 +73,38 @@ function remove_all_filters($hook_name) {
 }
 
 function apply_filters($hook_name, $value, ...$args) {
-    if (empty($GLOBALS['digitalogic_test_filters'][$hook_name])) {
+    if (!isset($GLOBALS['digitalogic_test_filters'][$hook_name])) {
         return $value;
     }
 
-    foreach ($GLOBALS['digitalogic_test_filters'][$hook_name] as $filter) {
+    $registered = $GLOBALS['digitalogic_test_filters'][$hook_name];
+    if (is_callable($registered)) {
+        return call_user_func($registered, $value, ...$args);
+    }
+
+    if (!is_array($registered)) {
+        return $value;
+    }
+
+    foreach ($registered as $filter) {
+        if (!is_array($filter) || !isset($filter['callback']) || !is_callable($filter['callback'])) {
+            continue;
+        }
+
         $parameters = array_merge(array($value), $args);
-        $parameters = array_slice($parameters, 0, $filter['accepted_args']);
+        $parameters = array_slice($parameters, 0, isset($filter['accepted_args']) ? $filter['accepted_args'] : 1);
         $value = call_user_func_array($filter['callback'], $parameters);
     }
 
     return $value;
+}
+
+function do_action($hook_name, ...$args) {
+    if (!isset($GLOBALS['digitalogic_test_actions'][$hook_name])) {
+        $GLOBALS['digitalogic_test_actions'][$hook_name] = array();
+    }
+
+    $GLOBALS['digitalogic_test_actions'][$hook_name][] = $args;
 }
 
 function register_rest_route($namespace, $route, $args = array(), $override = false) {
@@ -93,4 +127,151 @@ function rest_url($path = '') {
     throw new RuntimeException('The WooCommerce route matcher must not call rest_url().');
 }
 
+function get_option($name, $default = false) {
+    return array_key_exists($name, $GLOBALS['digitalogic_test_options'])
+        ? $GLOBALS['digitalogic_test_options'][$name]
+        : $default;
+}
+
+function update_option($name, $value, $autoload = null) {
+    if (in_array($name, $GLOBALS['digitalogic_test_update_failures'], true)) {
+        return false;
+    }
+
+    $changed = !array_key_exists($name, $GLOBALS['digitalogic_test_options'])
+        || $GLOBALS['digitalogic_test_options'][$name] !== $value;
+    $GLOBALS['digitalogic_test_options'][$name] = $value;
+
+    return $changed;
+}
+
+function wp_cache_delete($key, $group = '') {
+    $GLOBALS['digitalogic_test_cache_deletes'][] = array($key, $group);
+
+    return true;
+}
+
+function absint($value) {
+    return abs((int) $value);
+}
+
+function sanitize_key($value) {
+    return preg_replace('/[^a-z0-9_\-]/', '', strtolower((string) $value));
+}
+
+function sanitize_text_field($value) {
+    return trim(strip_tags((string) $value));
+}
+
+function current_time($type) {
+    return '2026-07-16 12:00:00';
+}
+
+function wp_json_encode($value) {
+    return json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+}
+
+function __($message, $domain = null) {
+    return $message;
+}
+
+class Digitalogic_Test_WPDB {
+    public $acquire_result = 1;
+    public $acquire_count = 0;
+    public $release_count = 0;
+
+    public function prepare($query, ...$args) {
+        return array(
+            'query' => $query,
+            'args' => $args,
+        );
+    }
+
+    public function get_var($prepared) {
+        $query = is_array($prepared) && isset($prepared['query']) ? $prepared['query'] : (string) $prepared;
+        if (strpos($query, 'GET_LOCK') !== false) {
+            $this->acquire_count++;
+            return $this->acquire_result;
+        }
+
+        if (strpos($query, 'RELEASE_LOCK') !== false) {
+            $this->release_count++;
+            return 1;
+        }
+
+        return null;
+    }
+}
+
+class Digitalogic_Test_Redis_Client {
+    public $connect_result = true;
+    public $auth_result = true;
+    public $select_result = true;
+    public $publish_result = 0;
+    public $calls = array();
+    public $published = array();
+
+    public function connect($host, $port, $timeout) {
+        $this->calls[] = array('connect', $host, $port, $timeout);
+        return $this->connect_result;
+    }
+
+    public function auth($password) {
+        $this->calls[] = array('auth', $password);
+        return $this->auth_result;
+    }
+
+    public function select($database) {
+        $this->calls[] = array('select', $database);
+        return $this->select_result;
+    }
+
+    public function publish($channel, $payload) {
+        $this->calls[] = array('publish', $channel);
+        $this->published[] = array($channel, $payload);
+        return $this->publish_result;
+    }
+
+    public function close() {
+        $this->calls[] = array('close');
+        return true;
+    }
+}
+
+class WP_CLI {
+    public static $commands = array();
+    public static $errors = array();
+    public static $warnings = array();
+    public static $logs = array();
+
+    public static function add_command($name, $callable) {
+        self::$commands[$name] = $callable;
+    }
+
+    public static function error($message) {
+        self::$errors[] = (string) $message;
+    }
+
+    public static function warning($message) {
+        self::$warnings[] = (string) $message;
+    }
+
+    public static function log($message) {
+        self::$logs[] = (string) $message;
+    }
+
+    public static function success($message) {
+        throw new RuntimeException('WP_CLI::success must not be used by the long-running server: ' . $message);
+    }
+
+    public static function line($message) {
+        self::$logs[] = (string) $message;
+    }
+}
+
+$GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
+
 require_once dirname(__DIR__) . '/includes/api/class-rest-api.php';
+require_once dirname(__DIR__) . '/includes/panel/class-panel.php';
+require_once dirname(__DIR__) . '/includes/websocket/class-websocket-server.php';
+require_once dirname(__DIR__) . '/includes/cli/class-cli-commands.php';


### PR DESCRIPTION
Closes #35

## Summary
- persist monotonic panel-event envelopes under a database lock
- publish the exact stored envelope through validated Redis connections
- harden AUTH, SELECT, SUBSCRIBE, reconnect, and full-write handling
- initialize and advance the browser cursor so polling and WebSocket delivery cooperate without duplicate toasts
- keep the long-running WP-CLI server alive and add lifecycle regression coverage

## Validation
- 37 PHPUnit tests, 128 assertions
- PHP syntax checks
- panel JavaScript syntax check
- Composer validation
- public-tree guard
- real Redis/WebSocket concurrency smoke performed on the server