### PR TITLE
Prevent recursive REST authentication

### DIFF
--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -12,6 +12,24 @@ if (!defined('ABSPATH')) {
 class Digitalogic_REST_API {
     
     private static $instance = null;
+
+    /**
+     * REST path used for exact Digitalogic namespace matching.
+     *
+     * This is resolved before the WooCommerce authentication filter is
+     * registered so the filter never calls rest_url() while WordPress is
+     * resolving the current user.
+     *
+     * @var string|null
+     */
+    private $woocommerce_auth_api_path = null;
+
+    /**
+     * Whether this installation routes REST requests through rest_route.
+     *
+     * @var bool
+     */
+    private $woocommerce_auth_uses_rest_route = false;
     
     public static function instance() {
         if (is_null(self::$instance)) {
@@ -22,10 +40,43 @@ class Digitalogic_REST_API {
     
     private function __construct() {
         add_action('rest_api_init', array($this, 'register_routes'));
+
+        $this->prepare_woocommerce_rest_authentication();
+
         add_filter(
             'woocommerce_rest_is_request_to_rest_api',
             array($this, 'allow_woocommerce_rest_authentication')
         );
+    }
+
+    /**
+     * Resolve immutable route-matcher state before registering the Woo filter.
+     *
+     * WooCommerce can run its REST authentication check while resolving the
+     * current user. Calling rest_url() from that filter can therefore re-enter
+     * current-user resolution through other plugins. Resolve the installation
+     * path once, before our filter exists, and keep the callback side-effect
+     * free.
+     *
+     * @return void
+     */
+    private function prepare_woocommerce_rest_authentication() {
+        $api_url = rest_url('digitalogic/v1');
+        $api_path = wp_parse_url($api_url, PHP_URL_PATH);
+
+        if (!is_string($api_path)) {
+            return;
+        }
+
+        $this->woocommerce_auth_api_path = rtrim($api_path, '/');
+
+        $api_query = wp_parse_url($api_url, PHP_URL_QUERY);
+        if (!is_string($api_query) || '' === $api_query) {
+            return;
+        }
+
+        parse_str($api_query, $api_query_params);
+        $this->woocommerce_auth_uses_rest_route = isset($api_query_params['rest_route']);
     }
 
     /**
@@ -50,28 +101,24 @@ class Digitalogic_REST_API {
 
         $request_uri = wp_unslash($_SERVER['REQUEST_URI']);
         $request_path = wp_parse_url($request_uri, PHP_URL_PATH);
-        $api_url = rest_url('digitalogic/v1');
-        $api_path = wp_parse_url($api_url, PHP_URL_PATH);
-        $api_query = wp_parse_url($api_url, PHP_URL_QUERY);
 
-        if (is_string($api_query) && '' !== $api_query) {
-            parse_str($api_query, $api_query_params);
-            if (isset($api_query_params['rest_route'])) {
-                if (!is_string($request_path) || !is_string($api_path)) {
-                    return false;
-                }
-
-                if (rtrim($request_path, '/') !== rtrim($api_path, '/')) {
-                    return false;
-                }
-
-                return $this->query_targets_digitalogic_namespace($request_uri);
+        if ($this->woocommerce_auth_uses_rest_route) {
+            if (!is_string($request_path) || !is_string($this->woocommerce_auth_api_path)) {
+                return false;
             }
+
+            if (rtrim($request_path, '/') !== $this->woocommerce_auth_api_path) {
+                return false;
+            }
+
+            return $this->query_targets_digitalogic_namespace($request_uri);
         }
 
-        if (is_string($request_path) && is_string($api_path) && '/' !== $api_path) {
-            $api_path = rtrim($api_path, '/');
-            if ($request_path === $api_path || str_starts_with($request_path, $api_path . '/')) {
+        if (is_string($request_path) && !empty($this->woocommerce_auth_api_path)) {
+            if (
+                $request_path === $this->woocommerce_auth_api_path
+                || str_starts_with($request_path, $this->woocommerce_auth_api_path . '/')
+            ) {
                 return true;
             }
         }

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -13,12 +13,42 @@ final class RestApiPermissionsTest extends TestCase {
         $GLOBALS['digitalogic_test_filters'] = array();
         $GLOBALS['digitalogic_test_routes'] = array();
         $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/wp-json/';
+        $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
+        $GLOBALS['digitalogic_test_rest_url_depth'] = 0;
+        $GLOBALS['digitalogic_test_rest_url_nested_filter'] = false;
+        $GLOBALS['digitalogic_test_rest_url_nested_results'] = array();
         unset($_SERVER['REQUEST_URI']);
+
+        $this->resetApi();
+    }
+
+    private function resetApi($rest_url = null) {
+        if (is_string($rest_url)) {
+            $GLOBALS['digitalogic_test_rest_url'] = $rest_url;
+        }
+
+        remove_all_filters('woocommerce_rest_is_request_to_rest_api');
 
         $instance = new ReflectionProperty(Digitalogic_REST_API::class, 'instance');
         $instance->setAccessible(true);
         $instance->setValue(null, null);
         $this->api = Digitalogic_REST_API::instance();
+    }
+
+    public function test_woocommerce_route_matcher_is_precomputed_before_filter_registration() {
+        $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
+        $GLOBALS['digitalogic_test_rest_url_nested_filter'] = true;
+        $GLOBALS['digitalogic_test_rest_url_nested_results'] = array();
+
+        $this->resetApi();
+
+        $this->assertSame(1, $GLOBALS['digitalogic_test_rest_url_calls']);
+        $this->assertSame(array(false), $GLOBALS['digitalogic_test_rest_url_nested_results']);
+
+        $_SERVER['REQUEST_URI'] = '/wp-json/digitalogic/v1/products';
+
+        $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+        $this->assertSame(1, $GLOBALS['digitalogic_test_rest_url_calls']);
     }
 
     /**
@@ -67,14 +97,14 @@ final class RestApiPermissionsTest extends TestCase {
     }
 
     public function test_woocommerce_authentication_recognizes_subdirectory_install() {
-        $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/store/wp-json/';
+        $this->resetApi('https://example.test/store/wp-json/');
         $_SERVER['REQUEST_URI'] = '/store/wp-json/digitalogic/v1/products';
 
         $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
     }
 
     public function test_woocommerce_authentication_recognizes_rest_route_query() {
-        $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/?rest_route=/';
+        $this->resetApi('https://example.test/?rest_route=/');
         $_SERVER['REQUEST_URI'] = '/?rest_route=%2Fdigitalogic%2Fv1%2Fproducts';
 
         $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
@@ -84,7 +114,7 @@ final class RestApiPermissionsTest extends TestCase {
     }
 
     public function test_rest_route_query_does_not_authenticate_unrelated_subdirectory_request() {
-        $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/store/?rest_route=/';
+        $this->resetApi('https://example.test/store/?rest_route=/');
         $_SERVER['REQUEST_URI'] = '/store/?unrelated=1';
 
         $this->assertFalse(apply_filters('woocommerce_rest_is_request_to_rest_api', false));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,10 @@ $GLOBALS['digitalogic_test_capabilities'] = array();
 $GLOBALS['digitalogic_test_filters'] = array();
 $GLOBALS['digitalogic_test_routes'] = array();
 $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/wp-json/';
+$GLOBALS['digitalogic_test_rest_url_calls'] = 0;
+$GLOBALS['digitalogic_test_rest_url_depth'] = 0;
+$GLOBALS['digitalogic_test_rest_url_nested_filter'] = false;
+$GLOBALS['digitalogic_test_rest_url_nested_results'] = array();
 
 class WP_REST_Request {
 }
@@ -88,9 +92,27 @@ function wp_parse_url($url, $component = -1) {
 }
 
 function rest_url($path = '') {
+    $GLOBALS['digitalogic_test_rest_url_calls']++;
+    $GLOBALS['digitalogic_test_rest_url_depth']++;
+
+    if ($GLOBALS['digitalogic_test_rest_url_depth'] > 1) {
+        throw new RuntimeException('REST URL resolution re-entered the WooCommerce authentication filter.');
+    }
+
     $base = $GLOBALS['digitalogic_test_rest_url'];
 
-    return rtrim($base, '/') . '/' . ltrim($path, '/');
+    try {
+        if (!empty($GLOBALS['digitalogic_test_rest_url_nested_filter'])) {
+            $GLOBALS['digitalogic_test_rest_url_nested_results'][] = apply_filters(
+                'woocommerce_rest_is_request_to_rest_api',
+                false
+            );
+        }
+
+        return rtrim($base, '/') . '/' . ltrim($path, '/');
+    } finally {
+        $GLOBALS['digitalogic_test_rest_url_depth']--;
+    }
 }
 
 require_once dirname(__DIR__) . '/includes/api/class-rest-api.php';


### PR DESCRIPTION
Closes #44

## Summary
- precompute immutable REST route matcher state before registering WooCommerce authentication
- keep the authentication callback free of `rest_url()` and other current-user-capable APIs
- preserve exact namespace, subdirectory, and `rest_route` matching while rejecting lookalikes
- add a nested-invocation regression test

## Validation
- 21 PHPUnit tests, 56 assertions
- PHP syntax and Composer validation
- public-tree guard and `git diff --check`
- isolated production-stack smoke: homepage 200/non-empty, exact route accepted, lookalike rejected, anonymous management REST 401

Production is temporarily fail-closed by withholding Digitalogic management route registration until this corrective PR is merged and deployed.