### PR TITLE
Remove URL generation from REST authentication

### DIFF
--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -12,24 +12,6 @@ if (!defined('ABSPATH')) {
 class Digitalogic_REST_API {
     
     private static $instance = null;
-
-    /**
-     * REST path used for exact Digitalogic namespace matching.
-     *
-     * This is resolved before the WooCommerce authentication filter is
-     * registered so the filter never calls rest_url() while WordPress is
-     * resolving the current user.
-     *
-     * @var string|null
-     */
-    private $woocommerce_auth_api_path = null;
-
-    /**
-     * Whether this installation routes REST requests through rest_route.
-     *
-     * @var bool
-     */
-    private $woocommerce_auth_uses_rest_route = false;
     
     public static function instance() {
         if (is_null(self::$instance)) {
@@ -40,43 +22,10 @@ class Digitalogic_REST_API {
     
     private function __construct() {
         add_action('rest_api_init', array($this, 'register_routes'));
-
-        $this->prepare_woocommerce_rest_authentication();
-
         add_filter(
             'woocommerce_rest_is_request_to_rest_api',
             array($this, 'allow_woocommerce_rest_authentication')
         );
-    }
-
-    /**
-     * Resolve immutable route-matcher state before registering the Woo filter.
-     *
-     * WooCommerce can run its REST authentication check while resolving the
-     * current user. Calling rest_url() from that filter can therefore re-enter
-     * current-user resolution through other plugins. Resolve the installation
-     * path once, before our filter exists, and keep the callback side-effect
-     * free.
-     *
-     * @return void
-     */
-    private function prepare_woocommerce_rest_authentication() {
-        $api_url = rest_url('digitalogic/v1');
-        $api_path = wp_parse_url($api_url, PHP_URL_PATH);
-
-        if (!is_string($api_path)) {
-            return;
-        }
-
-        $this->woocommerce_auth_api_path = rtrim($api_path, '/');
-
-        $api_query = wp_parse_url($api_url, PHP_URL_QUERY);
-        if (!is_string($api_query) || '' === $api_query) {
-            return;
-        }
-
-        parse_str($api_query, $api_query_params);
-        $this->woocommerce_auth_uses_rest_route = isset($api_query_params['rest_route']);
     }
 
     /**
@@ -99,54 +48,135 @@ class Digitalogic_REST_API {
             return false;
         }
 
-        $request_uri = wp_unslash($_SERVER['REQUEST_URI']);
-        $request_path = wp_parse_url($request_uri, PHP_URL_PATH);
-
-        if ($this->woocommerce_auth_uses_rest_route) {
-            if (!is_string($request_path) || !is_string($this->woocommerce_auth_api_path)) {
-                return false;
-            }
-
-            if (rtrim($request_path, '/') !== $this->woocommerce_auth_api_path) {
-                return false;
-            }
-
-            return $this->query_targets_digitalogic_namespace($request_uri);
+        $request_uri = (string) $_SERVER['REQUEST_URI'];
+        $request_path = parse_url($request_uri, PHP_URL_PATH);
+        if (!is_string($request_path)) {
+            return false;
         }
 
-        if (is_string($request_path) && !empty($this->woocommerce_auth_api_path)) {
-            if (
-                $request_path === $this->woocommerce_auth_api_path
-                || str_starts_with($request_path, $this->woocommerce_auth_api_path . '/')
-            ) {
-                return true;
-            }
+        $query_match = $this->query_targets_digitalogic_namespace($request_uri);
+        if (null !== $query_match) {
+            return $query_match && $this->request_path_targets_front_controller($request_path);
         }
 
-        return false;
+        return $this->request_path_targets_digitalogic_namespace($request_path);
     }
 
     /**
      * Check a rest_route query parameter against the Digitalogic namespace.
      *
      * @param string $request_uri Current request URI.
-     * @return bool
+     * @return bool|null True or false when rest_route is present; null otherwise.
      */
     private function query_targets_digitalogic_namespace($request_uri) {
-
-        $request_query = wp_parse_url($request_uri, PHP_URL_QUERY);
+        $request_query = parse_url($request_uri, PHP_URL_QUERY);
         if (!is_string($request_query) || '' === $request_query) {
-            return false;
+            return null;
         }
 
         parse_str($request_query, $query_params);
-        if (!isset($query_params['rest_route']) || !is_string($query_params['rest_route'])) {
+        if (!array_key_exists('rest_route', $query_params)) {
+            return null;
+        }
+
+        if (!is_string($query_params['rest_route'])) {
             return false;
         }
 
         $route = '/' . trim($query_params['rest_route'], '/');
 
         return '/digitalogic/v1' === $route || str_starts_with($route, '/digitalogic/v1/');
+    }
+
+    /**
+     * Match a pretty-permalink REST request without generating a REST URL.
+     *
+     * @param string $request_path Current request path.
+     * @return bool
+     */
+    private function request_path_targets_digitalogic_namespace($request_path) {
+        $rest_prefix = rest_get_url_prefix();
+        if (!is_string($rest_prefix) || '' === trim($rest_prefix, '/')) {
+            return false;
+        }
+
+        $api_path = $this->normalize_request_path(
+            $this->get_wordpress_base_path()
+            . '/'
+            . trim($rest_prefix, '/')
+            . '/digitalogic/v1'
+        );
+        $request_path = $this->normalize_request_path($request_path);
+
+        return $request_path === $api_path || str_starts_with($request_path, $api_path . '/');
+    }
+
+    /**
+     * Ensure query-style REST requests target this WordPress front controller.
+     *
+     * @param string $request_path Current request path.
+     * @return bool
+     */
+    private function request_path_targets_front_controller($request_path) {
+        $request_path = $this->normalize_request_path($request_path);
+        $base_path = $this->get_wordpress_base_path();
+        $base_path = '' === $base_path ? '/' : $base_path;
+
+        if ($request_path === $base_path) {
+            return true;
+        }
+
+        $script_path = $this->get_wordpress_script_path();
+
+        return null !== $script_path && $request_path === $script_path;
+    }
+
+    /**
+     * Resolve the URL path of the active WordPress front controller.
+     *
+     * @return string|null
+     */
+    private function get_wordpress_script_path() {
+        if (empty($_SERVER['SCRIPT_NAME']) || !is_string($_SERVER['SCRIPT_NAME'])) {
+            return null;
+        }
+
+        $script_path = parse_url($_SERVER['SCRIPT_NAME'], PHP_URL_PATH);
+        if (!is_string($script_path) || '' === $script_path) {
+            return null;
+        }
+
+        return $this->normalize_request_path($script_path);
+    }
+
+    /**
+     * Resolve the install subdirectory from the front-controller path.
+     *
+     * @return string Empty for a root installation.
+     */
+    private function get_wordpress_base_path() {
+        $script_path = $this->get_wordpress_script_path();
+        if (null === $script_path) {
+            return '';
+        }
+
+        $base_path = str_replace('\\', '/', dirname($script_path));
+
+        return '/' === $base_path || '.' === $base_path
+            ? ''
+            : $this->normalize_request_path($base_path);
+    }
+
+    /**
+     * Normalize a URL path for exact, segment-boundary comparisons.
+     *
+     * @param string $path URL path.
+     * @return string
+     */
+    private function normalize_request_path($path) {
+        $path = '/' . trim($path, '/');
+
+        return '/' === $path ? '/' : rtrim($path, '/');
     }
     
     /**

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -12,21 +12,16 @@ final class RestApiPermissionsTest extends TestCase {
         $GLOBALS['digitalogic_test_capabilities'] = array();
         $GLOBALS['digitalogic_test_filters'] = array();
         $GLOBALS['digitalogic_test_routes'] = array();
-        $GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/wp-json/';
+        $GLOBALS['digitalogic_test_rest_prefix'] = 'wp-json';
         $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
-        $GLOBALS['digitalogic_test_rest_url_depth'] = 0;
-        $GLOBALS['digitalogic_test_rest_url_nested_filter'] = false;
-        $GLOBALS['digitalogic_test_rest_url_nested_results'] = array();
+        $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
         unset($_SERVER['REQUEST_URI']);
 
         $this->resetApi();
     }
 
-    private function resetApi($rest_url = null) {
-        if (is_string($rest_url)) {
-            $GLOBALS['digitalogic_test_rest_url'] = $rest_url;
-        }
-
+    private function resetApi() {
         remove_all_filters('woocommerce_rest_is_request_to_rest_api');
 
         $instance = new ReflectionProperty(Digitalogic_REST_API::class, 'instance');
@@ -35,20 +30,17 @@ final class RestApiPermissionsTest extends TestCase {
         $this->api = Digitalogic_REST_API::instance();
     }
 
-    public function test_woocommerce_route_matcher_is_precomputed_before_filter_registration() {
+    public function test_woocommerce_route_matcher_never_generates_a_rest_url_or_resolves_a_user() {
         $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
-        $GLOBALS['digitalogic_test_rest_url_nested_filter'] = true;
-        $GLOBALS['digitalogic_test_rest_url_nested_results'] = array();
+        $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
 
         $this->resetApi();
-
-        $this->assertSame(1, $GLOBALS['digitalogic_test_rest_url_calls']);
-        $this->assertSame(array(false), $GLOBALS['digitalogic_test_rest_url_nested_results']);
 
         $_SERVER['REQUEST_URI'] = '/wp-json/digitalogic/v1/products';
 
         $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
-        $this->assertSame(1, $GLOBALS['digitalogic_test_rest_url_calls']);
+        $this->assertSame(0, $GLOBALS['digitalogic_test_rest_url_calls']);
+        $this->assertSame(0, $GLOBALS['digitalogic_test_current_user_can_calls']);
     }
 
     /**
@@ -97,14 +89,16 @@ final class RestApiPermissionsTest extends TestCase {
     }
 
     public function test_woocommerce_authentication_recognizes_subdirectory_install() {
-        $this->resetApi('https://example.test/store/wp-json/');
+        $_SERVER['SCRIPT_NAME'] = '/store/index.php';
         $_SERVER['REQUEST_URI'] = '/store/wp-json/digitalogic/v1/products';
 
         $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+
+        $_SERVER['REQUEST_URI'] = '/elsewhere/wp-json/digitalogic/v1/products';
+        $this->assertFalse(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
     }
 
     public function test_woocommerce_authentication_recognizes_rest_route_query() {
-        $this->resetApi('https://example.test/?rest_route=/');
         $_SERVER['REQUEST_URI'] = '/?rest_route=%2Fdigitalogic%2Fv1%2Fproducts';
 
         $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
@@ -114,13 +108,29 @@ final class RestApiPermissionsTest extends TestCase {
     }
 
     public function test_rest_route_query_does_not_authenticate_unrelated_subdirectory_request() {
-        $this->resetApi('https://example.test/store/?rest_route=/');
+        $_SERVER['SCRIPT_NAME'] = '/store/index.php';
         $_SERVER['REQUEST_URI'] = '/store/?unrelated=1';
 
         $this->assertFalse(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
 
         $_SERVER['REQUEST_URI'] = '/store/?rest_route=%2Fdigitalogic%2Fv1%2Fproducts';
         $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+
+        $_SERVER['REQUEST_URI'] = '/store/index.php?rest_route=%2Fdigitalogic%2Fv1%2Fproducts';
+        $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+
+        $_SERVER['REQUEST_URI'] = '/elsewhere/?rest_route=%2Fdigitalogic%2Fv1%2Fproducts';
+        $this->assertFalse(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+    }
+
+    public function test_woocommerce_authentication_uses_the_configured_rest_prefix() {
+        $GLOBALS['digitalogic_test_rest_prefix'] = 'api';
+        $_SERVER['REQUEST_URI'] = '/api/digitalogic/v1/products';
+
+        $this->assertTrue(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
+
+        $_SERVER['REQUEST_URI'] = '/wp-json/digitalogic/v1/products';
+        $this->assertFalse(apply_filters('woocommerce_rest_is_request_to_rest_api', false));
     }
 
     public function test_woocommerce_route_recognition_does_not_bypass_capability_policy() {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,11 +8,9 @@ define('ABSPATH', __DIR__ . '/');
 $GLOBALS['digitalogic_test_capabilities'] = array();
 $GLOBALS['digitalogic_test_filters'] = array();
 $GLOBALS['digitalogic_test_routes'] = array();
-$GLOBALS['digitalogic_test_rest_url'] = 'https://example.test/wp-json/';
+$GLOBALS['digitalogic_test_rest_prefix'] = 'wp-json';
 $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
-$GLOBALS['digitalogic_test_rest_url_depth'] = 0;
-$GLOBALS['digitalogic_test_rest_url_nested_filter'] = false;
-$GLOBALS['digitalogic_test_rest_url_nested_results'] = array();
+$GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
 
 class WP_REST_Request {
 }
@@ -41,6 +39,8 @@ function add_action($hook_name, $callback, $priority = 10, $accepted_args = 1) {
 }
 
 function current_user_can($capability) {
+    $GLOBALS['digitalogic_test_current_user_can_calls']++;
+
     return !empty($GLOBALS['digitalogic_test_capabilities'][$capability]);
 }
 
@@ -83,36 +83,14 @@ function register_rest_route($namespace, $route, $args = array(), $override = fa
     return true;
 }
 
-function wp_unslash($value) {
-    return $value;
-}
-
-function wp_parse_url($url, $component = -1) {
-    return parse_url($url, $component);
+function rest_get_url_prefix() {
+    return $GLOBALS['digitalogic_test_rest_prefix'];
 }
 
 function rest_url($path = '') {
     $GLOBALS['digitalogic_test_rest_url_calls']++;
-    $GLOBALS['digitalogic_test_rest_url_depth']++;
 
-    if ($GLOBALS['digitalogic_test_rest_url_depth'] > 1) {
-        throw new RuntimeException('REST URL resolution re-entered the WooCommerce authentication filter.');
-    }
-
-    $base = $GLOBALS['digitalogic_test_rest_url'];
-
-    try {
-        if (!empty($GLOBALS['digitalogic_test_rest_url_nested_filter'])) {
-            $GLOBALS['digitalogic_test_rest_url_nested_results'][] = apply_filters(
-                'woocommerce_rest_is_request_to_rest_api',
-                false
-            );
-        }
-
-        return rtrim($base, '/') . '/' . ltrim($path, '/');
-    } finally {
-        $GLOBALS['digitalogic_test_rest_url_depth']--;
-    }
+    throw new RuntimeException('The WooCommerce route matcher must not call rest_url().');
 }
 
 require_once dirname(__DIR__) . '/includes/api/class-rest-api.php';


### PR DESCRIPTION
Closes #44

Follow-up to #45 after the exact first merge still reproduced an empty production response.

## Summary
- remove constructor-time and callback-time `rest_url()`/`home_url()` generation entirely
- match raw request path/query data against the exact REST prefix, front controller, install subdirectory, and `digitalogic/v1` segment boundaries
- preserve query-mode, custom-prefix, and existing WooCommerce recognition
- keep lookalikes and unrelated paths fail-closed
- assert the matcher performs zero REST URL generation or capability resolution

## Validation
- 22 PHPUnit tests, 60 assertions
- PHP lint and Composer validation
- public-tree guard and diff check
- private-mount smoke at the normal active-plugin load phase: marker loaded, exact route true, v10 false, anonymous management REST 401, homepage 200 and 464,644 bytes

The production plugin remains temporarily fail-closed until this PR is merged and the exact deployed checkout passes the same smoke.