### PR TITLE
Add canonical import-freight catalog and Code assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced plugin page with action links and row meta links
 - Fixed WP-CLI command registration to prevent "can't have subcommands" error
 
+## [1.1.0] - 2026-07-16
+
+### Added
+- Canonical supplier import-freight catalog, immutable method IDs, legacy ACF migration, and exact product/variation assignment APIs.
+- Shared exact product identifier resolver with WooCommerce ID, SKU, and Patris Code precedence.
+- `landed_price_v1` integration catalog and percentage-markup contract for Patris Export.
+- Result-aware durable panel queue, Redis/WebSocket, and multi-destination webhook delivery reporting.
+
+### Changed
+- Patris gram weights are converted into the configured WooCommerce store weight unit.
+- Import-freight writes use verified InnoDB transactions, authoritative rollback, cache invalidation, and compare-and-swap legacy reconciliation.
+
 ## [1.0.0] - 2024-12-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ curl -X POST https://yoursite.com/wp-json/digitalogic/v1/products/batch \
 #### Pricing
 - `POST /wp-json/digitalogic/v1/pricing/recalculate` - Recalculate all prices
 
+#### Import Freight Integration
+- `GET /wp-json/digitalogic/v1/integration/catalog` - Read the versioned pricing/freight catalog
+- `GET|POST /wp-json/digitalogic/v1/import-freight-methods` - List or create supplier import methods
+- `GET|PUT|DELETE /wp-json/digitalogic/v1/import-freight-methods/{id}` - Manage an immutable method ID
+- `GET|PUT /wp-json/digitalogic/v1/products/by-code/{code}/import-pricing` - Read or assign by exact Patris Code/SKU
+- `POST /wp-json/digitalogic/v1/products/import-pricing/batch` - Preflight and apply Code-based assignments
+
+Import freight is distinct from customer delivery and WooCommerce checkout
+shipping. See [Import Freight Integration Contract](docs/IMPORT-FREIGHT-API.md).
+
 #### Export
 - `GET /wp-json/digitalogic/v1/export?format=csv` - Export products as CSV
 - `GET /wp-json/digitalogic/v1/export?format=json` - Export products as JSON
@@ -338,6 +348,11 @@ GPL v2 or later. See LICENSE file for details.
 Developed for Digitalogic electronic components shop.
 
 ## Changelog
+
+### 1.1.0
+- Added the canonical supplier import-freight catalog, Code/SKU assignments, landed-price contract, and Patris integration API.
+- Added transactional migration from legacy freight options and ACF assignments with observable panel, Redis, and webhook delivery results.
+- Normalized Patris gram weights into the WooCommerce store weight unit.
 
 ### 1.0.0
 - Initial release

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('DIGITALOGIC_VERSION', '1.0.0');
+define('DIGITALOGIC_VERSION', '1.1.0');
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.2');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('DIGITALOGIC_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -112,7 +112,10 @@ final class Digitalogic {
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-manager.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-pricing.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-import-export.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-unit-converter.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-identifier-resolver.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-patris-feed.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-import-freight-service.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-report-engine.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-command-dispatcher.php';
 
@@ -176,6 +179,7 @@ final class Digitalogic {
         Digitalogic_Pricing::instance();
         Digitalogic_Import_Export::instance();
         Digitalogic_Patris_Feed::instance();
+        Digitalogic_Import_Freight_Service::instance();
         Digitalogic_Report_Engine::instance();
         Digitalogic_Command_Dispatcher::instance();
         Digitalogic_WebSocket::instance();
@@ -366,7 +370,6 @@ final class Digitalogic {
                 'api_url' => '',
                 'api_token' => '',
                 'selected_warehouses' => array(),
-                'shipping_methods' => array(),
                 'legacy_url_replacements' => array(),
                 'image_quality_thresholds' => array(
                     'very_low' => 180,

--- a/docs/API.md
+++ b/docs/API.md
@@ -150,9 +150,33 @@ curl -u key:secret "https://yoursite.com/wp-json/digitalogic/v1/products?page=1&
 
 ---
 
+## Import Freight Integration
+
+Import freight describes supplier-to-Digitalogic transport. It does not use
+WooCommerce checkout, shipping-zone, or customer delivery APIs.
+
+- **GET** `/integration/catalog` - versioned CNY/IRT rate, `landed_price_v1`, selected warehouses, and methods
+- **GET** `/import-freight-methods` - list canonical methods
+- **POST** `/import-freight-methods` - create a method with an immutable ID
+- **GET|PUT|DELETE** `/import-freight-methods/{id}` - read, update, or delete an unassigned method
+- **GET|PUT** `/products/by-code/{code}/import-pricing` - read or assign by exact Patris Code/SKU
+- **POST** `/products/import-pricing/batch` - preflight and apply an atomic assignment batch
+
+GET routes use the `read` permission scope. Mutating routes use `write`.
+Deleting an assigned method returns HTTP 409; disabling it remains available.
+See [Import Freight Integration Contract](IMPORT-FREIGHT-API.md) for schemas,
+migration behavior, and the pricing formula.
+
+---
+
 ## Webhooks
 
 Webhook events:
+
+- `import_freight.method.created`
+- `import_freight.method.updated`
+- `import_freight.method.deleted`
+- `import_freight.assignment.updated`
 - `product.created`
 - `product.updated`
 - `currency.updated`
@@ -174,6 +198,15 @@ Supported command names:
 - `digitalogic_update_currency`
 - `digitalogic_export`
 - `digitalogic_get_logs`
+- `digitalogic_get_integration_catalog`
+- `digitalogic_list_import_freight_methods`
+- `digitalogic_create_import_freight_method`
+- `digitalogic_get_import_freight_method`
+- `digitalogic_update_import_freight_method`
+- `digitalogic_delete_import_freight_method`
+- `digitalogic_get_product_import_pricing`
+- `digitalogic_assign_product_import_freight`
+- `digitalogic_batch_assign_product_import_freight`
 
 Browser WebSocket request:
 ```json

--- a/docs/IMPORT-FREIGHT-API.md
+++ b/docs/IMPORT-FREIGHT-API.md
@@ -1,0 +1,173 @@
+# Import Freight Integration Contract
+
+Digitalogic import freight methods describe how inventory is brought from a
+supplier to Digitalogic. They are not WooCommerce shipping zones, checkout
+rates, or customer delivery methods.
+
+## Canonical methods and migration
+
+The first migration reads the existing ACF option values and creates immutable
+IDs:
+
+| Legacy ACF value | Canonical ID | Default live rate |
+| --- | --- | ---: |
+| `express` | `air_express` | 85 CNY/kg |
+| `aerial` | `air_freight` | 80 CNY/kg |
+| `marine` | `sea_freight` | 50 CNY/kg |
+
+Existing product values in `shipping_method` are copied to
+`_digitalogic_import_freight_method_id`. The `_shipping_method` ACF field-key
+reference is preserved. Canonical assignments continue to mirror a compatible
+legacy value so existing ACF screens remain usable.
+
+The ACF radio choices are populated from the canonical catalog. The three
+legacy methods keep their existing `express`, `aerial`, and `marine` values;
+custom methods use their canonical ID as the radio value. Disabled choices
+remain visible for existing products but cannot be selected for a new
+assignment. The three legacy-seeded methods are disable-only so those field
+values and historical assignments cannot be orphaned.
+
+The old free-form `shipping_methods` member of
+`digitalogic_patris_feed_settings` is deprecated and ignored.
+
+## REST endpoints
+
+All routes require an authenticated identity with the plugin's read or write
+integration permission (normally `manage_woocommerce`). WooCommerce REST API
+keys may provide that identity.
+
+- `GET /wp-json/digitalogic/v1/integration/catalog`
+- `GET|POST /wp-json/digitalogic/v1/import-freight-methods`
+- `GET|PUT|DELETE /wp-json/digitalogic/v1/import-freight-methods/{id}`
+- `GET|PUT /wp-json/digitalogic/v1/products/by-code/{code}/import-pricing`
+- `POST /wp-json/digitalogic/v1/products/import-pricing/batch`
+
+Method IDs are immutable. An assigned method returns HTTP 409 when deleted; it
+may be disabled with `{"enabled": false}` and existing assignments remain
+readable. Disabled methods cannot be assigned to new products, while replaying
+the same disabled assignment is an allowed idempotent no-op. Custom IDs cannot
+use the legacy ACF values `express`, `aerial`, or `marine`.
+
+Product assignment uses the shared exact identifier resolver. Its deterministic
+precedence is an explicitly supplied WooCommerce product/variation ID, exact
+`_sku`, then exact `_digitalogic_patris_product_code`; the legacy `{code}` route
+uses exact SKU before exact Patris Code. Identifiers remain strings, so a code
+such as `00123` is never coerced to an integer. Missing and same-source duplicate
+identifiers fail without a write; names are never used for automatic matching.
+Trash and auto-draft records are excluded.
+
+Example assignment:
+
+```json
+{
+  "import_freight_method_id": "air_express"
+}
+```
+
+The method field is required on assignment commands. An explicitly empty or
+`null` method ID clears the assignment; omitting the field is an error. A batch is preflighted and
+does not change any product when one of its rows is invalid:
+
+```json
+{
+  "assignments": [
+    {"code": "113007045", "import_freight_method_id": "air_express"},
+    {"code": "113007046", "import_freight_method_id": "sea_freight"}
+  ]
+}
+```
+
+Single and batch responses include `changed`; batch responses also include
+`updated` and `unchanged`. Retrying an identical assignment is a no-op and does
+not publish a duplicate domain event. A batch also rejects two different codes
+that resolve to the same product, such as its SKU and Patris Code.
+
+Catalog and assignment mutations are serialized with one site-scoped database
+advisory lock. Every option and post-meta write is verified by exact readback.
+Multi-key and multi-row writes use an InnoDB database transaction, so a failed
+write is restored by the authoritative database `ROLLBACK` and emits no domain
+event. The application performs no post-rollback snapshot rewrites that could
+overwrite a newer writer. Touched caches are invalidated after rollback, and a
+failed `ROLLBACK` query is returned as a storage error. Migration is stamped
+only after the catalog and every legacy assignment have been verified.
+
+Transactional reads and writes bypass the shared WordPress/Redis object cache.
+Touched caches and compatibility hooks are invalidated/dispatched only after
+commit, and are invalidated after rollback as well. Post-write legacy ACF/option
+hooks reconcile with uncached `FOR UPDATE` reads and compare-and-swap behavior,
+so a stale hook never restores over a newer writer.
+
+Committed method and assignment changes use independent, result-aware delivery
+channels for the durable panel queue, Redis/WebSocket publication, and every
+configured outbound webhook. Each channel must explicitly confirm success;
+void results, queue/Redis failures, webhook transport/non-2xx failures, and
+exceptions become machine-readable `delivery_warnings`. Every channel and every
+webhook destination is attempted even when an earlier one fails. The stable
+WordPress domain actions are still emitted for compatibility after result-aware
+channels run. A committed mutation remains successful, while no-op retries do
+not emit another event. An empty webhook destination list is an intentionally
+disabled, confirmed-success channel.
+
+## Catalog and formula
+
+The read-only integration catalog contains the CNY-to-local (currently IRT)
+rate, effective currency date, selected Patris warehouses, enabled/disabled
+method records, and a deterministic revision. Consumers can cache by revision.
+`currency.cny_to_local` is the currency-neutral rate. The compatibility field
+`currency.cny_to_irt` is populated only when the WooCommerce local currency is
+IRT. `currency.effective_date` is ISO `YYYY-MM-DD`; the original compact value
+is retained as `source_effective_date` with format `ymd`.
+
+`landed_price_v1` is:
+
+```text
+((weight_g * freight_cny_per_kg / 1000) + foreign_price_cny)
+  * (1 + profit_percent / 100)
+  * cny_to_irt
+```
+
+The method schema reserves validated fields for minimum charge, actual versus
+volumetric billable weight, volumetric divisor, transit-day bounds, metadata,
+and tiered rates. Version 1 exposes these fields but does not silently apply a
+reserved rule to the formula.
+
+Patris payloads express product weight in grams. When a feed updates a
+WooCommerce product, Digitalogic converts that positive finite gram value with
+`wc_get_weight()` into the configured `woocommerce_weight_unit` (for example,
+`240 g` remains `240` in a gram store and becomes `0.24` in a kilogram store).
+The original gram value remains available in Patris metadata for formula input.
+
+Feed ingestion uses the same shared generic Code/SKU resolver as freight
+assignment. A Patris-Code-only product can therefore be updated, while an exact
+SKU wins over a different product carrying the same Patris Code. Not-found rows
+are counted as `missing_in_woocommerce`; ambiguous or invalid identifiers are
+counted as failed with non-sensitive errors and never write a product. Every
+valid normalized upstream row is still retained in the feed snapshot for
+reporting and later reconciliation, including missing or ambiguous rows.
+
+Product assignment reads expose the markup mapping used by the formula:
+
+```json
+{
+  "markup": {
+    "type": "percentage",
+    "value": 12.5,
+    "profit_percent": 12.5,
+    "warning": null
+  },
+  "profit_percent": 12.5,
+  "pricing_warnings": []
+}
+```
+
+Only a numeric `percentage` markup maps to `profit_percent`. A `fixed`, missing,
+or unsupported markup returns `profit_percent: null` and a machine-readable
+warning; `landed_price_v1` never silently treats a fixed amount as a percent.
+
+Administrators can manage methods and assign products by exact Patris Code/SKU
+on the existing Patris Reports screen. This UI and all integration routes are
+for supplier import freight only and do not read or mutate WooCommerce customer
+delivery methods.
+
+The same `Digitalogic_Import_Freight_Service` backs REST and the shared command
+dispatcher used by AJAX/WebSocket transports.

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -464,29 +464,114 @@ class Digitalogic_Admin {
     }
 
     public function render_patris_reports_page() {
+        if (!current_user_can('manage_woocommerce')) {
+            wp_die(esc_html__('You do not have permission to manage Patris reports.', 'digitalogic'));
+        }
+
         $feed = Digitalogic_Patris_Feed::instance();
+        $freight_service = Digitalogic_Import_Freight_Service::instance();
         $notice = '';
+        $notice_type = 'info';
+        $freight_assignment = null;
+        $posted_value = static function ($key) {
+            if (!isset($_POST[$key]) || !is_scalar($_POST[$key])) {
+                return '';
+            }
+
+            return wp_unslash((string) $_POST[$key]);
+        };
+
+        $freight_action = sanitize_key($posted_value('digitalogic_import_freight_action'));
+
+        if ($freight_action !== '') {
+            check_admin_referer('digitalogic_import_freight_admin');
+
+            switch ($freight_action) {
+                case 'create_method':
+                    $result = $freight_service->create_method(array(
+                        'id' => $posted_value('method_id'),
+                        'name' => sanitize_text_field($posted_value('method_name')),
+                        'price_per_kg_cny' => $posted_value('price_per_kg_cny'),
+                        'enabled' => isset($_POST['method_enabled']),
+                    ));
+                    $notice = is_wp_error($result)
+                        ? $result->get_error_message()
+                        : sprintf(__('Import freight method "%s" created.', 'digitalogic'), $result['name']);
+                    $notice_type = is_wp_error($result) ? 'error' : 'success';
+                    break;
+
+                case 'update_method':
+                    $method_id = $posted_value('method_id');
+                    $result = $freight_service->update_method($method_id, array(
+                        'name' => sanitize_text_field($posted_value('method_name')),
+                        'price_per_kg_cny' => $posted_value('price_per_kg_cny'),
+                        'enabled' => isset($_POST['method_enabled']),
+                    ));
+                    $notice = is_wp_error($result)
+                        ? $result->get_error_message()
+                        : sprintf(__('Import freight method "%s" updated.', 'digitalogic'), $result['name']);
+                    $notice_type = is_wp_error($result) ? 'error' : 'success';
+                    break;
+
+                case 'delete_method':
+                    $method_id = $posted_value('method_id');
+                    $result = $freight_service->delete_method($method_id);
+                    $notice = is_wp_error($result)
+                        ? $result->get_error_message()
+                        : __('Import freight method deleted.', 'digitalogic');
+                    $notice_type = is_wp_error($result) ? 'error' : 'success';
+                    break;
+
+                case 'assign_product':
+                    $code = sanitize_text_field($posted_value('product_code'));
+                    $method_id = $posted_value('assignment_method_id');
+                    $result = $freight_service->assign_product_by_code($code, $method_id);
+                    if (is_wp_error($result)) {
+                        $notice = $result->get_error_message();
+                        $notice_type = 'error';
+                    } else {
+                        $freight_assignment = $result;
+                        $notice = $method_id === ''
+                            ? __('The import freight assignment was cleared.', 'digitalogic')
+                            : __('The import freight method was assigned.', 'digitalogic');
+                        $notice_type = 'success';
+                    }
+                    break;
+
+                default:
+                    $notice = __('Unknown import freight action.', 'digitalogic');
+                    $notice_type = 'error';
+                    break;
+            }
+        }
 
         if (isset($_POST['digitalogic_patris_settings_submit']) && check_admin_referer('digitalogic_patris_settings')) {
             $feed->update_settings(array(
-                'api_url' => isset($_POST['api_url']) ? wp_unslash($_POST['api_url']) : '',
-                'api_token' => isset($_POST['api_token']) ? wp_unslash($_POST['api_token']) : '',
-                'selected_warehouses' => isset($_POST['selected_warehouses']) ? wp_unslash($_POST['selected_warehouses']) : '',
-                'shipping_methods' => isset($_POST['shipping_methods']) ? wp_unslash($_POST['shipping_methods']) : '',
-                'stale_after_hours' => isset($_POST['stale_after_hours']) ? absint($_POST['stale_after_hours']) : 48,
-                'sync_interval' => isset($_POST['sync_interval']) ? sanitize_key(wp_unslash($_POST['sync_interval'])) : '',
+                'api_url' => $posted_value('api_url'),
+                'api_token' => $posted_value('api_token'),
+                'selected_warehouses' => $posted_value('selected_warehouses'),
+                'stale_after_hours' => $posted_value('stale_after_hours') !== '' ? absint($posted_value('stale_after_hours')) : 48,
+                'sync_interval' => sanitize_key($posted_value('sync_interval')),
             ));
             $notice = __('Patris report settings saved.', 'digitalogic');
+            $notice_type = 'success';
         }
 
         if (isset($_POST['digitalogic_patris_sync_submit']) && check_admin_referer('digitalogic_patris_sync')) {
             $result = $feed->pull_sync();
             $notice = is_wp_error($result) ? $result->get_error_message() : __('Patris feed synchronized.', 'digitalogic');
+            $notice_type = is_wp_error($result) ? 'error' : 'success';
         }
 
         $settings = $feed->get_settings();
         $push_token = $feed->get_push_token();
         $report = Digitalogic_Report_Engine::instance()->get_report();
+        $freight_methods = $freight_service->list_methods(true);
+        if (is_wp_error($freight_methods)) {
+            $notice = $freight_methods->get_error_message();
+            $notice_type = 'error';
+            $freight_methods = array();
+        }
 
         include DIGITALOGIC_PLUGIN_DIR . 'includes/admin/views/patris-reports.php';
     }

--- a/includes/admin/views/patris-reports.php
+++ b/includes/admin/views/patris-reports.php
@@ -6,6 +6,9 @@
  * @var string $push_token
  * @var array  $report
  * @var string $notice
+ * @var string $notice_type
+ * @var array  $freight_methods
+ * @var array|null $freight_assignment
  */
 
 if (!defined('ABSPATH')) {
@@ -13,13 +16,14 @@ if (!defined('ABSPATH')) {
 }
 
 $push_url = rest_url('digitalogic/v1/patris/push');
+$notice_type = in_array($notice_type, array('success', 'error', 'warning', 'info'), true) ? $notice_type : 'info';
 ?>
 <div class="wrap digitalogic-patris-reports">
     <h1><?php echo esc_html__('Digitalogic Patris Reports', 'digitalogic'); ?></h1>
     <p class="description"><?php echo esc_html__('Normalized Patris/API data is compared against WooCommerce to recreate and extend the old reportFinal workflows.', 'digitalogic'); ?></p>
 
     <?php if (!empty($notice)) : ?>
-        <div class="notice notice-info is-dismissible"><p><?php echo esc_html($notice); ?></p></div>
+        <div class="notice notice-<?php echo esc_attr($notice_type); ?> is-dismissible"><p><?php echo esc_html($notice); ?></p></div>
     <?php endif; ?>
 
     <div class="digitalogic-report-layout">
@@ -41,8 +45,11 @@ $push_url = rest_url('digitalogic/v1/patris/push');
                         <td><input class="regular-text code" id="digitalogic-patris-warehouses" name="selected_warehouses" value="<?php echo esc_attr(implode(',', (array) $settings['selected_warehouses'])); ?>" dir="ltr"><p class="description"><?php echo esc_html__('Comma-separated dynamic warehouse keys from the normalized API.', 'digitalogic'); ?></p></td>
                     </tr>
                     <tr>
-                        <th scope="row"><label for="digitalogic-patris-shipping"><?php echo esc_html__('Shipping Methods JSON', 'digitalogic'); ?></label></th>
-                        <td><textarea class="large-text code" rows="4" id="digitalogic-patris-shipping" name="shipping_methods" dir="ltr"><?php echo esc_textarea(wp_json_encode($settings['shipping_methods'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)); ?></textarea></td>
+                        <th scope="row"><?php echo esc_html__('Import Freight Catalog', 'digitalogic'); ?></th>
+                        <td>
+                            <code><?php echo esc_html(rest_url('digitalogic/v1/import-freight-methods')); ?></code>
+                            <p class="description"><?php echo esc_html__('Supplier import freight methods are managed as validated records. They are separate from WooCommerce customer delivery methods.', 'digitalogic'); ?></p>
+                        </td>
                     </tr>
                     <tr>
                         <th scope="row"><label for="digitalogic-patris-stale"><?php echo esc_html__('Stale After Hours', 'digitalogic'); ?></label></th>
@@ -85,6 +92,155 @@ $push_url = rest_url('digitalogic/v1/patris/push');
             <?php endif; ?>
         </section>
     </div>
+
+    <section class="digitalogic-section digitalogic-import-freight">
+        <h2><?php echo esc_html__('Supplier Import Freight', 'digitalogic'); ?></h2>
+        <p class="description">
+            <?php echo esc_html__('Manage freight used to import products from Patris. These records do not change WooCommerce customer delivery methods.', 'digitalogic'); ?>
+        </p>
+
+        <h3><?php echo esc_html__('Freight methods', 'digitalogic'); ?></h3>
+        <div class="digitalogic-report-table-wrap">
+            <table class="widefat striped">
+                <thead>
+                    <tr>
+                        <th scope="col"><?php echo esc_html__('Method ID', 'digitalogic'); ?></th>
+                        <th scope="col"><?php echo esc_html__('Name', 'digitalogic'); ?></th>
+                        <th scope="col"><?php echo esc_html__('CNY per kg', 'digitalogic'); ?></th>
+                        <th scope="col"><?php echo esc_html__('Enabled', 'digitalogic'); ?></th>
+                        <th scope="col"><?php echo esc_html__('Assigned products', 'digitalogic'); ?></th>
+                        <th scope="col"><?php echo esc_html__('Actions', 'digitalogic'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($freight_methods)) : ?>
+                        <tr><td colspan="6"><?php echo esc_html__('No import freight methods are available.', 'digitalogic'); ?></td></tr>
+                    <?php else : ?>
+                        <?php foreach ($freight_methods as $method) : ?>
+                            <?php
+                            $method_id = (string) $method['id'];
+                            $form_id = 'digitalogic-freight-update-' . sanitize_html_class($method_id);
+                            $assigned_products = isset($method['assigned_products']) ? absint($method['assigned_products']) : 0;
+                            $can_delete = $assigned_products === 0 && empty($method['legacy_key']);
+                            ?>
+                            <tr>
+                                <td><code><?php echo esc_html($method_id); ?></code></td>
+                                <td>
+                                    <label class="screen-reader-text" for="<?php echo esc_attr($form_id); ?>-name"><?php echo esc_html__('Method name', 'digitalogic'); ?></label>
+                                    <input id="<?php echo esc_attr($form_id); ?>-name" class="regular-text" form="<?php echo esc_attr($form_id); ?>" name="method_name" value="<?php echo esc_attr($method['name']); ?>" required>
+                                </td>
+                                <td>
+                                    <label class="screen-reader-text" for="<?php echo esc_attr($form_id); ?>-rate"><?php echo esc_html__('CNY price per kilogram', 'digitalogic'); ?></label>
+                                    <input id="<?php echo esc_attr($form_id); ?>-rate" class="small-text" form="<?php echo esc_attr($form_id); ?>" type="number" min="0" step="any" name="price_per_kg_cny" value="<?php echo esc_attr($method['price_per_kg_cny']); ?>" required dir="ltr">
+                                </td>
+                                <td>
+                                    <label>
+                                        <input form="<?php echo esc_attr($form_id); ?>" type="checkbox" name="method_enabled" value="1" <?php checked(!empty($method['enabled'])); ?>>
+                                        <?php echo esc_html__('Active', 'digitalogic'); ?>
+                                    </label>
+                                </td>
+                                <td><?php echo esc_html(number_format_i18n($assigned_products)); ?></td>
+                                <td>
+                                    <form method="post" id="<?php echo esc_attr($form_id); ?>" class="digitalogic-inline-form">
+                                        <?php wp_nonce_field('digitalogic_import_freight_admin'); ?>
+                                        <input type="hidden" name="digitalogic_import_freight_action" value="update_method">
+                                        <input type="hidden" name="method_id" value="<?php echo esc_attr($method_id); ?>">
+                                        <button type="submit" class="button button-small"><?php echo esc_html__('Save', 'digitalogic'); ?></button>
+                                    </form>
+                                    <?php if ($can_delete) : ?>
+                                        <form method="post" class="digitalogic-inline-form">
+                                            <?php wp_nonce_field('digitalogic_import_freight_admin'); ?>
+                                            <input type="hidden" name="digitalogic_import_freight_action" value="delete_method">
+                                            <input type="hidden" name="method_id" value="<?php echo esc_attr($method_id); ?>">
+                                            <button type="submit" class="button button-small button-link-delete"><?php echo esc_html__('Delete', 'digitalogic'); ?></button>
+                                        </form>
+                                    <?php else : ?>
+                                        <span class="description"><?php echo esc_html__('Delete unavailable', 'digitalogic'); ?></span>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+
+        <h3><?php echo esc_html__('Add a freight method', 'digitalogic'); ?></h3>
+        <form method="post">
+            <?php wp_nonce_field('digitalogic_import_freight_admin'); ?>
+            <input type="hidden" name="digitalogic_import_freight_action" value="create_method">
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row"><label for="digitalogic-freight-new-id"><?php echo esc_html__('Method ID', 'digitalogic'); ?></label></th>
+                    <td>
+                        <input id="digitalogic-freight-new-id" class="regular-text code" name="method_id" required pattern="[a-z][a-z0-9_]{1,63}" dir="ltr">
+                        <p class="description"><?php echo esc_html__('A stable 2-64 character lowercase ID, such as rail_freight. It cannot be renamed later.', 'digitalogic'); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="digitalogic-freight-new-name"><?php echo esc_html__('Name', 'digitalogic'); ?></label></th>
+                    <td><input id="digitalogic-freight-new-name" class="regular-text" name="method_name" required></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="digitalogic-freight-new-rate"><?php echo esc_html__('CNY per kg', 'digitalogic'); ?></label></th>
+                    <td><input id="digitalogic-freight-new-rate" type="number" min="0" step="any" name="price_per_kg_cny" required dir="ltr"></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php echo esc_html__('Status', 'digitalogic'); ?></th>
+                    <td><label><input type="checkbox" name="method_enabled" value="1" checked> <?php echo esc_html__('Enabled', 'digitalogic'); ?></label></td>
+                </tr>
+            </table>
+            <p class="submit"><button type="submit" class="button button-primary"><?php echo esc_html__('Add freight method', 'digitalogic'); ?></button></p>
+        </form>
+
+        <h3><?php echo esc_html__('Assign a product', 'digitalogic'); ?></h3>
+        <p class="description"><?php echo esc_html__('Enter one exact Patris Code or WooCommerce SKU. An empty method selection clears the current assignment.', 'digitalogic'); ?></p>
+        <form method="post">
+            <?php wp_nonce_field('digitalogic_import_freight_admin'); ?>
+            <input type="hidden" name="digitalogic_import_freight_action" value="assign_product">
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row"><label for="digitalogic-freight-product-code"><?php echo esc_html__('Exact Code / SKU', 'digitalogic'); ?></label></th>
+                    <td><input id="digitalogic-freight-product-code" class="regular-text code" name="product_code" required dir="ltr"></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="digitalogic-freight-assignment-method"><?php echo esc_html__('Import freight method', 'digitalogic'); ?></label></th>
+                    <td>
+                        <select id="digitalogic-freight-assignment-method" name="assignment_method_id">
+                            <option value=""><?php echo esc_html__('Clear assignment', 'digitalogic'); ?></option>
+                            <?php foreach ($freight_methods as $method) : ?>
+                                <option value="<?php echo esc_attr($method['id']); ?>" <?php disabled(empty($method['enabled'])); ?>>
+                                    <?php
+                                    echo esc_html(sprintf(
+                                        '%1$s - %2$s CNY/kg%3$s',
+                                        $method['name'],
+                                        $method['price_per_kg_cny'],
+                                        empty($method['enabled']) ? ' (' . __('disabled', 'digitalogic') . ')' : ''
+                                    ));
+                                    ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </td>
+                </tr>
+            </table>
+            <p class="submit"><button type="submit" class="button button-primary"><?php echo esc_html__('Apply assignment', 'digitalogic'); ?></button></p>
+        </form>
+
+        <?php if (is_array($freight_assignment)) : ?>
+            <p>
+                <strong><?php echo esc_html__('Resolved product:', 'digitalogic'); ?></strong>
+                <?php echo esc_html(sprintf('#%1$d (%2$s)', absint($freight_assignment['product_id']), $freight_assignment['resolved_by'])); ?>
+                &mdash;
+                <strong><?php echo esc_html__('Current method:', 'digitalogic'); ?></strong>
+                <?php
+                echo empty($freight_assignment['import_freight_method'])
+                    ? esc_html__('None', 'digitalogic')
+                    : esc_html($freight_assignment['import_freight_method']['name']);
+                ?>
+            </p>
+        <?php endif; ?>
+    </section>
 
     <section class="digitalogic-section digitalogic-report-results">
         <h2><?php echo esc_html__('Problem Rows', 'digitalogic'); ?></h2>

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -252,6 +252,63 @@ class Digitalogic_REST_API {
             'callback' => array($this, 'push_patris'),
             'permission_callback' => array($this, 'check_patris_push_permission')
         ));
+
+        // Supplier import freight (not WooCommerce customer delivery methods).
+        register_rest_route('digitalogic/v1', '/integration/catalog', array(
+            'methods' => 'GET',
+            'callback' => array($this, 'get_integration_catalog'),
+            'permission_callback' => array($this, 'check_read_permission'),
+        ));
+
+        register_rest_route('digitalogic/v1', '/import-freight-methods', array(
+            array(
+                'methods' => 'GET',
+                'callback' => array($this, 'list_import_freight_methods'),
+                'permission_callback' => array($this, 'check_read_permission'),
+            ),
+            array(
+                'methods' => 'POST',
+                'callback' => array($this, 'create_import_freight_method'),
+                'permission_callback' => array($this, 'check_write_permission'),
+            ),
+        ));
+
+        register_rest_route('digitalogic/v1', '/import-freight-methods/(?P<id>[a-z][a-z0-9_]{1,63})', array(
+            array(
+                'methods' => 'GET',
+                'callback' => array($this, 'get_import_freight_method'),
+                'permission_callback' => array($this, 'check_read_permission'),
+            ),
+            array(
+                'methods' => 'PUT',
+                'callback' => array($this, 'update_import_freight_method'),
+                'permission_callback' => array($this, 'check_write_permission'),
+            ),
+            array(
+                'methods' => 'DELETE',
+                'callback' => array($this, 'delete_import_freight_method'),
+                'permission_callback' => array($this, 'check_write_permission'),
+            ),
+        ));
+
+        register_rest_route('digitalogic/v1', '/products/by-code/(?P<code>[^/]+)/import-pricing', array(
+            array(
+                'methods' => 'GET',
+                'callback' => array($this, 'get_product_import_pricing'),
+                'permission_callback' => array($this, 'check_read_permission'),
+            ),
+            array(
+                'methods' => 'PUT',
+                'callback' => array($this, 'assign_product_import_freight'),
+                'permission_callback' => array($this, 'check_write_permission'),
+            ),
+        ));
+
+        register_rest_route('digitalogic/v1', '/products/import-pricing/batch', array(
+            'methods' => 'POST',
+            'callback' => array($this, 'batch_assign_product_import_freight'),
+            'permission_callback' => array($this, 'check_write_permission'),
+        ));
     }
     
     /**
@@ -332,7 +389,7 @@ class Digitalogic_REST_API {
     public function check_patris_push_permission(WP_REST_Request $request) {
         return Digitalogic_Patris_Feed::instance()->verify_push_request($request);
     }
-    
+
     /**
      * GET /products
      */
@@ -549,5 +606,90 @@ class Digitalogic_REST_API {
             'success' => true,
             'data' => $result
         ), 200);
+    }
+
+    public function get_integration_catalog(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->get_integration_catalog($request->get_params())
+        );
+    }
+
+    public function list_import_freight_methods(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->list_import_freight_methods($request->get_params())
+        );
+    }
+
+    public function create_import_freight_method(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->create_import_freight_method($this->request_payload($request)),
+            201
+        );
+    }
+
+    public function get_import_freight_method(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->get_import_freight_method(array('id' => $request['id']))
+        );
+    }
+
+    public function update_import_freight_method(WP_REST_Request $request) {
+        $payload = array(
+            'id' => $request['id'],
+            'method' => $this->request_payload($request),
+        );
+
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->update_import_freight_method($payload)
+        );
+    }
+
+    public function delete_import_freight_method(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->delete_import_freight_method(array('id' => $request['id']))
+        );
+    }
+
+    public function get_product_import_pricing(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing(array('code' => $request['code']))
+        );
+    }
+
+    public function assign_product_import_freight(WP_REST_Request $request) {
+        $payload = $this->request_payload($request);
+        $payload['code'] = $request['code'];
+
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->assign_product_import_freight($payload)
+        );
+    }
+
+    public function batch_assign_product_import_freight(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->batch_assign_product_import_freight($this->request_payload($request))
+        );
+    }
+
+    private function request_payload(WP_REST_Request $request) {
+        $payload = $request->get_json_params();
+
+        return is_array($payload) ? $payload : array();
+    }
+
+    private function import_freight_response($result, $success_status = 200) {
+        if (is_wp_error($result)) {
+            $details = $result->get_error_data();
+            $status = is_array($details) && isset($details['status']) ? (int) $details['status'] : 400;
+
+            return new WP_REST_Response(array(
+                'success' => false,
+                'code' => $result->get_error_code(),
+                'message' => $result->get_error_message(),
+                'details' => $details,
+            ), $status);
+        }
+
+        return new WP_REST_Response(array('success' => true, 'data' => $result), $success_status);
     }
 }

--- a/includes/api/class-webhooks.php
+++ b/includes/api/class-webhooks.php
@@ -18,6 +18,7 @@ class Digitalogic_Webhooks {
         if (is_null(self::$instance)) {
             self::$instance = new self();
         }
+        self::$instance->register_import_freight_delivery_channel();
         return self::$instance;
     }
     
@@ -43,10 +44,19 @@ class Digitalogic_Webhooks {
         // Hook into currency updates
         add_action('update_option_dollar_price', array($this, 'currency_updated'), 10, 3);
         add_action('update_option_yuan_price', array($this, 'currency_updated'), 10, 3);
-        
+
         // Add settings page
         add_action('admin_init', array($this, 'register_settings'));
         add_action('rest_api_init', array($this, 'register_routes'));
+    }
+
+    private function register_import_freight_delivery_channel() {
+        // Freight delivery uses an explicit result contract so failures from
+        // one transport cannot abort panel/Redis or other webhook attempts.
+        Digitalogic_Import_Freight_Service::instance()->register_delivery_channel(
+            'webhook',
+            array($this, 'deliver_import_freight_event')
+        );
     }
     
     /**
@@ -278,6 +288,68 @@ class Digitalogic_Webhooks {
         
         $this->trigger_webhook('currency.updated', $data);
     }
+
+    public function import_freight_method_created($method) {
+        return $this->trigger_import_freight_method_webhook('import_freight.method.created', $method);
+    }
+
+    public function import_freight_method_updated($method) {
+        return $this->trigger_import_freight_method_webhook('import_freight.method.updated', $method);
+    }
+
+    public function import_freight_method_deleted($method) {
+        return $this->trigger_import_freight_method_webhook('import_freight.method.deleted', $method);
+    }
+
+    public function import_freight_assignment_updated($product_id, $method_id) {
+        return $this->trigger_webhook('import_freight.assignment.updated', array(
+            'product_id' => absint($product_id),
+            'import_freight_method_id' => sanitize_key((string) $method_id),
+        ));
+    }
+
+    private function trigger_import_freight_method_webhook($event, $method) {
+        $method = is_array($method) ? $method : array();
+        return $this->trigger_webhook($event, array(
+            'id' => isset($method['id']) ? sanitize_key($method['id']) : '',
+            'name' => isset($method['name']) ? sanitize_text_field($method['name']) : '',
+            'enabled' => !empty($method['enabled']),
+            'price_per_kg_cny' => isset($method['price_per_kg_cny']) ? (float) $method['price_per_kg_cny'] : null,
+        ));
+    }
+
+    /**
+     * Result-aware synchronous freight delivery used by the canonical service.
+     */
+    public function deliver_import_freight_event($hook, $args) {
+        $args = is_array($args) ? $args : array();
+        if ('digitalogic_product_import_freight_method_updated' === $hook) {
+            return $this->trigger_webhook('import_freight.assignment.updated', array(
+                'product_id' => absint(isset($args[0]) ? $args[0] : 0),
+                'import_freight_method_id' => sanitize_key((string) (isset($args[1]) ? $args[1] : '')),
+            ), true);
+        }
+
+        $events = array(
+            'digitalogic_import_freight_method_created' => 'import_freight.method.created',
+            'digitalogic_import_freight_method_updated' => 'import_freight.method.updated',
+            'digitalogic_import_freight_method_deleted' => 'import_freight.method.deleted',
+        );
+        if (!isset($events[$hook])) {
+            return new WP_Error(
+                'digitalogic_webhook_delivery_event_unknown',
+                __('The webhook transport does not recognize this import freight event.', 'digitalogic')
+            );
+        }
+
+        $method = isset($args[0]) && is_array($args[0]) ? $args[0] : array();
+        return $this->trigger_webhook($events[$hook], array(
+            'id' => isset($method['id']) ? sanitize_key($method['id']) : '',
+            'name' => isset($method['name']) ? sanitize_text_field($method['name']) : '',
+            'enabled' => !empty($method['enabled']),
+            'price_per_kg_cny' => isset($method['price_per_kg_cny']) ? (float) $method['price_per_kg_cny'] : null,
+        ), true);
+    }
     
     /**
      * Trigger webhook
@@ -286,7 +358,7 @@ class Digitalogic_Webhooks {
         $webhook_urls = get_option('digitalogic_webhook_urls', array());
         
         if (empty($webhook_urls)) {
-            return;
+            return true;
         }
         
         // Ensure it's an array
@@ -308,36 +380,65 @@ class Digitalogic_Webhooks {
         );
         
         $payload_json = json_encode($payload);
+        if (!is_string($payload_json)) {
+            return new WP_Error(
+                'digitalogic_webhook_payload_encoding_failed',
+                __('The webhook payload could not be encoded.', 'digitalogic')
+            );
+        }
         $signature = hash_hmac('sha256', $payload_json, $secret);
-        
-        foreach ($webhook_urls as $url) {
+
+        $failures = array();
+        foreach (array_values($webhook_urls) as $index => $url) {
             if (empty($url)) {
                 continue;
             }
+
+            try {
+                $response = wp_remote_post($url, array(
+                    'headers' => array(
+                        'Content-Type' => 'application/json',
+                        'X-Digitalogic-Signature' => $signature,
+                        'X-Digitalogic-Event' => $event
+                    ),
+                    'body' => $payload_json,
+                    'timeout' => 10,
+                    'blocking' => (bool) $blocking
+                ));
+            } catch (Throwable $exception) {
+                $response = new WP_Error('digitalogic_webhook_transport_exception', $exception->getMessage());
+            }
             
-            $response = wp_remote_post($url, array(
-                'headers' => array(
-                    'Content-Type' => 'application/json',
-                    'X-Digitalogic-Signature' => $signature,
-                    'X-Digitalogic-Event' => $event
-                ),
-                'body' => $payload_json,
-                'timeout' => 10,
-                'blocking' => (bool) $blocking
-            ));
-            
-            // Log failed webhook attempts for debugging
-            if (is_wp_error($response)) {
-                Digitalogic_Logger::instance()->log(
-                    'webhook_failed',
-                    'webhook',
-                    null,
-                    null,
-                    json_encode(array('url' => $url, 'error' => $response->get_error_message())),
-                    'Webhook delivery failed'
-                );
+            $response_code = is_wp_error($response) ? 0 : (int) wp_remote_retrieve_response_code($response);
+            if (is_wp_error($response) || ($blocking && ($response_code < 200 || $response_code >= 300))) {
+                $error_message = is_wp_error($response)
+                    ? $response->get_error_message()
+                    : sprintf('HTTP %d', $response_code);
+                $failures[] = array('index' => $index, 'reason' => $error_message);
+                try {
+                    Digitalogic_Logger::instance()->log(
+                        'webhook_failed',
+                        'webhook',
+                        null,
+                        null,
+                        wp_json_encode(array('destination_index' => $index, 'error' => $error_message)),
+                        'Webhook delivery failed'
+                    );
+                } catch (Throwable $exception) {
+                    error_log('[Digitalogic webhooks] Failure logging was unavailable.');
+                }
             }
         }
+
+        if (!empty($failures)) {
+            return new WP_Error(
+                'digitalogic_webhook_delivery_failed',
+                __('One or more webhook destinations rejected the import freight event.', 'digitalogic'),
+                array('failures' => $failures)
+            );
+        }
+
+        return true;
     }
     
     /**

--- a/includes/class-command-dispatcher.php
+++ b/includes/class-command-dispatcher.php
@@ -84,6 +84,15 @@ class Digitalogic_Command_Dispatcher {
             'digitalogic_sync_patris' => array($this, 'sync_patris'),
             'digitalogic_import_patris_payload' => array($this, 'import_patris_payload'),
             'digitalogic_update_patris_settings' => array($this, 'update_patris_settings'),
+            'digitalogic_get_integration_catalog' => array($this, 'get_integration_catalog'),
+            'digitalogic_list_import_freight_methods' => array($this, 'list_import_freight_methods'),
+            'digitalogic_create_import_freight_method' => array($this, 'create_import_freight_method'),
+            'digitalogic_get_import_freight_method' => array($this, 'get_import_freight_method'),
+            'digitalogic_update_import_freight_method' => array($this, 'update_import_freight_method'),
+            'digitalogic_delete_import_freight_method' => array($this, 'delete_import_freight_method'),
+            'digitalogic_get_product_import_pricing' => array($this, 'get_product_import_pricing'),
+            'digitalogic_assign_product_import_freight' => array($this, 'assign_product_import_freight'),
+            'digitalogic_batch_assign_product_import_freight' => array($this, 'batch_assign_product_import_freight'),
         );
     }
 
@@ -248,6 +257,78 @@ class Digitalogic_Command_Dispatcher {
             'settings' => Digitalogic_Patris_Feed::instance()->update_settings($payload),
             'push_token' => Digitalogic_Patris_Feed::instance()->get_push_token(),
         );
+    }
+
+    public function get_integration_catalog($payload = array()) {
+        return Digitalogic_Import_Freight_Service::instance()->get_integration_catalog();
+    }
+
+    public function list_import_freight_methods($payload = array()) {
+        $include_disabled = !isset($payload['include_disabled'])
+            || filter_var($payload['include_disabled'], FILTER_VALIDATE_BOOLEAN);
+
+        $methods = Digitalogic_Import_Freight_Service::instance()->list_methods($include_disabled);
+        if (is_wp_error($methods)) {
+            return $methods;
+        }
+
+        return array(
+            'methods' => $methods,
+        );
+    }
+
+    public function create_import_freight_method($payload) {
+        $data = isset($payload['method']) && is_array($payload['method']) ? $payload['method'] : $payload;
+
+        return Digitalogic_Import_Freight_Service::instance()->create_method($data);
+    }
+
+    public function get_import_freight_method($payload) {
+        return Digitalogic_Import_Freight_Service::instance()->get_method(isset($payload['id']) ? $payload['id'] : '');
+    }
+
+    public function update_import_freight_method($payload) {
+        $id = isset($payload['id']) ? $payload['id'] : '';
+        $data = isset($payload['method']) && is_array($payload['method']) ? $payload['method'] : $payload;
+
+        return Digitalogic_Import_Freight_Service::instance()->update_method($id, $data);
+    }
+
+    public function delete_import_freight_method($payload) {
+        return Digitalogic_Import_Freight_Service::instance()->delete_method(isset($payload['id']) ? $payload['id'] : '');
+    }
+
+    public function get_product_import_pricing($payload) {
+        return Digitalogic_Import_Freight_Service::instance()->get_product_assignment_by_code(
+            isset($payload['code']) ? $payload['code'] : ''
+        );
+    }
+
+    public function assign_product_import_freight($payload) {
+        if (array_key_exists('import_freight_method_id', $payload)) {
+            $method_id = $payload['import_freight_method_id'];
+        } elseif (array_key_exists('method_id', $payload)) {
+            $method_id = $payload['method_id'];
+        } else {
+            return new WP_Error(
+                'digitalogic_import_freight_method_required',
+                __('The import freight method field is required; use null or an empty value to clear it explicitly.', 'digitalogic'),
+                array('status' => 400)
+            );
+        }
+
+        return Digitalogic_Import_Freight_Service::instance()->assign_product_by_code(
+            isset($payload['code']) ? $payload['code'] : '',
+            $method_id
+        );
+    }
+
+    public function batch_assign_product_import_freight($payload) {
+        $assignments = isset($payload['assignments']) && is_array($payload['assignments'])
+            ? $payload['assignments']
+            : array();
+
+        return Digitalogic_Import_Freight_Service::instance()->batch_assign_products($assignments);
     }
 
     /**

--- a/includes/class-import-freight-service.php
+++ b/includes/class-import-freight-service.php
@@ -1,0 +1,2129 @@
+<?php
+/**
+ * Canonical inbound freight catalog and product assignment service.
+ *
+ * Import freight describes how Digitalogic obtains inventory from suppliers.
+ * It is intentionally independent from WooCommerce customer delivery methods.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('Digitalogic_Product_Identifier_Resolver')) {
+    require_once __DIR__ . '/class-product-identifier-resolver.php';
+}
+
+final class Digitalogic_Import_Freight_Service {
+
+    public const METHODS_OPTION = 'digitalogic_import_freight_methods_v1';
+    public const MIGRATION_OPTION = 'digitalogic_import_freight_migration_v1';
+    public const PRODUCT_METHOD_META = '_digitalogic_import_freight_method_id';
+    public const LEGACY_PRODUCT_METHOD_META = 'shipping_method';
+    public const LEGACY_ACF_REFERENCE_META = '_shipping_method';
+    public const LEGACY_ACF_FIELD_KEY = 'field_694534693f9ba';
+    public const CATALOG_SCHEMA = 'digitalogic.integration-catalog';
+    public const CATALOG_SCHEMA_VERSION = '1.0.0';
+    public const FORMULA_ID = 'landed_price_v1';
+    public const FORMULA_REVISION = '1.0.0';
+
+    private const MIGRATION_VERSION = 1;
+    private const MAX_BATCH_SIZE = 500;
+    private const CATALOG_LOCK_NAME = 'digitalogic_import_freight_catalog_v1';
+    private const CATALOG_LOCK_TIMEOUT_SECONDS = 10;
+
+    private static $instance = null;
+    private $migration_checked = false;
+    private $migrating = false;
+    private $syncing_legacy_meta = false;
+    private $syncing_legacy_rate = false;
+    private $catalog_lock_depth = 0;
+    private $transaction_active = false;
+    private $transaction_option_names = array();
+    private $transaction_post_ids = array();
+    private $transaction_hook_events = array();
+    private $delivery_channels = array();
+
+    public static function instance() {
+        if (is_null(self::$instance)) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action('init', array($this, 'maybe_migrate'), 5);
+        add_action('added_post_meta', array($this, 'sync_legacy_assignment'), 10, 4);
+        add_action('updated_post_meta', array($this, 'sync_legacy_assignment'), 10, 4);
+        add_action('deleted_post_meta', array($this, 'delete_legacy_assignment'), 10, 4);
+        add_action('added_option', array($this, 'sync_added_legacy_rate'), 10, 2);
+        add_action('updated_option', array($this, 'sync_updated_legacy_rate'), 10, 3);
+        add_filter('acf/load_field/key=' . self::LEGACY_ACF_FIELD_KEY, array($this, 'filter_acf_method_field'));
+        add_filter('acf/validate_value/key=' . self::LEGACY_ACF_FIELD_KEY, array($this, 'validate_acf_method_value'), 10, 4);
+    }
+
+    /**
+     * Register an independently invoked post-commit delivery channel.
+     *
+     * Channel callbacks receive the stable domain action name and its argument
+     * array. They must return true on confirmed delivery or a WP_Error on
+     * failure. A null/void result is deliberately treated as unconfirmed.
+     */
+    public function register_delivery_channel($name, $callback) {
+        $name = sanitize_key((string) $name);
+        if ($name === '' || !is_callable($callback) || isset($this->delivery_channels[$name])) {
+            return false;
+        }
+
+        $this->delivery_channels[$name] = $callback;
+        return true;
+    }
+
+    public function unregister_delivery_channel($name) {
+        $name = sanitize_key((string) $name);
+        if (!isset($this->delivery_channels[$name])) {
+            return false;
+        }
+
+        unset($this->delivery_channels[$name]);
+        return true;
+    }
+
+    /**
+     * Seed the canonical catalog and migrate legacy ACF product values once.
+     *
+     * @return array Migration result.
+     */
+    public function maybe_migrate() {
+        if ($this->migration_checked || $this->migrating) {
+            return array('migrated' => false, 'assignments_migrated' => 0);
+        }
+
+        $version_row = $this->read_option_db(self::MIGRATION_OPTION);
+        $methods_row = $this->read_option_db(self::METHODS_OPTION);
+        $version = $version_row['exists'] ? (int) $version_row['value'] : 0;
+        $stored = $methods_row['exists'] ? $methods_row['value'] : false;
+
+        $required_methods_present = is_array($stored)
+            && isset($stored['air_express'], $stored['air_freight'], $stored['sea_freight']);
+        if ($version >= self::MIGRATION_VERSION && $required_methods_present) {
+            $this->migration_checked = true;
+            return array('migrated' => false, 'assignments_migrated' => 0);
+        }
+
+        return $this->migrate_legacy_data();
+    }
+
+    /**
+     * Explicit migration entry point used by activation, upgrades, and tests.
+     *
+     * @return array Migration result.
+     */
+    public function migrate_legacy_data() {
+        if ($this->migrating) {
+            return array('migrated' => false, 'assignments_migrated' => 0);
+        }
+
+        $this->migrating = true;
+        try {
+            $result = $this->with_catalog_lock(function() {
+                return $this->run_transaction(function() {
+                    $methods = $this->load_methods();
+                    $catalog_seeded = false;
+
+                    $seed_methods = $this->legacy_seed_methods();
+                    foreach ($seed_methods as $method) {
+                        if (is_wp_error($method)) {
+                            return $method;
+                        }
+                    }
+
+                    foreach ($seed_methods as $id => $method) {
+                        if (!isset($methods[$id])) {
+                            $methods[$id] = $method;
+                            $catalog_seeded = true;
+                        }
+                    }
+
+                    if ($catalog_seeded) {
+                        $stored = $this->store_methods($methods);
+                        if (is_wp_error($stored)) {
+                            return $stored;
+                        }
+                    }
+
+                    $assignments_migrated = $this->migrate_legacy_product_assignments($methods);
+                    if (is_wp_error($assignments_migrated)) {
+                        return $assignments_migrated;
+                    }
+
+                    $version_stored = $this->store_option_verified(
+                        self::MIGRATION_OPTION,
+                        self::MIGRATION_VERSION,
+                        'digitalogic_import_freight_migration_write_failed'
+                    );
+                    if (is_wp_error($version_stored)) {
+                        return $version_stored;
+                    }
+
+                    return array(
+                        'migrated' => $catalog_seeded || $assignments_migrated > 0,
+                        'catalog_seeded' => $catalog_seeded,
+                        'assignments_migrated' => $assignments_migrated,
+                        'migration_version' => self::MIGRATION_VERSION,
+                    );
+                });
+            });
+
+            if (!is_wp_error($result)) {
+                $this->migration_checked = true;
+            }
+
+            return $result;
+        } finally {
+            $this->migrating = false;
+        }
+    }
+
+    /**
+     * Return methods with assignment counts.
+     *
+     * @param bool $include_disabled Whether disabled methods should be returned.
+     * @return array
+     */
+    public function list_methods($include_disabled = true) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+        $methods = $this->load_methods();
+        $result = array();
+
+        foreach ($methods as $method) {
+            if (!$include_disabled && empty($method['enabled'])) {
+                continue;
+            }
+
+            $method['assigned_products'] = $this->count_assignments($method['id']);
+            $result[] = $method;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Fetch one method.
+     *
+     * @param string $id Immutable method ID.
+     * @return array|WP_Error
+     */
+    public function get_method($id) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+        $id = $this->validate_method_id($id);
+        if (is_wp_error($id)) {
+            return $id;
+        }
+
+        $methods = $this->load_methods();
+        if (!isset($methods[$id])) {
+            return new WP_Error(
+                'digitalogic_import_freight_method_not_found',
+                __('Import freight method not found.', 'digitalogic'),
+                array('status' => 404)
+            );
+        }
+
+        $method = $methods[$id];
+        $method['assigned_products'] = $this->count_assignments($id);
+
+        return $method;
+    }
+
+    /**
+     * Create a method with a caller-supplied immutable ID.
+     *
+     * @param array $data Method data.
+     * @return array|WP_Error
+     */
+    public function create_method($data) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+        $data = is_array($data) ? $data : array();
+        if (array_key_exists('legacy_key', $data) && trim((string) $data['legacy_key']) !== '') {
+            return new WP_Error(
+                'digitalogic_import_freight_legacy_key_reserved',
+                __('Legacy freight mappings are reserved for migrated methods.', 'digitalogic'),
+                array('status' => 400)
+            );
+        }
+        $id = $this->validate_method_id(isset($data['id']) ? $data['id'] : '');
+        if (is_wp_error($id)) {
+            return $id;
+        }
+
+        if (in_array($id, array('express', 'aerial', 'marine'), true)) {
+            return new WP_Error(
+                'digitalogic_import_freight_method_id_reserved',
+                __('That method ID is reserved by the legacy ACF field mapping.', 'digitalogic'),
+                array('status' => 409)
+            );
+        }
+
+        $data['id'] = $id;
+        $reserved_legacy_keys = array(
+            'air_express' => 'express',
+            'air_freight' => 'aerial',
+            'sea_freight' => 'marine',
+        );
+        if (isset($reserved_legacy_keys[$id])) {
+            $data['legacy_key'] = $reserved_legacy_keys[$id];
+        }
+        $method = $this->sanitize_method($data);
+        if (is_wp_error($method)) {
+            return $method;
+        }
+
+        return $this->with_catalog_lock(function() use ($id, $method) {
+            $methods = $this->load_methods();
+            if (isset($methods[$id])) {
+                return new WP_Error(
+                    'digitalogic_import_freight_method_exists',
+                    __('Import freight method ID already exists.', 'digitalogic'),
+                    array('status' => 409)
+                );
+            }
+
+            $methods[$id] = $method;
+            $stored = $this->run_transaction(function() use ($methods) {
+                return $this->store_methods($methods);
+            });
+            if (is_wp_error($stored)) {
+                return $stored;
+            }
+
+            $delivery_warnings = $this->emit_domain_action('digitalogic_import_freight_method_created', $method);
+            $result = $method;
+            $result['assigned_products'] = 0;
+            if (!empty($delivery_warnings)) {
+                $result['delivery_warnings'] = $delivery_warnings;
+            }
+
+            return $result;
+        });
+    }
+
+    /**
+     * Update mutable method fields while preserving the ID and legacy mapping.
+     *
+     * @param string $id Method ID.
+     * @param array  $changes Changed fields.
+     * @return array|WP_Error
+     */
+    public function update_method($id, $changes) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+        $id = $this->validate_method_id($id);
+        if (is_wp_error($id)) {
+            return $id;
+        }
+
+        $changes = is_array($changes) ? $changes : array();
+        if (isset($changes['id']) && (string) $changes['id'] !== $id) {
+            return new WP_Error(
+                'digitalogic_import_freight_method_id_immutable',
+                __('Import freight method IDs are immutable.', 'digitalogic'),
+                array('status' => 400)
+            );
+        }
+
+        return $this->with_catalog_lock(function() use ($id, $changes) {
+            $methods = $this->load_methods();
+            if (!isset($methods[$id])) {
+                return new WP_Error(
+                    'digitalogic_import_freight_method_not_found',
+                    __('Import freight method not found.', 'digitalogic'),
+                    array('status' => 404)
+                );
+            }
+
+            if (isset($changes['legacy_key']) && $changes['legacy_key'] !== $methods[$id]['legacy_key']) {
+                return new WP_Error(
+                    'digitalogic_import_freight_legacy_key_immutable',
+                    __('Legacy freight mappings are immutable.', 'digitalogic'),
+                    array('status' => 400)
+                );
+            }
+
+            $candidate = array_merge($methods[$id], $changes, array('id' => $id));
+            $candidate['legacy_key'] = $methods[$id]['legacy_key'];
+            $method = $this->sanitize_method($candidate, $methods[$id]);
+            if (is_wp_error($method)) {
+                return $method;
+            }
+
+            $changed = $method !== $methods[$id];
+            $delivery_warnings = array();
+            if ($changed) {
+                $methods[$id] = $method;
+                $stored = $this->run_transaction(function() use ($methods, $method) {
+                    $result = $this->store_methods($methods);
+                    if (is_wp_error($result)) {
+                        return $result;
+                    }
+
+                    return $this->sync_legacy_rate_option($method);
+                });
+                if (is_wp_error($stored)) {
+                    return $stored;
+                }
+
+                $delivery_warnings = $this->emit_domain_action('digitalogic_import_freight_method_updated', $method);
+            }
+
+            $method['assigned_products'] = $this->count_assignments($id);
+            $method['changed'] = $changed;
+            if (!empty($delivery_warnings)) {
+                $method['delivery_warnings'] = $delivery_warnings;
+            }
+
+            return $method;
+        });
+    }
+
+    /**
+     * Delete an unassigned method. Assigned methods can be disabled instead.
+     *
+     * @param string $id Method ID.
+     * @return array|WP_Error
+     */
+    public function delete_method($id) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+        $id = $this->validate_method_id($id);
+        if (is_wp_error($id)) {
+            return $id;
+        }
+
+        return $this->with_catalog_lock(function() use ($id) {
+            $methods = $this->load_methods();
+            if (!isset($methods[$id])) {
+                return new WP_Error(
+                    'digitalogic_import_freight_method_not_found',
+                    __('Import freight method not found.', 'digitalogic'),
+                    array('status' => 404)
+                );
+            }
+
+            $assigned = $this->count_assignments($id);
+            if ($assigned > 0) {
+                return new WP_Error(
+                    'digitalogic_import_freight_method_assigned',
+                    __('Assigned import freight methods cannot be deleted. Disable the method or reassign its products first.', 'digitalogic'),
+                    array('status' => 409, 'assigned_products' => $assigned)
+                );
+            }
+
+            if (!empty($methods[$id]['legacy_key'])) {
+                return new WP_Error(
+                    'digitalogic_import_freight_legacy_method_delete_forbidden',
+                    __('Migrated legacy import freight methods must be disabled instead of deleted.', 'digitalogic'),
+                    array('status' => 409)
+                );
+            }
+
+            $deleted = $methods[$id];
+            unset($methods[$id]);
+            $stored = $this->run_transaction(function() use ($methods) {
+                return $this->store_methods($methods);
+            });
+            if (is_wp_error($stored)) {
+                return $stored;
+            }
+
+            $delivery_warnings = $this->emit_domain_action('digitalogic_import_freight_method_deleted', $deleted);
+            $result = array('deleted' => true, 'id' => $id);
+            if (!empty($delivery_warnings)) {
+                $result['delivery_warnings'] = $delivery_warnings;
+            }
+            return $result;
+        });
+    }
+
+    /**
+     * Resolve an exact Patris Code/SKU and return its current assignment.
+     *
+     * @param string $code Patris Code or exact SKU.
+     * @return array|WP_Error
+     */
+    public function get_product_assignment_by_code($code) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+        $resolved = $this->resolve_freight_product($code);
+        if (is_wp_error($resolved)) {
+            return $resolved;
+        }
+
+        return $this->build_assignment_response($resolved);
+    }
+
+    /**
+     * Assign or clear a method through deterministic Code/SKU resolution.
+     *
+     * @param string      $code Patris Code or exact SKU.
+     * @param string|null $method_id Method ID; empty clears the assignment.
+     * @return array|WP_Error
+     */
+    public function assign_product_by_code($code, $method_id) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+
+        return $this->with_catalog_lock(function() use ($code, $method_id) {
+            $resolved = $this->resolve_freight_product($code);
+            if (is_wp_error($resolved)) {
+                return $resolved;
+            }
+
+            $method = $this->validate_assignment_method($method_id, $resolved['product_id']);
+            if (is_wp_error($method)) {
+                return $method;
+            }
+
+            $write = $this->run_transaction(function() use ($resolved, $method) {
+                return $this->apply_assignment($resolved['product_id'], $method);
+            });
+            if (is_wp_error($write)) {
+                return $write;
+            }
+
+            $delivery_warnings = array();
+            if (!empty($write['changed'])) {
+                $delivery_warnings = $this->emit_domain_action(
+                    'digitalogic_product_import_freight_method_updated',
+                    $resolved['product_id'],
+                    is_null($method) ? '' : $method['id']
+                );
+            }
+
+            $response = $this->build_assignment_response($resolved);
+            $response['changed'] = !empty($write['changed']);
+            if (!empty($delivery_warnings)) {
+                $response['delivery_warnings'] = $delivery_warnings;
+            }
+
+            return $response;
+        });
+    }
+
+    /**
+     * Apply a preflighted batch. No changes occur when any row is invalid.
+     *
+     * @param array $assignments List of code/method assignments.
+     * @return array|WP_Error
+     */
+    public function batch_assign_products($assignments) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+        if (!is_array($assignments) || empty($assignments)) {
+            return new WP_Error(
+                'digitalogic_import_freight_empty_batch',
+                __('At least one product assignment is required.', 'digitalogic'),
+                array('status' => 400)
+            );
+        }
+
+        if (count($assignments) > self::MAX_BATCH_SIZE) {
+            return new WP_Error(
+                'digitalogic_import_freight_batch_too_large',
+                __('Import freight assignment batches are limited to 500 rows.', 'digitalogic'),
+                array('status' => 413)
+            );
+        }
+
+        return $this->with_catalog_lock(function() use ($assignments) {
+            $prepared = array();
+            $errors = array();
+            $seen_codes = array();
+            $seen_product_ids = array();
+
+            foreach (array_values($assignments) as $index => $assignment) {
+                $assignment = is_array($assignment) ? $assignment : array();
+                $code = $this->normalize_code(isset($assignment['code']) ? $assignment['code'] : '');
+                if (array_key_exists('import_freight_method_id', $assignment)) {
+                    $method_id = $assignment['import_freight_method_id'];
+                } elseif (array_key_exists('method_id', $assignment)) {
+                    $method_id = $assignment['method_id'];
+                } else {
+                    $errors[$index] = array(
+                        'code' => 'digitalogic_import_freight_method_required',
+                        'message' => __('The import freight method field is required; use null or an empty value to clear it explicitly.', 'digitalogic'),
+                    );
+                    continue;
+                }
+
+                if ($code === '') {
+                    $errors[$index] = array('code' => 'digitalogic_invalid_product_code', 'message' => __('Product Code/SKU is required.', 'digitalogic'));
+                    continue;
+                }
+
+                if (isset($seen_codes[$code])) {
+                    $errors[$index] = array('code' => 'digitalogic_duplicate_product_code', 'message' => __('Duplicate Code/SKU in assignment batch.', 'digitalogic'));
+                    continue;
+                }
+                $seen_codes[$code] = true;
+
+                $resolved = $this->resolve_freight_product($code);
+                if (is_wp_error($resolved)) {
+                    $errors[$index] = array('code' => $resolved->get_error_code(), 'message' => $resolved->get_error_message());
+                    continue;
+                }
+
+                $product_id = (int) $resolved['product_id'];
+                if (isset($seen_product_ids[$product_id])) {
+                    $errors[$index] = array(
+                        'code' => 'digitalogic_duplicate_product_target',
+                        'message' => __('Two batch rows resolve to the same product.', 'digitalogic'),
+                        'product_id' => $product_id,
+                        'first_index' => $seen_product_ids[$product_id],
+                    );
+                    continue;
+                }
+                $seen_product_ids[$product_id] = $index;
+
+                $method = $this->validate_assignment_method($method_id, $product_id);
+                if (is_wp_error($method)) {
+                    $errors[$index] = array('code' => $method->get_error_code(), 'message' => $method->get_error_message());
+                    continue;
+                }
+
+                $prepared[] = array('resolved' => $resolved, 'method' => $method);
+            }
+
+            if (!empty($errors)) {
+                return new WP_Error(
+                    'digitalogic_import_freight_batch_invalid',
+                    __('No assignments were changed because one or more batch rows were invalid.', 'digitalogic'),
+                    array('status' => 400, 'errors' => $errors)
+                );
+            }
+
+            $writes = $this->run_transaction(function() use ($prepared) {
+                $results = array();
+                foreach ($prepared as $row) {
+                    $write = $this->apply_assignment($row['resolved']['product_id'], $row['method']);
+                    if (is_wp_error($write)) {
+                        return $write;
+                    }
+                    $results[] = $write;
+                }
+
+                return $results;
+            });
+            if (is_wp_error($writes)) {
+                return $writes;
+            }
+
+            $results = array();
+            $updated = 0;
+            $delivery_warnings = array();
+            foreach ($prepared as $index => $row) {
+                if (!empty($writes[$index]['changed'])) {
+                    $updated++;
+                    $delivery_warnings = array_merge($delivery_warnings, $this->emit_domain_action(
+                        'digitalogic_product_import_freight_method_updated',
+                        $row['resolved']['product_id'],
+                        is_null($row['method']) ? '' : $row['method']['id']
+                    ));
+                }
+
+                $response = $this->build_assignment_response($row['resolved']);
+                $response['changed'] = !empty($writes[$index]['changed']);
+                $results[] = $response;
+            }
+
+            $result = array(
+                'updated' => $updated,
+                'unchanged' => count($results) - $updated,
+                'assignments' => $results,
+            );
+            if (!empty($delivery_warnings)) {
+                $result['delivery_warnings'] = array_values(array_unique($delivery_warnings));
+            }
+            return $result;
+        });
+    }
+
+    /**
+     * Read-only contract consumed by Patris Export or another integration.
+     *
+     * @return array
+     */
+    public function get_integration_catalog() {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+        $settings = get_option('digitalogic_patris_feed_settings', array());
+        $settings = is_array($settings) ? $settings : array();
+        $warehouses = isset($settings['selected_warehouses']) && is_array($settings['selected_warehouses'])
+            ? array_values(array_unique(array_filter(array_map('sanitize_text_field', $settings['selected_warehouses']))))
+            : array();
+        sort($warehouses, SORT_STRING);
+
+        $methods = $this->list_methods(true);
+        if (is_wp_error($methods)) {
+            return $methods;
+        }
+
+        $local_currency = $this->local_currency();
+        $yuan_rate = $this->yuan_rate();
+        $source_effective_date = $this->currency_effective_date();
+        $currency_warnings = is_null($yuan_rate)
+            ? array('cny_to_local_missing_or_invalid')
+            : array();
+        $material = array(
+            'schema' => self::CATALOG_SCHEMA,
+            'schema_version' => self::CATALOG_SCHEMA_VERSION,
+            'currency' => array(
+                'foreign' => 'CNY',
+                'local' => $local_currency,
+                'cny_to_local' => $yuan_rate,
+                'cny_to_irt' => 'IRT' === $local_currency ? $yuan_rate : null,
+                'effective_date' => $this->normalize_effective_date($source_effective_date),
+                'source_effective_date' => $source_effective_date,
+                'source_effective_date_format' => 'ymd',
+                'warnings' => $currency_warnings,
+            ),
+            'pricing' => array(
+                'formula_id' => self::FORMULA_ID,
+                'formula_revision' => self::FORMULA_REVISION,
+                'expression' => '((weight_g * freight_cny_per_kg / 1000) + foreign_price_cny) * (1 + profit_percent / 100) * cny_to_irt',
+                'inputs' => array('weight_g', 'freight_cny_per_kg', 'foreign_price_cny', 'profit_percent', 'cny_to_irt'),
+                'product_markup_contract' => array(
+                    'type_field' => 'markup.type',
+                    'value_field' => 'markup.value',
+                    'profit_percent_field' => 'markup.profit_percent',
+                    'supported_type' => 'percentage',
+                    'unsupported_types_return_null_with_warning' => true,
+                ),
+                'rounding' => array(
+                    'mode' => 'half_up',
+                    'local_currency_decimals' => $this->local_currency_decimals(),
+                ),
+            ),
+            'selected_warehouses' => $warehouses,
+            'import_freight_methods' => $methods,
+        );
+
+        $revision_material = $material;
+        foreach ($revision_material['import_freight_methods'] as &$method) {
+            unset($method['assigned_products']);
+        }
+        unset($method);
+        $material['revision'] = 'sha256:' . hash('sha256', wp_json_encode($revision_material, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $material;
+    }
+
+    /**
+     * Keep the canonical assignment in sync when legacy ACF saves a product.
+     */
+    public function sync_legacy_assignment($meta_id, $object_id, $meta_key, $meta_value) {
+        if ($this->syncing_legacy_meta || self::LEGACY_PRODUCT_METHOD_META !== $meta_key || !$this->is_product($object_id)) {
+            return;
+        }
+
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return;
+        }
+
+        $attempted_value = (string) $meta_value;
+        $result = $this->with_catalog_lock(function() use ($object_id, $attempted_value) {
+            $methods = $this->load_methods();
+            $write = $this->run_transaction(function() use ($object_id, $attempted_value, $methods) {
+                $legacy = $this->read_post_meta_db($object_id, self::LEGACY_PRODUCT_METHOD_META, true);
+                if (!$legacy['exists'] || (string) $legacy['value'] !== $attempted_value) {
+                    return array('stale' => true, 'changed' => false);
+                }
+
+                $canonical = $this->read_post_meta_db($object_id, self::PRODUCT_METHOD_META, true);
+                $current_id = $canonical['exists'] ? (string) $canonical['value'] : '';
+                $method_id = $this->legacy_value_to_method_id($attempted_value, $methods);
+                if (
+                    $method_id === ''
+                    || !isset($methods[$method_id])
+                    || (empty($methods[$method_id]['enabled']) && $current_id !== $method_id)
+                ) {
+                    $restored = $this->restore_legacy_assignment_in_transaction($object_id, $current_id, $methods);
+                    return is_wp_error($restored)
+                        ? $restored
+                        : array('rejected' => true, 'changed' => false);
+                }
+
+                $assignment = $this->apply_assignment($object_id, $methods[$method_id]);
+                return is_wp_error($assignment)
+                    ? $assignment
+                    : array('write' => $assignment, 'method_id' => $method_id);
+            });
+
+            if (is_wp_error($write)) {
+                $this->restore_legacy_assignment_cas($object_id, $attempted_value, $methods);
+            }
+
+            return $write;
+        });
+
+        if (is_wp_error($result) || empty($result['write'])) {
+            return;
+        }
+
+        if (!empty($result['write']['changed'])) {
+            $this->emit_domain_action('digitalogic_product_import_freight_method_updated', $object_id, $result['method_id']);
+        }
+    }
+
+    /**
+     * Clear the canonical value when ACF clears the legacy value.
+     */
+    public function delete_legacy_assignment($meta_ids, $object_id, $meta_key, $meta_value) {
+        if ($this->syncing_legacy_meta || self::LEGACY_PRODUCT_METHOD_META !== $meta_key || !$this->is_product($object_id)) {
+            return;
+        }
+
+        $result = $this->with_catalog_lock(function() use ($object_id, $meta_value) {
+            return $this->run_transaction(function() use ($object_id, $meta_value) {
+                $legacy = $this->read_post_meta_db($object_id, self::LEGACY_PRODUCT_METHOD_META, true);
+                if ($legacy['exists']) {
+                    return array('changed' => false, 'stale' => true);
+                }
+
+                $canonical_row = $this->read_post_meta_db($object_id, self::PRODUCT_METHOD_META, true);
+                $canonical = $canonical_row['exists'] ? (string) $canonical_row['value'] : '';
+                $deleted_method_id = $this->legacy_value_to_method_id($meta_value);
+                if ($canonical === '' || $canonical !== $deleted_method_id) {
+                    return array('changed' => false);
+                }
+
+                return $this->apply_assignment($object_id, null);
+            });
+        });
+        if (!is_wp_error($result) && !empty($result['changed'])) {
+            $this->emit_domain_action('digitalogic_product_import_freight_method_updated', $object_id, '');
+        }
+    }
+
+    /**
+     * Mirror a newly-created legacy ACF rate into an existing canonical method.
+     */
+    public function sync_added_legacy_rate($option, $value) {
+        if (!$this->syncing_legacy_rate) {
+            $this->sync_legacy_rate_change($option, $value, false, null);
+        }
+    }
+
+    /**
+     * Mirror a legacy ACF rate update into the canonical catalog.
+     */
+    public function sync_updated_legacy_rate($option, $old_value, $value) {
+        if (!$this->syncing_legacy_rate) {
+            $this->sync_legacy_rate_change($option, $value, true, $old_value);
+        }
+    }
+
+    private function legacy_seed_methods() {
+        $definitions = array(
+            'air_express' => array(
+                'name' => 'Air Freight (Express)',
+                'legacy_key' => 'express',
+                'fallback_rate' => 85,
+            ),
+            'air_freight' => array(
+                'name' => 'Air Freight',
+                'legacy_key' => 'aerial',
+                'fallback_rate' => 80,
+            ),
+            'sea_freight' => array(
+                'name' => 'Sea/Ocean Freight',
+                'legacy_key' => 'marine',
+                'fallback_rate' => 50,
+            ),
+        );
+
+        $methods = array();
+        foreach ($definitions as $id => $definition) {
+            $methods[$id] = $this->sanitize_method(array(
+                'id' => $id,
+                'name' => $definition['name'],
+                'enabled' => true,
+                'currency' => 'CNY',
+                'price_per_kg_cny' => $this->legacy_rate($definition['legacy_key'], $definition['fallback_rate']),
+                'minimum_charge_cny' => null,
+                'billable_weight_rule' => 'actual',
+                'volumetric_divisor_cm3_per_kg' => null,
+                'transit_days_min' => null,
+                'transit_days_max' => null,
+                'metadata' => array('source' => 'legacy_acf_options'),
+                'tiered_rates' => array(),
+                'legacy_key' => $definition['legacy_key'],
+            ));
+        }
+
+        return $methods;
+    }
+
+    private function legacy_rate($legacy_key, $fallback) {
+        $stored = $this->read_option_db('options_' . $legacy_key, $this->transaction_active);
+        $value = $this->number_or_null($stored['exists'] ? $stored['value'] : null);
+
+        return is_null($value) ? (float) $fallback : $value;
+    }
+
+    private function migrate_legacy_product_assignments($methods) {
+        $ids = get_posts(array(
+            'post_type' => array('product', 'product_variation'),
+            'post_status' => 'any',
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'no_found_rows' => true,
+            'meta_query' => array(
+                array('key' => self::LEGACY_PRODUCT_METHOD_META, 'compare' => 'EXISTS'),
+            ),
+        ));
+        $migrated = 0;
+
+        foreach ((array) $ids as $product_id) {
+            $canonical_row = $this->read_post_meta_db($product_id, self::PRODUCT_METHOD_META, true);
+            $canonical = $canonical_row['exists'] ? (string) $canonical_row['value'] : '';
+            if ($canonical !== '' && isset($methods[$canonical])) {
+                $method_id = $canonical;
+            } else {
+                $legacy_row = $this->read_post_meta_db($product_id, self::LEGACY_PRODUCT_METHOD_META, true);
+                $legacy = $legacy_row['exists'] ? $legacy_row['value'] : '';
+                $method_id = $this->legacy_value_to_method_id($legacy, $methods);
+                if ($method_id === '') {
+                    continue;
+                }
+            }
+
+            $write = $this->apply_assignment($product_id, $methods[$method_id]);
+            if (is_wp_error($write)) {
+                return $write;
+            }
+            if (!empty($write['changed'])) {
+                $migrated++;
+            }
+        }
+
+        return $migrated;
+    }
+
+    private function sanitize_method($data, $existing = null) {
+        $id = $this->validate_method_id(isset($data['id']) ? $data['id'] : '');
+        if (is_wp_error($id)) {
+            return $id;
+        }
+
+        $name = sanitize_text_field(isset($data['name']) ? wp_unslash($data['name']) : '');
+        if ($name === '') {
+            return new WP_Error('digitalogic_import_freight_name_required', __('Import freight method name is required.', 'digitalogic'), array('status' => 400));
+        }
+
+        $currency = strtoupper(sanitize_key(isset($data['currency']) ? $data['currency'] : 'CNY'));
+        if ('CNY' !== $currency) {
+            return new WP_Error('digitalogic_import_freight_currency_unsupported', __('landed_price_v1 currently requires CNY freight rates.', 'digitalogic'), array('status' => 400));
+        }
+
+        $price = $this->number_or_null(isset($data['price_per_kg_cny']) ? $data['price_per_kg_cny'] : null);
+        if (is_null($price) || $price < 0) {
+            return new WP_Error('digitalogic_import_freight_rate_invalid', __('A non-negative CNY price per kilogram is required.', 'digitalogic'), array('status' => 400));
+        }
+
+        $minimum = $this->number_or_null(isset($data['minimum_charge_cny']) ? $data['minimum_charge_cny'] : null);
+        if (!is_null($minimum) && $minimum < 0) {
+            return new WP_Error('digitalogic_import_freight_minimum_invalid', __('Minimum charge cannot be negative.', 'digitalogic'), array('status' => 400));
+        }
+
+        $billable_rule = sanitize_key(isset($data['billable_weight_rule']) ? $data['billable_weight_rule'] : 'actual');
+        if (!in_array($billable_rule, array('actual', 'volumetric', 'greater_of'), true)) {
+            return new WP_Error('digitalogic_import_freight_billable_weight_invalid', __('Unknown billable-weight rule.', 'digitalogic'), array('status' => 400));
+        }
+
+        $divisor = $this->number_or_null(isset($data['volumetric_divisor_cm3_per_kg']) ? $data['volumetric_divisor_cm3_per_kg'] : null);
+        if (!is_null($divisor) && $divisor <= 0) {
+            return new WP_Error('digitalogic_import_freight_divisor_invalid', __('Volumetric divisor must be greater than zero.', 'digitalogic'), array('status' => 400));
+        }
+
+        $transit_min = $this->nullable_absint(isset($data['transit_days_min']) ? $data['transit_days_min'] : null);
+        $transit_max = $this->nullable_absint(isset($data['transit_days_max']) ? $data['transit_days_max'] : null);
+        if (is_wp_error($transit_min)) {
+            return $transit_min;
+        }
+        if (is_wp_error($transit_max)) {
+            return $transit_max;
+        }
+        if (!is_null($transit_min) && !is_null($transit_max) && $transit_max < $transit_min) {
+            return new WP_Error('digitalogic_import_freight_transit_invalid', __('Maximum transit days cannot be lower than minimum transit days.', 'digitalogic'), array('status' => 400));
+        }
+
+        $legacy_key = '';
+        if (is_array($existing) && isset($existing['legacy_key'])) {
+            $legacy_key = $existing['legacy_key'];
+        } elseif (isset($data['legacy_key'])) {
+            $legacy_key = sanitize_key($data['legacy_key']);
+        }
+
+        $tiered_rates = $this->sanitize_tiered_rates(isset($data['tiered_rates']) ? $data['tiered_rates'] : array());
+        if (is_wp_error($tiered_rates)) {
+            return $tiered_rates;
+        }
+
+        return array(
+            'id' => $id,
+            'name' => $name,
+            'enabled' => !isset($data['enabled']) || $this->boolean_value($data['enabled']),
+            'currency' => 'CNY',
+            'price_per_kg_cny' => $price,
+            'minimum_charge_cny' => $minimum,
+            'billable_weight_rule' => $billable_rule,
+            'volumetric_divisor_cm3_per_kg' => $divisor,
+            'transit_days_min' => $transit_min,
+            'transit_days_max' => $transit_max,
+            'metadata' => $this->sanitize_metadata(isset($data['metadata']) ? $data['metadata'] : array()),
+            'tiered_rates' => $tiered_rates,
+            'legacy_key' => $legacy_key,
+        );
+    }
+
+    private function sanitize_tiered_rates($tiers) {
+        $clean = array();
+        foreach ((array) $tiers as $index => $tier) {
+            if (!is_array($tier)) {
+                return new WP_Error(
+                    'digitalogic_import_freight_tier_invalid',
+                    __('Every tiered rate must be an object.', 'digitalogic'),
+                    array('status' => 400, 'tier_index' => $index)
+                );
+            }
+
+            $min = $this->number_or_null(isset($tier['min_weight_kg']) ? $tier['min_weight_kg'] : null);
+            $max = $this->number_or_null(isset($tier['max_weight_kg']) ? $tier['max_weight_kg'] : null);
+            $rate = $this->number_or_null(isset($tier['price_per_kg_cny']) ? $tier['price_per_kg_cny'] : null);
+            if (is_null($min) || $min < 0 || is_null($rate) || $rate < 0 || (!is_null($max) && $max < $min)) {
+                return new WP_Error(
+                    'digitalogic_import_freight_tier_invalid',
+                    __('Tiered rates require valid non-negative bounds and rates.', 'digitalogic'),
+                    array('status' => 400, 'tier_index' => $index)
+                );
+            }
+
+            $clean[] = array(
+                'min_weight_kg' => $min,
+                'max_weight_kg' => $max,
+                'price_per_kg_cny' => $rate,
+            );
+        }
+
+        usort($clean, function($left, $right) {
+            return $left['min_weight_kg'] <=> $right['min_weight_kg'];
+        });
+
+        $previous_max = null;
+        foreach ($clean as $index => $tier) {
+            if ($index > 0 && (is_null($previous_max) || $tier['min_weight_kg'] <= $previous_max)) {
+                return new WP_Error(
+                    'digitalogic_import_freight_tiers_overlap',
+                    __('Tiered freight-rate ranges cannot overlap.', 'digitalogic'),
+                    array('status' => 400, 'tier_index' => $index)
+                );
+            }
+            $previous_max = $tier['max_weight_kg'];
+        }
+
+        return $clean;
+    }
+
+    private function sanitize_metadata($value, $depth = 0) {
+        if ($depth >= 4 || !is_array($value)) {
+            return array();
+        }
+
+        $clean = array();
+        foreach ($value as $key => $item) {
+            $key = sanitize_key($key);
+            if ($key === '') {
+                continue;
+            }
+
+            if (is_array($item)) {
+                $clean[$key] = $this->sanitize_metadata($item, $depth + 1);
+            } elseif (is_bool($item) || is_numeric($item)) {
+                $clean[$key] = $item;
+            } else {
+                $clean[$key] = sanitize_text_field(wp_unslash((string) $item));
+            }
+        }
+
+        ksort($clean, SORT_STRING);
+        return $clean;
+    }
+
+    private function validate_method_id($id) {
+        $id = (string) $id;
+        if (!preg_match('/^[a-z][a-z0-9_]{1,63}$/', $id)) {
+            return new WP_Error(
+                'digitalogic_import_freight_method_id_invalid',
+                __('Method ID must be 2-64 lowercase letters, numbers, or underscores and start with a letter.', 'digitalogic'),
+                array('status' => 400)
+            );
+        }
+
+        return $id;
+    }
+
+    private function validate_assignment_method($method_id, $product_id = 0) {
+        if (is_null($method_id) || '' === trim((string) $method_id)) {
+            return null;
+        }
+
+        $method_id = $this->validate_method_id($method_id);
+        if (is_wp_error($method_id)) {
+            return $method_id;
+        }
+
+        $methods = $this->load_methods();
+        if (!isset($methods[$method_id])) {
+            return new WP_Error('digitalogic_import_freight_method_not_found', __('Import freight method not found.', 'digitalogic'), array('status' => 404));
+        }
+        if (empty($methods[$method_id]['enabled'])) {
+            $current = $product_id
+                ? $this->read_post_meta_db($product_id, self::PRODUCT_METHOD_META)
+                : array('exists' => false, 'value' => null);
+            $current_method_id = $current['exists'] ? (string) $current['value'] : '';
+            if ($current_method_id === $method_id) {
+                return $methods[$method_id];
+            }
+
+            return new WP_Error('digitalogic_import_freight_method_disabled', __('Disabled import freight methods cannot be assigned to new products.', 'digitalogic'), array('status' => 409));
+        }
+
+        return $methods[$method_id];
+    }
+
+    private function resolve_freight_product($code) {
+        $resolved = Digitalogic_Product_Identifier_Resolver::instance()->resolve(array('code' => $code));
+        if (is_wp_error($resolved)) {
+            $error_code = $resolved->get_error_code();
+            $data = is_array($resolved->get_error_data()) ? $resolved->get_error_data() : array();
+            if ('digitalogic_invalid_product_identifier' === $error_code) {
+                return new WP_Error('digitalogic_invalid_product_code', __('Product Code/SKU is required.', 'digitalogic'), array('status' => 400));
+            }
+            if ('digitalogic_product_identifier_not_found' === $error_code) {
+                return new WP_Error('digitalogic_product_code_not_found', __('No product has that exact Patris Code or SKU.', 'digitalogic'), array('status' => 404));
+            }
+            if ('digitalogic_product_identifier_ambiguous' === $error_code) {
+                return new WP_Error(
+                    'digitalogic_product_code_ambiguous',
+                    __('More than one product has that exact Patris Code or SKU; no assignment was changed.', 'digitalogic'),
+                    array(
+                        'status' => 409,
+                        'product_ids' => isset($data['woocommerce_ids']) ? $data['woocommerce_ids'] : array(),
+                    )
+                );
+            }
+
+            return $resolved;
+        }
+
+        return array(
+            'product_id' => (int) $resolved['woocommerce_id'],
+            'woocommerce_id' => $resolved['woocommerce_id'],
+            'post_type' => $resolved['post_type'],
+            'code' => $resolved['identifier'],
+            'sku' => $resolved['sku'],
+            'patris_code' => $resolved['patris_code'],
+            'resolved_by' => $resolved['resolved_by'],
+        );
+    }
+
+    private function apply_assignment($product_id, $method) {
+        $desired_method_id = is_null($method) ? '' : (string) $method['id'];
+        $desired_legacy_value = is_null($method) ? '' : $this->field_value_for_method($method);
+        $changed = false;
+
+        $this->syncing_legacy_meta = true;
+        try {
+            $canonical_write = $this->store_post_meta_verified(
+                $product_id,
+                self::PRODUCT_METHOD_META,
+                $desired_method_id
+            );
+            if (is_wp_error($canonical_write)) {
+                return $canonical_write;
+            }
+            $changed = $changed || !empty($canonical_write['changed']);
+
+            $legacy_write = $this->store_post_meta_verified(
+                $product_id,
+                self::LEGACY_PRODUCT_METHOD_META,
+                $desired_legacy_value
+            );
+            if (is_wp_error($legacy_write)) {
+                return $legacy_write;
+            }
+            $changed = $changed || !empty($legacy_write['changed']);
+
+            if (!is_null($method)) {
+                $reference = $this->read_post_meta_db($product_id, self::LEGACY_ACF_REFERENCE_META, true);
+                $reference_write = $this->store_post_meta_verified(
+                    $product_id,
+                    self::LEGACY_ACF_REFERENCE_META,
+                    $reference['exists'] && (string) $reference['value'] !== ''
+                        ? (string) $reference['value']
+                        : self::LEGACY_ACF_FIELD_KEY
+                );
+                if (is_wp_error($reference_write)) {
+                    return $reference_write;
+                }
+            }
+        } finally {
+            $this->syncing_legacy_meta = false;
+        }
+
+        return array('changed' => $changed, 'product_id' => (int) $product_id);
+    }
+
+    private function build_assignment_response($resolved) {
+        $method_row = $this->read_post_meta_db($resolved['product_id'], self::PRODUCT_METHOD_META);
+        $legacy_row = $this->read_post_meta_db($resolved['product_id'], self::LEGACY_PRODUCT_METHOD_META);
+        $method_id = $method_row['exists'] ? (string) $method_row['value'] : '';
+        $methods = $this->load_methods();
+        $markup = $this->build_markup_contract($resolved['product_id']);
+
+        return array_merge($resolved, array(
+            'import_freight_method_id' => $method_id,
+            'import_freight_method' => $method_id !== '' && isset($methods[$method_id]) ? $methods[$method_id] : null,
+            'legacy_shipping_method' => $legacy_row['exists'] ? (string) $legacy_row['value'] : '',
+            'markup' => $markup,
+            'profit_percent' => $markup['profit_percent'],
+            'pricing_warnings' => $markup['warning'] ? array($markup['warning']) : array(),
+        ));
+    }
+
+    private function count_assignments($method_id) {
+        $ids = get_posts(array(
+            'post_type' => array('product', 'product_variation'),
+            'post_status' => 'any',
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'no_found_rows' => true,
+            'meta_key' => self::PRODUCT_METHOD_META,
+            'meta_value' => $method_id,
+        ));
+
+        $methods = $this->load_methods();
+        if (isset($methods[$method_id])) {
+            $legacy_value = $this->field_value_for_method($methods[$method_id]);
+            $legacy_ids = get_posts(array(
+                'post_type' => array('product', 'product_variation'),
+                'post_status' => 'any',
+                'posts_per_page' => -1,
+                'fields' => 'ids',
+                'no_found_rows' => true,
+                'meta_key' => self::LEGACY_PRODUCT_METHOD_META,
+                'meta_value' => $legacy_value,
+            ));
+            $ids = array_merge((array) $ids, (array) $legacy_ids);
+        }
+
+        return count(array_unique(array_map('absint', (array) $ids)));
+    }
+
+    private function legacy_value_to_method_id($legacy_value, $methods = null) {
+        $legacy_value = sanitize_key((string) $legacy_value);
+        if ($legacy_value === '') {
+            return '';
+        }
+
+        $aliases = array(
+            'express' => 'air_express',
+            'aerial' => 'air_freight',
+            'marine' => 'sea_freight',
+        );
+        $methods = is_array($methods) ? $methods : $this->load_methods();
+        if (isset($aliases[$legacy_value])) {
+            return isset($methods[$aliases[$legacy_value]]) ? $aliases[$legacy_value] : '';
+        }
+
+        return isset($methods[$legacy_value]) ? $legacy_value : '';
+    }
+
+    private function sync_legacy_rate_option($method) {
+        if (!empty($method['legacy_key'])) {
+            $this->syncing_legacy_rate = true;
+            try {
+                return $this->store_option_verified(
+                    'options_' . $method['legacy_key'],
+                    $method['price_per_kg_cny'],
+                    'digitalogic_import_freight_legacy_rate_write_failed'
+                );
+            } finally {
+                $this->syncing_legacy_rate = false;
+            }
+        }
+
+        return array('changed' => false);
+    }
+
+    private function sync_legacy_rate_change($option, $value, $old_exists, $old_value = null) {
+        $mapping = array(
+            'options_express' => 'air_express',
+            'options_aerial' => 'air_freight',
+            'options_marine' => 'sea_freight',
+        );
+        if (!isset($mapping[$option])) {
+            return;
+        }
+
+        $method_id = $mapping[$option];
+        $result = $this->with_catalog_lock(function() use ($option, $value, $method_id, $old_exists, $old_value) {
+            $methods = $this->load_methods();
+            $stored = $this->run_transaction(function() use ($option, $value, $method_id, $old_exists, $old_value, $methods) {
+                $current = $this->read_option_db($option, true);
+                if (!$current['exists'] || (string) $current['value'] !== (string) $value) {
+                    return array('changed' => false, 'stale' => true, 'method' => null);
+                }
+
+                $rate = $this->number_or_null($current['value']);
+                if (is_null($rate) || $rate < 0) {
+                    $restored = $this->store_option_state_verified(
+                        $option,
+                        $old_exists,
+                        $old_value,
+                        'digitalogic_import_freight_legacy_rate_restore_failed'
+                    );
+                    return is_wp_error($restored)
+                        ? $restored
+                        : array('changed' => false, 'rejected' => true, 'method' => null);
+                }
+
+                if (!isset($methods[$method_id]) || $methods[$method_id]['price_per_kg_cny'] === $rate) {
+                    return array('changed' => false, 'method' => isset($methods[$method_id]) ? $methods[$method_id] : null);
+                }
+
+                $methods[$method_id]['price_per_kg_cny'] = $rate;
+                $catalog_stored = $this->store_methods($methods);
+                return is_wp_error($catalog_stored)
+                    ? $catalog_stored
+                    : array('changed' => true, 'method' => $methods[$method_id]);
+            });
+
+            if (is_wp_error($stored)) {
+                $this->restore_legacy_rate_option_cas($option, $value, $old_exists, $old_value);
+            }
+
+            return $stored;
+        });
+
+        if (is_wp_error($result)) {
+            return;
+        }
+
+        if (!empty($result['changed']) && is_array($result['method'])) {
+            $this->emit_domain_action('digitalogic_import_freight_method_updated', $result['method']);
+        }
+    }
+
+    private function load_methods() {
+        $stored = $this->read_option_db(self::METHODS_OPTION);
+        $methods = $stored['exists'] ? $stored['value'] : array();
+        if (!is_array($methods)) {
+            return array();
+        }
+
+        $valid = array();
+        foreach ($methods as $id => $method) {
+            if (!is_array($method) || !isset($method['id']) || $method['id'] !== $id) {
+                continue;
+            }
+            $valid[$id] = $method;
+        }
+        ksort($valid, SORT_STRING);
+
+        return $valid;
+    }
+
+    private function store_methods($methods) {
+        ksort($methods, SORT_STRING);
+        return $this->store_option_verified(
+            self::METHODS_OPTION,
+            $methods,
+            'digitalogic_import_freight_catalog_write_failed'
+        );
+    }
+
+    /**
+     * Read an option from MySQL on the current connection, bypassing the
+     * shared WordPress object cache. FOR UPDATE is used only inside a write
+     * transaction so concurrent database writers cannot change the row while
+     * it is being reconciled.
+     */
+    private function read_option_db($name, $for_update = false) {
+        global $wpdb;
+
+        $table = isset($wpdb->options) ? $wpdb->options : $wpdb->prefix . 'options';
+        $query = "SELECT option_value FROM {$table} WHERE option_name = %s LIMIT 1";
+        if ($for_update) {
+            $query .= ' FOR UPDATE';
+        }
+        $row = $wpdb->get_row($wpdb->prepare($query, $name), ARRAY_A);
+
+        return is_array($row)
+            ? array(
+                'exists' => true,
+                'value' => maybe_unserialize($row['option_value']),
+                'raw' => (string) $row['option_value'],
+            )
+            : array('exists' => false, 'value' => null, 'raw' => null);
+    }
+
+    /**
+     * Compare an option row using the exact serialized representation MySQL
+     * stores. WordPress/MySQL returns scalar option values as strings, so a
+     * strict comparison of the unserialized PHP values rejects valid writes
+     * such as integer migration markers and floating-point legacy rates.
+     */
+    private function option_row_matches($row, $desired_exists, $value = null) {
+        if ((bool) $row['exists'] !== (bool) $desired_exists) {
+            return false;
+        }
+        if (!$desired_exists) {
+            return true;
+        }
+
+        return (string) $row['raw'] === (string) maybe_serialize($value);
+    }
+
+    /**
+     * Read one post-meta value directly from MySQL, bypassing Redis/meta cache.
+     */
+    private function read_post_meta_db($post_id, $key, $for_update = false) {
+        global $wpdb;
+
+        $table = isset($wpdb->postmeta) ? $wpdb->postmeta : $wpdb->prefix . 'postmeta';
+        $query = "SELECT meta_id, meta_value FROM {$table} WHERE post_id = %d AND meta_key = %s ORDER BY meta_id ASC LIMIT 1";
+        if ($for_update) {
+            $query .= ' FOR UPDATE';
+        }
+        $row = $wpdb->get_row($wpdb->prepare($query, (int) $post_id, $key), ARRAY_A);
+
+        return is_array($row)
+            ? array(
+                'exists' => true,
+                'value' => maybe_unserialize($row['meta_value']),
+                'meta_id' => (int) $row['meta_id'],
+            )
+            : array('exists' => false, 'value' => null, 'meta_id' => 0);
+    }
+
+    /**
+     * Low-level option write used by the transaction.
+     * It deliberately does not mutate WordPress caches or fire hooks.
+     */
+    private function write_option_db($name, $exists, $value = null) {
+        global $wpdb;
+
+        $table = isset($wpdb->options) ? $wpdb->options : $wpdb->prefix . 'options';
+        $current = $this->read_option_db($name, $this->transaction_active);
+        if (!$exists) {
+            if (!$current['exists']) {
+                return true;
+            }
+            return false !== $wpdb->delete($table, array('option_name' => $name), array('%s'));
+        }
+
+        $serialized = maybe_serialize($value);
+        if ($current['exists']) {
+            if ($this->option_row_matches($current, true, $value)) {
+                return true;
+            }
+            return false !== $wpdb->update(
+                $table,
+                array('option_value' => $serialized),
+                array('option_name' => $name),
+                array('%s'),
+                array('%s')
+            );
+        }
+
+        return false !== $wpdb->insert(
+            $table,
+            array('option_name' => $name, 'option_value' => $serialized, 'autoload' => 'no'),
+            array('%s', '%s', '%s')
+        );
+    }
+
+    /**
+     * Low-level post-meta write used by the transaction.
+     */
+    private function write_post_meta_db($post_id, $key, $exists, $value = null) {
+        global $wpdb;
+
+        $table = isset($wpdb->postmeta) ? $wpdb->postmeta : $wpdb->prefix . 'postmeta';
+        $current = $this->read_post_meta_db($post_id, $key, $this->transaction_active);
+        if (!$exists) {
+            if (!$current['exists']) {
+                return true;
+            }
+            return false !== $wpdb->delete(
+                $table,
+                array('post_id' => (int) $post_id, 'meta_key' => $key),
+                array('%d', '%s')
+            );
+        }
+
+        $serialized = maybe_serialize($value);
+        if ($current['exists']) {
+            if ($current['value'] === $value) {
+                return true;
+            }
+            return false !== $wpdb->update(
+                $table,
+                array('meta_value' => $serialized),
+                array('meta_id' => $current['meta_id']),
+                array('%s'),
+                array('%d')
+            );
+        }
+
+        return false !== $wpdb->insert(
+            $table,
+            array('post_id' => (int) $post_id, 'meta_key' => $key, 'meta_value' => $serialized),
+            array('%d', '%s', '%s')
+        );
+    }
+
+    private function restore_legacy_rate_option_cas($option, $attempted_value, $old_exists, $old_value) {
+        return $this->run_transaction(function() use ($option, $attempted_value, $old_exists, $old_value) {
+            $current = $this->read_option_db($option, true);
+            if (!$current['exists'] || (string) $current['value'] !== (string) $attempted_value) {
+                return array('changed' => false, 'stale' => true);
+            }
+
+            return $this->store_option_state_verified(
+                $option,
+                $old_exists,
+                $old_value,
+                'digitalogic_import_freight_legacy_rate_restore_failed'
+            );
+        });
+    }
+
+    /**
+     * Run a catalog/assignment mutation under a site-scoped advisory lock.
+     *
+     * @param callable $callback Mutation callback.
+     * @return mixed|WP_Error
+     */
+    private function with_catalog_lock($callback) {
+        $acquired = $this->acquire_catalog_lock();
+        if (is_wp_error($acquired)) {
+            return $acquired;
+        }
+
+        try {
+            return call_user_func($callback);
+        } catch (Throwable $exception) {
+            if ($this->transaction_active) {
+                $rollback = $this->rollback_transaction();
+                if (is_wp_error($rollback)) {
+                    return $rollback;
+                }
+            }
+
+            return new WP_Error(
+                'digitalogic_import_freight_unexpected_write_failure',
+                __('The import freight change could not be completed.', 'digitalogic'),
+                array('status' => 500, 'exception' => get_class($exception))
+            );
+        } finally {
+            $this->release_catalog_lock();
+        }
+    }
+
+    private function acquire_catalog_lock() {
+        if ($this->catalog_lock_depth > 0) {
+            $this->catalog_lock_depth++;
+            return true;
+        }
+
+        global $wpdb;
+        if (!is_object($wpdb) || !method_exists($wpdb, 'get_var') || !method_exists($wpdb, 'prepare')) {
+            return new WP_Error(
+                'digitalogic_import_freight_lock_unavailable',
+                __('The database lock service is unavailable.', 'digitalogic'),
+                array('status' => 503)
+            );
+        }
+
+        $prefix = isset($wpdb->prefix) ? (string) $wpdb->prefix : 'wp_';
+        $lock_name = substr(self::CATALOG_LOCK_NAME . '_' . md5($prefix), 0, 64);
+        $locked = $wpdb->get_var($wpdb->prepare(
+            'SELECT GET_LOCK(%s, %d)',
+            $lock_name,
+            self::CATALOG_LOCK_TIMEOUT_SECONDS
+        ));
+        if ('1' !== (string) $locked) {
+            return new WP_Error(
+                'digitalogic_import_freight_catalog_busy',
+                __('Another import freight update is already running. Please retry.', 'digitalogic'),
+                array('status' => 503, 'retryable' => true)
+            );
+        }
+
+        $this->catalog_lock_depth = 1;
+        return true;
+    }
+
+    private function release_catalog_lock() {
+        if ($this->catalog_lock_depth <= 0) {
+            return;
+        }
+        $this->catalog_lock_depth--;
+        if ($this->catalog_lock_depth > 0) {
+            return;
+        }
+
+        global $wpdb;
+        if (!is_object($wpdb) || !method_exists($wpdb, 'get_var') || !method_exists($wpdb, 'prepare')) {
+            return;
+        }
+
+        $prefix = isset($wpdb->prefix) ? (string) $wpdb->prefix : 'wp_';
+        $lock_name = substr(self::CATALOG_LOCK_NAME . '_' . md5($prefix), 0, 64);
+        $wpdb->get_var($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $lock_name));
+    }
+
+    private function run_transaction($callback) {
+        $started = $this->begin_transaction();
+        if (is_wp_error($started)) {
+            return $started;
+        }
+
+        try {
+            $result = call_user_func($callback);
+        } catch (Throwable $exception) {
+            $rollback = $this->rollback_transaction();
+            if (is_wp_error($rollback)) {
+                return $rollback;
+            }
+            return new WP_Error(
+                'digitalogic_import_freight_transaction_exception',
+                __('The import freight transaction was rolled back.', 'digitalogic'),
+                array('status' => 500, 'exception' => get_class($exception))
+            );
+        }
+
+        if (is_wp_error($result)) {
+            $rollback = $this->rollback_transaction();
+            return is_wp_error($rollback) ? $rollback : $result;
+        }
+
+        $committed = $this->commit_transaction();
+        if (is_wp_error($committed)) {
+            $rollback = $this->rollback_transaction();
+            return is_wp_error($rollback) ? $rollback : $committed;
+        }
+
+        return $result;
+    }
+
+    private function begin_transaction() {
+        if ($this->transaction_active) {
+            return new WP_Error(
+                'digitalogic_import_freight_nested_transaction',
+                __('Nested import freight transactions are not supported.', 'digitalogic'),
+                array('status' => 500)
+            );
+        }
+
+        global $wpdb;
+        if (!is_object($wpdb) || !method_exists($wpdb, 'query') || false === $wpdb->query('START TRANSACTION')) {
+            return new WP_Error(
+                'digitalogic_import_freight_transaction_unavailable',
+                __('The database could not start an import freight transaction.', 'digitalogic'),
+                array('status' => 503)
+            );
+        }
+
+        $this->transaction_active = true;
+        $this->transaction_option_names = array();
+        $this->transaction_post_ids = array();
+        $this->transaction_hook_events = array();
+        return true;
+    }
+
+    private function commit_transaction() {
+        global $wpdb;
+        if (!$this->transaction_active || false === $wpdb->query('COMMIT')) {
+            return new WP_Error(
+                'digitalogic_import_freight_commit_failed',
+                __('The import freight transaction could not be committed.', 'digitalogic'),
+                array('status' => 500)
+            );
+        }
+
+        $option_names = $this->transaction_option_names;
+        $post_ids = $this->transaction_post_ids;
+        $hook_events = $this->transaction_hook_events;
+        $this->transaction_active = false;
+        $this->transaction_option_names = array();
+        $this->transaction_post_ids = array();
+        $this->transaction_hook_events = array();
+        $this->invalidate_transaction_caches($option_names, $post_ids);
+        $this->dispatch_committed_storage_hooks($hook_events);
+        return true;
+    }
+
+    private function rollback_transaction() {
+        global $wpdb;
+        $option_names = $this->transaction_option_names;
+        $post_ids = $this->transaction_post_ids;
+        $rollback_failed = $this->transaction_active
+            && (!is_object($wpdb) || !method_exists($wpdb, 'query') || false === $wpdb->query('ROLLBACK'));
+
+        $this->transaction_active = false;
+        $this->transaction_option_names = array();
+        $this->transaction_post_ids = array();
+        $this->transaction_hook_events = array();
+        $this->invalidate_transaction_caches($option_names, $post_ids);
+
+        if ($rollback_failed) {
+            return new WP_Error(
+                'digitalogic_import_freight_rollback_failed',
+                __('The database could not roll back the failed import freight change.', 'digitalogic'),
+                array('status' => 500)
+            );
+        }
+
+        return true;
+    }
+
+    private function invalidate_transaction_caches($option_names, $post_ids) {
+        if (!function_exists('wp_cache_delete')) {
+            return;
+        }
+
+        foreach (array_keys((array) $option_names) as $option_name) {
+            wp_cache_delete($option_name, 'options');
+        }
+        if (!empty($option_names)) {
+            wp_cache_delete('alloptions', 'options');
+            wp_cache_delete('notoptions', 'options');
+        }
+        foreach (array_keys((array) $post_ids) as $post_id) {
+            wp_cache_delete((int) $post_id, 'post_meta');
+        }
+    }
+
+    private function dispatch_committed_storage_hooks($events) {
+        $previous_legacy_rate_guard = $this->syncing_legacy_rate;
+        $previous_legacy_meta_guard = $this->syncing_legacy_meta;
+        $this->syncing_legacy_rate = true;
+        $this->syncing_legacy_meta = true;
+        try {
+            foreach ((array) $events as $event) {
+                if (!isset($event['hook'], $event['args'])) {
+                    continue;
+                }
+                if ('updated_option' === $event['hook']) {
+                    $this->safe_do_action('update_option', $event['args'][0], $event['args'][1], $event['args'][2]);
+                    $this->safe_do_action('update_option_' . $event['args'][0], $event['args'][1], $event['args'][2], $event['args'][0]);
+                } elseif ('added_option' === $event['hook']) {
+                    $this->safe_do_action('add_option', $event['args'][0], $event['args'][1]);
+                    $this->safe_do_action('add_option_' . $event['args'][0], $event['args'][0], $event['args'][1]);
+                } elseif ('deleted_option' === $event['hook']) {
+                    $this->safe_do_action('delete_option', $event['args'][0]);
+                    $this->safe_do_action('delete_option_' . $event['args'][0], $event['args'][0]);
+                }
+                $this->safe_do_action($event['hook'], ...$event['args']);
+            }
+        } finally {
+            $this->syncing_legacy_rate = $previous_legacy_rate_guard;
+            $this->syncing_legacy_meta = $previous_legacy_meta_guard;
+        }
+    }
+
+    private function safe_do_action($hook, ...$args) {
+        try {
+            do_action($hook, ...$args);
+            return true;
+        } catch (Throwable $exception) {
+            error_log(sprintf(
+                '[Digitalogic import freight] Listener for %s failed after commit: %s',
+                $hook,
+                $exception->getMessage()
+            ));
+            return false;
+        }
+    }
+
+    private function emit_domain_action($hook, ...$args) {
+        $warnings = array();
+
+        // Built-in and third-party result-aware transports run independently,
+        // so one exception or false/void result cannot prevent later channels.
+        foreach ($this->delivery_channels as $channel => $callback) {
+            try {
+                $result = call_user_func($callback, $hook, $args);
+                if (true === $result) {
+                    continue;
+                }
+
+                if (is_wp_error($result)) {
+                    $warnings[] = 'event_delivery_failed:' . $channel . ':' . sanitize_key($result->get_error_code());
+                } else {
+                    $warnings[] = 'event_delivery_unconfirmed:' . $channel;
+                }
+            } catch (Throwable $exception) {
+                error_log(sprintf(
+                    '[Digitalogic import freight] Delivery channel %s failed after commit: %s',
+                    $channel,
+                    $exception->getMessage()
+                ));
+                $warnings[] = 'event_delivery_failed:' . $channel . ':exception';
+            }
+        }
+
+        // Preserve the public domain actions for existing integrations. The
+        // result-aware transports above no longer depend on this action fanout.
+        if (!$this->safe_do_action($hook, ...$args)) {
+            $warnings[] = 'event_delivery_failed:' . $hook;
+        }
+
+        return array_values(array_unique($warnings));
+    }
+
+    private function store_option_verified($name, $value, $error_code) {
+        return $this->store_option_state_verified($name, true, $value, $error_code);
+    }
+
+    private function store_option_state_verified($name, $desired_exists, $value, $error_code) {
+        if (!$this->transaction_active) {
+            return new WP_Error(
+                'digitalogic_import_freight_transaction_required',
+                __('Import freight storage writes require an active transaction.', 'digitalogic'),
+                array('status' => 500)
+            );
+        }
+
+        $old = $this->read_option_db($name, true);
+        $old_value = $old['value'];
+        $old_exists = $old['exists'];
+        if ($this->option_row_matches($old, $desired_exists, $value)) {
+            return array('changed' => false);
+        }
+
+        $this->transaction_option_names[$name] = true;
+        if (!$this->write_option_db($name, $desired_exists, $value)) {
+            return new WP_Error(
+                $error_code,
+                __('The import freight option could not be saved.', 'digitalogic'),
+                array('status' => 500, 'option' => $name)
+            );
+        }
+        $stored = $this->read_option_db($name, true);
+        if (!$this->option_row_matches($stored, $desired_exists, $value)) {
+            return new WP_Error(
+                $error_code,
+                __('The import freight option could not be saved.', 'digitalogic'),
+                array('status' => 500, 'option' => $name)
+            );
+        }
+
+        if (!$desired_exists) {
+            $this->transaction_hook_events[] = array('hook' => 'deleted_option', 'args' => array($name));
+        } elseif ($old_exists) {
+            $this->transaction_hook_events[] = array('hook' => 'updated_option', 'args' => array($name, $old_value, $value));
+        } else {
+            $this->transaction_hook_events[] = array('hook' => 'added_option', 'args' => array($name, $value));
+        }
+
+        return array('changed' => true);
+    }
+
+    private function store_post_meta_verified($post_id, $key, $value) {
+        if (!$this->transaction_active) {
+            return new WP_Error(
+                'digitalogic_import_freight_transaction_required',
+                __('Import freight storage writes require an active transaction.', 'digitalogic'),
+                array('status' => 500)
+            );
+        }
+
+        $old = $this->read_post_meta_db($post_id, $key, true);
+        $old_exists = $old['exists'];
+        $old_value = $old['value'];
+        $value = (string) $value;
+        if ($this->transaction_active) {
+            $this->transaction_post_ids[(int) $post_id] = true;
+        }
+
+        $desired_exists = $value !== '';
+        if ($old_exists === $desired_exists && (!$desired_exists || (string) $old_value === $value)) {
+            return array('changed' => false);
+        }
+
+        if (!$this->write_post_meta_db($post_id, $key, $desired_exists, $value)) {
+            return new WP_Error(
+                'digitalogic_import_freight_meta_write_failed',
+                __('The product import freight assignment could not be saved.', 'digitalogic'),
+                array('status' => 500, 'product_id' => (int) $post_id, 'meta_key' => $key)
+            );
+        }
+        $stored = $this->read_post_meta_db($post_id, $key, true);
+        if (($desired_exists && (!$stored['exists'] || (string) $stored['value'] !== $value)) || (!$desired_exists && $stored['exists'])) {
+            return new WP_Error(
+                'digitalogic_import_freight_meta_write_failed',
+                __('The product import freight assignment could not be saved.', 'digitalogic'),
+                array('status' => 500, 'product_id' => (int) $post_id, 'meta_key' => $key)
+            );
+        }
+
+        if (!$desired_exists) {
+            $this->transaction_hook_events[] = array(
+                'hook' => 'deleted_post_meta',
+                'args' => array(array($old['meta_id']), (int) $post_id, $key, $old_value),
+            );
+        } elseif ($old_exists) {
+            $this->transaction_hook_events[] = array(
+                'hook' => 'updated_post_meta',
+                'args' => array($old['meta_id'], (int) $post_id, $key, $value),
+            );
+        } else {
+            $this->transaction_hook_events[] = array(
+                'hook' => 'added_post_meta',
+                'args' => array($stored['meta_id'], (int) $post_id, $key, $value),
+            );
+        }
+
+        return array('changed' => true);
+    }
+
+    private function field_value_for_method($method) {
+        return !empty($method['legacy_key']) ? (string) $method['legacy_key'] : (string) $method['id'];
+    }
+
+    private function restore_legacy_assignment_in_transaction($product_id, $canonical_id, $methods) {
+        $desired = $canonical_id !== '' && isset($methods[$canonical_id])
+            ? $this->field_value_for_method($methods[$canonical_id])
+            : '';
+
+        return $this->store_post_meta_verified(
+            $product_id,
+            self::LEGACY_PRODUCT_METHOD_META,
+            $desired
+        );
+    }
+
+    private function restore_legacy_assignment_cas($product_id, $attempted_value, $methods) {
+        return $this->run_transaction(function() use ($product_id, $attempted_value, $methods) {
+            $legacy = $this->read_post_meta_db($product_id, self::LEGACY_PRODUCT_METHOD_META, true);
+            if (!$legacy['exists'] || (string) $legacy['value'] !== (string) $attempted_value) {
+                return array('changed' => false, 'stale' => true);
+            }
+
+            $canonical = $this->read_post_meta_db($product_id, self::PRODUCT_METHOD_META, true);
+            $canonical_id = $canonical['exists'] ? (string) $canonical['value'] : '';
+            return $this->restore_legacy_assignment_in_transaction(
+                $product_id,
+                $canonical_id,
+                $methods
+            );
+        });
+    }
+
+    private function build_markup_contract($product_id) {
+        $type = sanitize_key((string) get_post_meta($product_id, '_digitalogic_markup_type', true));
+        $raw_value = get_post_meta($product_id, '_digitalogic_markup', true);
+        $value = $this->number_or_null($raw_value);
+        $profit_percent = null;
+        $warning = null;
+
+        if ($type === 'percentage' && !is_null($value)) {
+            $profit_percent = $value;
+        } elseif ($type === 'fixed') {
+            $warning = 'fixed_markup_not_supported_by_landed_price_v1';
+        } elseif ($type === 'percentage') {
+            $warning = 'percentage_markup_value_missing';
+        } elseif ($type === '') {
+            $warning = is_null($value) ? 'markup_missing' : 'markup_type_missing';
+        } else {
+            $warning = 'markup_type_unsupported';
+        }
+
+        return array(
+            'type' => $type === '' ? null : $type,
+            'value' => $value,
+            'profit_percent' => $profit_percent,
+            'warning' => $warning,
+        );
+    }
+
+    public function filter_acf_method_field($field) {
+        $methods = $this->list_methods(true);
+        if (is_wp_error($methods) || !is_array($field)) {
+            return $field;
+        }
+
+        $choices = array();
+        foreach ($methods as $method) {
+            $label = (string) $method['name'];
+            if (empty($method['enabled'])) {
+                $label .= ' ' . __('(disabled)', 'digitalogic');
+            }
+            $choices[$this->field_value_for_method($method)] = $label;
+        }
+        $field['choices'] = $choices;
+
+        return $field;
+    }
+
+    public function validate_acf_method_value($valid, $value, $field, $input) {
+        if (true !== $valid) {
+            return $valid;
+        }
+
+        $methods = $this->load_methods();
+        $method_id = $this->legacy_value_to_method_id($value, $methods);
+        if ($method_id === '' || !isset($methods[$method_id])) {
+            return __('Select a valid import freight method.', 'digitalogic');
+        }
+        if (!empty($methods[$method_id]['enabled'])) {
+            return true;
+        }
+
+        $post_id = 0;
+        if (function_exists('acf_get_form_data')) {
+            $post_id = absint(acf_get_form_data('post_id'));
+        }
+        if (!$post_id && isset($_POST['post_ID'])) {
+            $post_id = absint(wp_unslash($_POST['post_ID']));
+        }
+        $current_row = $post_id
+            ? $this->read_post_meta_db($post_id, self::PRODUCT_METHOD_META)
+            : array('exists' => false, 'value' => null);
+        $current = $current_row['exists'] ? (string) $current_row['value'] : '';
+
+        return $current === $method_id
+            ? true
+            : __('Disabled import freight methods cannot be assigned to new products.', 'digitalogic');
+    }
+
+    private function is_product($post_id) {
+        return in_array(get_post_type($post_id), array('product', 'product_variation'), true);
+    }
+
+    private function normalize_code($code) {
+        return is_string($code) || is_int($code) ? trim((string) $code) : '';
+    }
+
+    private function number_or_null($value) {
+        if (is_null($value) || $value === '') {
+            return null;
+        }
+        if (is_string($value)) {
+            $value = str_replace(array(',', '٬', '،', ' '), '', wp_unslash($value));
+        }
+
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        $number = (float) $value;
+        return is_finite($number) ? $number : null;
+    }
+
+    private function nullable_absint($value) {
+        if (is_null($value) || $value === '') {
+            return null;
+        }
+
+        if ((is_int($value) && $value >= 0) || (is_string($value) && preg_match('/^\d+$/', $value))) {
+            return (int) $value;
+        }
+
+        return new WP_Error(
+            'digitalogic_import_freight_transit_invalid',
+            __('Transit days must be non-negative whole numbers.', 'digitalogic'),
+            array('status' => 400)
+        );
+    }
+
+    private function boolean_value($value) {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        return in_array(strtolower((string) $value), array('1', 'true', 'yes', 'on'), true);
+    }
+
+    private function yuan_rate() {
+        if (class_exists('Digitalogic_Options')) {
+            $value = Digitalogic_Options::instance()->get_yuan_price();
+        } else {
+            $value = get_option('options_yuan_price', false);
+            $value = $value === false ? get_option('yuan_price', null) : $value;
+        }
+
+        $value = $this->number_or_null($value);
+        return !is_null($value) && $value > 0 ? $value : null;
+    }
+
+    private function currency_effective_date() {
+        if (class_exists('Digitalogic_Options')) {
+            return (string) Digitalogic_Options::instance()->get_update_date();
+        }
+
+        return (string) get_option('options_update_date', get_option('update_date', ''));
+    }
+
+    private function local_currency() {
+        return function_exists('get_woocommerce_currency') ? (string) get_woocommerce_currency() : 'IRT';
+    }
+
+    private function local_currency_decimals() {
+        return function_exists('wc_get_price_decimals') ? absint(wc_get_price_decimals()) : 0;
+    }
+
+    private function normalize_effective_date($value) {
+        $value = trim((string) $value);
+        if (!preg_match('/^(\d{2})(\d{2})(\d{2})$/', $value, $matches)) {
+            return null;
+        }
+
+        $year = 2000 + (int) $matches[1];
+        $month = (int) $matches[2];
+        $day = (int) $matches[3];
+        if (!checkdate($month, $day, $year)) {
+            return null;
+        }
+
+        return sprintf('%04d-%02d-%02d', $year, $month, $day);
+    }
+}

--- a/includes/class-patris-feed.php
+++ b/includes/class-patris-feed.php
@@ -11,6 +11,13 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+if (!class_exists('Digitalogic_Unit_Converter')) {
+    require_once __DIR__ . '/class-unit-converter.php';
+}
+if (!class_exists('Digitalogic_Product_Identifier_Resolver')) {
+    require_once __DIR__ . '/class-product-identifier-resolver.php';
+}
+
 class Digitalogic_Patris_Feed {
 
     private const SETTINGS_OPTION = 'digitalogic_patris_feed_settings';
@@ -37,11 +44,10 @@ class Digitalogic_Patris_Feed {
         $settings = get_option(self::SETTINGS_OPTION, array());
         $settings = is_array($settings) ? $settings : array();
 
-        return wp_parse_args($settings, array(
+        $settings = wp_parse_args($settings, array(
             'api_url' => '',
             'api_token' => '',
             'selected_warehouses' => array(),
-            'shipping_methods' => array(),
             'legacy_url_replacements' => array(),
             'image_quality_thresholds' => array(
                 'very_low' => 180,
@@ -52,19 +58,21 @@ class Digitalogic_Patris_Feed {
             'stale_after_hours' => 48,
             'sync_interval' => '',
         ));
+
+        unset($settings['shipping_methods']);
+        return $settings;
     }
 
     public function update_settings($settings) {
         $current = $this->get_settings();
         $next = is_array($settings) ? $settings : array();
 
+        // Import freight is now managed by Digitalogic_Import_Freight_Service.
+        // Never revive the former unvalidated, free-form shipping_methods blob.
+        unset($current['shipping_methods'], $next['shipping_methods']);
+
         if (isset($next['selected_warehouses']) && is_string($next['selected_warehouses'])) {
             $next['selected_warehouses'] = array_filter(array_map('trim', explode(',', $next['selected_warehouses'])));
-        }
-
-        if (isset($next['shipping_methods']) && is_string($next['shipping_methods'])) {
-            $decoded = json_decode($next['shipping_methods'], true);
-            $next['shipping_methods'] = is_array($decoded) ? $decoded : array();
         }
 
         if (isset($next['legacy_url_replacements']) && is_string($next['legacy_url_replacements'])) {
@@ -93,9 +101,6 @@ class Digitalogic_Patris_Feed {
         }
         if (isset($settings['selected_warehouses'])) {
             $clean['selected_warehouses'] = array_values(array_filter(array_map('sanitize_text_field', (array) $settings['selected_warehouses'])));
-        }
-        if (isset($settings['shipping_methods'])) {
-            $clean['shipping_methods'] = $this->sanitize_assoc_array($settings['shipping_methods']);
         }
         if (isset($settings['legacy_url_replacements'])) {
             $clean['legacy_url_replacements'] = $this->sanitize_assoc_array($settings['legacy_url_replacements']);
@@ -218,13 +223,27 @@ class Digitalogic_Patris_Feed {
             }
 
             $results['total']++;
+            // Keep the complete normalized upstream snapshot for reporting and
+            // reconciliation even when no unique WooCommerce target exists.
+            // Resolution failures below must never turn into product writes.
             $normalized_products[$product_data['product_code']] = $product_data;
 
-            $product_id = wc_get_product_id_by_sku($product_data['product_code']);
-            if (!$product_id) {
-                $results['missing_in_woocommerce']++;
+            $resolved = Digitalogic_Product_Identifier_Resolver::instance()->resolve(array(
+                'code' => $product_data['product_code'],
+            ));
+            if (is_wp_error($resolved)) {
+                if ('digitalogic_product_identifier_not_found' === $resolved->get_error_code()) {
+                    $results['missing_in_woocommerce']++;
+                } else {
+                    $results['failed']++;
+                    $results['errors'][] = 'digitalogic_product_identifier_ambiguous' === $resolved->get_error_code()
+                        ? __('Skipped product because its exact Code/SKU is ambiguous.', 'digitalogic')
+                        : __('Skipped product because its Code/SKU could not be resolved.', 'digitalogic');
+                }
                 continue;
             }
+
+            $product_id = (int) $resolved['woocommerce_id'];
 
             $product = wc_get_product($product_id);
             if (!$product) {
@@ -378,8 +397,9 @@ class Digitalogic_Patris_Feed {
         $product->update_meta_data('_digitalogic_patris_flags', wp_json_encode($data['flags']));
         $product->update_meta_data('_digitalogic_patris_last_feed', wp_json_encode($data['raw'], JSON_UNESCAPED_UNICODE));
 
-        if ($data['weight_grams'] !== null && $data['weight_grams'] > 0) {
-            $product->set_weight((string) ($data['weight_grams'] / 1000));
+        $store_weight = Digitalogic_Unit_Converter::grams_to_store_weight($data['weight_grams']);
+        if (!is_null($store_weight)) {
+            $product->set_weight((string) $store_weight);
         }
 
         if ($data['total_stock'] !== null) {

--- a/includes/class-product-identifier-resolver.php
+++ b/includes/class-product-identifier-resolver.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Shared exact product identifier resolver.
+ *
+ * Identifiers remain strings at the service boundary. Resolution is exact,
+ * variation-aware, and deliberately never falls back to fuzzy/name matching.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Digitalogic_Product_Identifier_Resolver {
+
+    public const PATRIS_CODE_META = '_digitalogic_patris_product_code';
+    public const SKU_META = '_sku';
+
+    private static $instance = null;
+
+    public static function instance() {
+        if (is_null(self::$instance)) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Resolve the highest-precedence supplied identifier.
+     *
+     * Precedence is explicit WooCommerce ID, exact SKU, exact Patris Code,
+     * then the generic exact code adapter (SKU before Patris Code).
+     *
+     * @param array $identifiers String identifiers.
+     * @return array|WP_Error
+     */
+    public function resolve($identifiers) {
+        if (!is_array($identifiers)) {
+            return $this->invalid('Product identifiers must be supplied as an object.');
+        }
+
+        if (array_key_exists('woocommerce_id', $identifiers) || array_key_exists('product_id', $identifiers)) {
+            $value = array_key_exists('woocommerce_id', $identifiers)
+                ? $identifiers['woocommerce_id']
+                : $identifiers['product_id'];
+            $identifier = $this->normalize_identifier($value, 'WooCommerce product ID', true);
+            if (is_wp_error($identifier)) {
+                return $identifier;
+            }
+            if (!$this->is_canonical_positive_integer($identifier)) {
+                return $this->invalid('WooCommerce product ID must be a canonical positive integer string.');
+            }
+
+            return $this->resolve_woocommerce_id($identifier);
+        }
+
+        if (array_key_exists('sku', $identifiers)) {
+            $sku = $this->normalize_identifier($identifiers['sku'], 'SKU');
+            return is_wp_error($sku) ? $sku : $this->resolve_meta(self::SKU_META, 'sku', $sku);
+        }
+
+        if (array_key_exists('patris_code', $identifiers)) {
+            $code = $this->normalize_identifier($identifiers['patris_code'], 'Patris Code');
+            return is_wp_error($code) ? $code : $this->resolve_meta(self::PATRIS_CODE_META, 'patris_code', $code);
+        }
+
+        if (array_key_exists('code', $identifiers)) {
+            $code = $this->normalize_identifier($identifiers['code'], 'Code/SKU');
+            return is_wp_error($code) ? $code : $this->resolve_code($code);
+        }
+
+        return $this->invalid('A WooCommerce ID, SKU, Patris Code, or generic Code/SKU is required.');
+    }
+
+    /**
+     * Resolve a legacy generic code using exact SKU-before-Patris precedence.
+     */
+    public function resolve_code($code) {
+        $code = $this->normalize_identifier($code, 'Code/SKU');
+        if (is_wp_error($code)) {
+            return $code;
+        }
+
+        global $wpdb;
+        $postmeta = isset($wpdb->postmeta) ? $wpdb->postmeta : $wpdb->prefix . 'postmeta';
+        $current_sku = "COALESCE((SELECT pm_sku_match.meta_value FROM {$postmeta} pm_sku_match
+            WHERE pm_sku_match.post_id = p.ID AND pm_sku_match.meta_key = '" . self::SKU_META . "'
+            ORDER BY pm_sku_match.meta_id DESC LIMIT 1), '')";
+        $current_patris = "COALESCE((SELECT pm_patris_match.meta_value FROM {$postmeta} pm_patris_match
+            WHERE pm_patris_match.post_id = p.ID AND pm_patris_match.meta_key = '" . self::PATRIS_CODE_META . "'
+            ORDER BY pm_patris_match.meta_id DESC LIMIT 1), '')";
+        $rows = $this->query_rows(
+            'code',
+            "(BINARY {$current_sku} = BINARY %s OR BINARY {$current_patris} = BINARY %s)",
+            array($code, $code)
+        );
+
+        $sku_matches = array();
+        $patris_matches = array();
+        foreach ((array) $rows as $row) {
+            if ((string) $row['sku'] === $code) {
+                $sku_matches[] = $row;
+            }
+            if ((string) $row['patris_code'] === $code) {
+                $patris_matches[] = $row;
+            }
+        }
+
+        if (!empty($sku_matches)) {
+            return $this->one_or_ambiguous($sku_matches, 'sku', $code);
+        }
+        if (!empty($patris_matches)) {
+            return $this->one_or_ambiguous($patris_matches, 'patris_code', $code);
+        }
+
+        return $this->not_found('No product has that exact Code or SKU.');
+    }
+
+    private function resolve_woocommerce_id($woocommerce_id) {
+        $rows = $this->query_rows('woocommerce_id', 'p.ID = %d', array((int) $woocommerce_id));
+        if (empty($rows)) {
+            return $this->not_found('No product or variation has that exact WooCommerce ID.');
+        }
+
+        return $this->format_match(reset($rows), 'woocommerce_id', $woocommerce_id);
+    }
+
+    private function resolve_meta($meta_key, $resolved_by, $value) {
+        global $wpdb;
+        $postmeta = isset($wpdb->postmeta) ? $wpdb->postmeta : $wpdb->prefix . 'postmeta';
+        $current_value = "COALESCE((SELECT pm_match.meta_value FROM {$postmeta} pm_match
+            WHERE pm_match.post_id = p.ID AND pm_match.meta_key = %s
+            ORDER BY pm_match.meta_id DESC LIMIT 1), '')";
+        $rows = $this->query_rows(
+            $resolved_by,
+            "BINARY {$current_value} = BINARY %s",
+            array($meta_key, $value)
+        );
+
+        // Defend exactness again in PHP in case a database collation or test
+        // adapter returns a broader row set than the BINARY predicate.
+        $column = self::SKU_META === $meta_key ? 'sku' : 'patris_code';
+        $rows = array_values(array_filter((array) $rows, static function($row) use ($column, $value) {
+            return isset($row[$column]) && (string) $row[$column] === $value;
+        }));
+
+        if (empty($rows)) {
+            return $this->not_found('No product has that exact identifier.');
+        }
+
+        return $this->one_or_ambiguous($rows, $resolved_by, $value);
+    }
+
+    /**
+     * Fetch one deterministic current SKU and Patris Code per candidate in a
+     * single query. Latest meta_id wins when corrupted duplicate rows exist.
+     */
+    private function query_rows($marker, $predicate, $args) {
+        global $wpdb;
+        $posts = isset($wpdb->posts) ? $wpdb->posts : $wpdb->prefix . 'posts';
+        $postmeta = isset($wpdb->postmeta) ? $wpdb->postmeta : $wpdb->prefix . 'postmeta';
+        $query = "/* digitalogic_identifier:{$marker} */
+            SELECT p.ID, p.post_type,
+                COALESCE((
+                    SELECT pm_sku.meta_value FROM {$postmeta} pm_sku
+                    WHERE pm_sku.post_id = p.ID AND pm_sku.meta_key = '" . self::SKU_META . "'
+                    ORDER BY pm_sku.meta_id DESC LIMIT 1
+                ), '') AS sku,
+                COALESCE((
+                    SELECT pm_patris.meta_value FROM {$postmeta} pm_patris
+                    WHERE pm_patris.post_id = p.ID AND pm_patris.meta_key = '" . self::PATRIS_CODE_META . "'
+                    ORDER BY pm_patris.meta_id DESC LIMIT 1
+                ), '') AS patris_code
+            FROM {$posts} p
+            WHERE p.post_type IN ('product', 'product_variation')
+                AND p.post_status NOT IN ('trash', 'auto-draft')
+                AND {$predicate}
+            ORDER BY p.ID ASC";
+
+        return $wpdb->get_results($wpdb->prepare($query, ...$args), ARRAY_A);
+    }
+
+    private function one_or_ambiguous($rows, $resolved_by, $value) {
+        if (count($rows) > 1) {
+            return new WP_Error(
+                'digitalogic_product_identifier_ambiguous',
+                __('More than one product has that exact identifier.', 'digitalogic'),
+                array(
+                    'status' => 409,
+                    'resolved_by' => $resolved_by,
+                    'woocommerce_ids' => array_values(array_map(static function($row) {
+                        return (string) $row['ID'];
+                    }, $rows)),
+                )
+            );
+        }
+
+        return $this->format_match(reset($rows), $resolved_by, $value);
+    }
+
+    private function format_match($row, $resolved_by, $identifier) {
+        return array(
+            'woocommerce_id' => (string) $row['ID'],
+            'post_type' => (string) $row['post_type'],
+            'sku' => isset($row['sku']) ? (string) $row['sku'] : '',
+            'patris_code' => isset($row['patris_code']) ? (string) $row['patris_code'] : '',
+            'identifier' => (string) $identifier,
+            'resolved_by' => (string) $resolved_by,
+        );
+    }
+
+    private function normalize_identifier($value, $label, $allow_integer = false) {
+        if (!is_string($value) && !($allow_integer && is_int($value))) {
+            return $this->invalid($label . ' must be a string.');
+        }
+
+        $value = trim((string) $value);
+        if ($value === '' || strlen($value) > 191 || preg_match('/[\x00-\x1F\x7F]/', $value)) {
+            return $this->invalid($label . ' is empty or invalid.');
+        }
+
+        return $value;
+    }
+
+    private function is_canonical_positive_integer($value) {
+        if (!preg_match('/^[1-9][0-9]*$/', $value)) {
+            return false;
+        }
+
+        $maximum = (string) PHP_INT_MAX;
+        return strlen($value) < strlen($maximum)
+            || (strlen($value) === strlen($maximum) && strcmp($value, $maximum) <= 0);
+    }
+
+    private function invalid($message) {
+        return new WP_Error(
+            'digitalogic_invalid_product_identifier',
+            __($message, 'digitalogic'),
+            array('status' => 400)
+        );
+    }
+
+    private function not_found($message) {
+        return new WP_Error(
+            'digitalogic_product_identifier_not_found',
+            __($message, 'digitalogic'),
+            array('status' => 404)
+        );
+    }
+}

--- a/includes/class-report-engine.php
+++ b/includes/class-report-engine.php
@@ -24,6 +24,9 @@ class Digitalogic_Report_Engine {
         $feed_products = $feed->get_products();
         $feed_customers = $feed->get_customers();
         $settings = $feed->get_settings();
+        $catalog = Digitalogic_Import_Freight_Service::instance()->get_integration_catalog();
+        $catalog_error = is_wp_error($catalog) ? $catalog : null;
+        $freight_methods = $catalog_error ? array() : $catalog['import_freight_methods'];
         $products = $this->get_woocommerce_products();
         $by_sku = $this->index_products_by_sku($products);
 
@@ -140,7 +143,12 @@ class Digitalogic_Report_Engine {
             ),
             'settings' => array(
                 'selected_warehouses' => $settings['selected_warehouses'],
-                'shipping_methods' => $settings['shipping_methods'],
+                // Backward-compatible report key; values now come from the
+                // validated supplier-import catalog, never Woo delivery APIs.
+                'shipping_methods' => $freight_methods,
+                'import_freight_methods' => $freight_methods,
+                'integration_catalog_revision' => $catalog_error ? null : $catalog['revision'],
+                'integration_catalog_error' => $catalog_error ? $catalog_error->get_error_code() : null,
                 'stale_after_hours' => $settings['stale_after_hours'],
             ),
             'last_sync' => $feed->get_last_sync(),

--- a/includes/class-unit-converter.php
+++ b/includes/class-unit-converter.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Canonical unit conversions shared by Patris ingestion and pricing flows.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Digitalogic_Unit_Converter {
+
+    /**
+     * Convert a positive gram value to the WooCommerce store weight unit.
+     *
+     * @param mixed $weight_grams Source weight in grams.
+     * @return float|null Converted positive finite weight, or null when invalid.
+     */
+    public static function grams_to_store_weight($weight_grams) {
+        if (!is_numeric($weight_grams)) {
+            return null;
+        }
+
+        $weight_grams = (float) $weight_grams;
+        if (!is_finite($weight_grams) || $weight_grams <= 0) {
+            return null;
+        }
+
+        $store_unit = trim((string) get_option('woocommerce_weight_unit', 'kg'));
+        if ($store_unit === '') {
+            $store_unit = 'kg';
+        }
+
+        $converted = wc_get_weight($weight_grams, $store_unit, 'g');
+        if (!is_numeric($converted)) {
+            return null;
+        }
+
+        $converted = (float) $converted;
+        return is_finite($converted) && $converted > 0 ? $converted : null;
+    }
+}

--- a/includes/panel/class-panel.php
+++ b/includes/panel/class-panel.php
@@ -28,6 +28,8 @@ class Digitalogic_Panel {
             self::$instance = new self();
         }
 
+        self::$instance->register_import_freight_delivery_channel();
+
         return self::$instance;
     }
 
@@ -47,6 +49,13 @@ class Digitalogic_Panel {
         add_filter('posts_search', array($this, 'extend_product_search'), 10, 2);
         add_action('wp_footer', array($this, 'hide_wp_armour_honeypot_notice'), 1000);
         add_action('admin_footer', array($this, 'hide_wp_armour_honeypot_notice'), 1000);
+    }
+
+    private function register_import_freight_delivery_channel() {
+        Digitalogic_Import_Freight_Service::instance()->register_delivery_channel(
+            'panel',
+            array($this, 'deliver_import_freight_event')
+        );
     }
 
     public function register_route() {
@@ -585,15 +594,107 @@ class Digitalogic_Panel {
         }
     }
 
+    public function record_import_freight_method_created($method) {
+        return $this->record_import_freight_method_event('import_freight.method.created', $method);
+    }
+
+    public function record_import_freight_method_updated($method) {
+        return $this->record_import_freight_method_event('import_freight.method.updated', $method);
+    }
+
+    public function record_import_freight_method_deleted($method) {
+        return $this->record_import_freight_method_event('import_freight.method.deleted', $method);
+    }
+
+    public function record_import_freight_assignment_event($product_id, $method_id) {
+        return self::record_event('import_freight.assignment.updated', array(
+            'product_id' => absint($product_id),
+            'import_freight_method_id' => sanitize_key((string) $method_id),
+        ));
+    }
+
+    private function record_import_freight_method_event($event, $method) {
+        $method = is_array($method) ? $method : array();
+        return self::record_event($event, array(
+            'id' => isset($method['id']) ? sanitize_key($method['id']) : '',
+            'name' => isset($method['name']) ? sanitize_text_field($method['name']) : '',
+            'enabled' => !empty($method['enabled']),
+            'price_per_kg_cny' => isset($method['price_per_kg_cny']) ? (float) $method['price_per_kg_cny'] : null,
+        ));
+    }
+
+    /**
+     * Result-aware import-freight delivery channel used after service commits.
+     */
+    public function deliver_import_freight_event($hook, $args) {
+        $args = is_array($args) ? $args : array();
+        if ('digitalogic_product_import_freight_method_updated' === $hook) {
+            $event = 'import_freight.assignment.updated';
+            $data = array(
+                'product_id' => absint(isset($args[0]) ? $args[0] : 0),
+                'import_freight_method_id' => sanitize_key((string) (isset($args[1]) ? $args[1] : '')),
+            );
+        } else {
+            $events = array(
+                'digitalogic_import_freight_method_created' => 'import_freight.method.created',
+                'digitalogic_import_freight_method_updated' => 'import_freight.method.updated',
+                'digitalogic_import_freight_method_deleted' => 'import_freight.method.deleted',
+            );
+            if (!isset($events[$hook])) {
+                return new WP_Error(
+                    'digitalogic_panel_delivery_event_unknown',
+                    __('The panel does not recognize this import freight event.', 'digitalogic')
+                );
+            }
+
+            $event = $events[$hook];
+            $method = isset($args[0]) && is_array($args[0]) ? $args[0] : array();
+            $data = array(
+                'id' => isset($method['id']) ? sanitize_key($method['id']) : '',
+                'name' => isset($method['name']) ? sanitize_text_field($method['name']) : '',
+                'enabled' => !empty($method['enabled']),
+                'price_per_kg_cny' => isset($method['price_per_kg_cny']) ? (float) $method['price_per_kg_cny'] : null,
+            );
+        }
+
+        $result = self::record_event_result($event, $data);
+        if (is_wp_error($result)) {
+            return $result;
+        }
+        if (!empty($result['delivery_warnings'])) {
+            return new WP_Error(
+                'digitalogic_panel_delivery_failed',
+                __('The panel event was stored, but one or more real-time deliveries failed.', 'digitalogic'),
+                array('warnings' => $result['delivery_warnings'])
+            );
+        }
+
+        return true;
+    }
+
     public static function record_event($event, $data = array()) {
+        $result = self::record_event_result($event, $data);
+        return is_wp_error($result) ? null : $result['event'];
+    }
+
+    /**
+     * Persist and publish an event while retaining per-channel outcome data.
+     *
+     * @return array{event:array,delivery_warnings:array}|WP_Error
+     */
+    public static function record_event_result($event, $data = array()) {
         $lock = self::acquire_event_lock();
         if ($lock === false) {
             self::report_event_delivery_failure('Could not acquire the database event lock; the event was not recorded.');
-            return null;
+            return new WP_Error(
+                'digitalogic_panel_queue_lock_failed',
+                __('The panel event queue lock could not be acquired.', 'digitalogic')
+            );
         }
 
         $stored = false;
         $event_envelope = null;
+        $delivery_warnings = array();
 
         try {
             self::refresh_event_option_cache(true);
@@ -623,6 +724,7 @@ class Digitalogic_Panel {
 
             if (!update_option(self::EVENT_SEQUENCE_OPTION, $event_id, false)) {
                 self::report_event_delivery_failure('The durable event sequence could not be updated.');
+                $delivery_warnings[] = 'panel_sequence_write_failed';
             }
 
             $stored = update_option(self::EVENT_OPTION, $events, false);
@@ -632,12 +734,20 @@ class Digitalogic_Panel {
 
         if (!$stored || !is_array($event_envelope)) {
             self::report_event_delivery_failure('The panel event queue could not be updated; Redis publication was skipped.');
-            return null;
+            return new WP_Error(
+                'digitalogic_panel_queue_write_failed',
+                __('The panel event queue could not be updated.', 'digitalogic')
+            );
         }
 
-        self::publish_event($event_envelope);
+        if (!self::publish_event($event_envelope)) {
+            $delivery_warnings[] = 'panel_redis_delivery_failed';
+        }
 
-        return $event_envelope;
+        return array(
+            'event' => $event_envelope,
+            'delivery_warnings' => array_values(array_unique($delivery_warnings)),
+        );
     }
 
     /**
@@ -704,6 +814,7 @@ class Digitalogic_Panel {
         $redis = apply_filters('digitalogic_panel_redis_client', null);
         if ($redis === null) {
             if (!class_exists('Redis')) {
+                self::report_event_delivery_failure('The Redis extension is unavailable.');
                 return false;
             }
 

--- a/tests/ImportFreightServiceTest.php
+++ b/tests/ImportFreightServiceTest.php
@@ -1,0 +1,1020 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ImportFreightServiceTest extends TestCase {
+    /** @var Digitalogic_Import_Freight_Service */
+    private $service;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $GLOBALS['digitalogic_test_options'] = array(
+            'options_express' => '85',
+            'options_aerial' => '80',
+            'options_marine' => '50',
+            'options_yuan_price' => '25300',
+            'options_update_date' => '260716',
+            'digitalogic_patris_feed_settings' => array(
+                'selected_warehouses' => array('tehran', 'shenzhen'),
+                'shipping_methods' => array('deprecated' => 999),
+                'image_quality_thresholds' => array('soft_review' => 450),
+            ),
+        );
+        $GLOBALS['digitalogic_test_posts'] = array();
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_post_meta_cache'] = array();
+        $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_action_callbacks'] = array();
+        $GLOBALS['digitalogic_test_filters'] = array();
+        $GLOBALS['digitalogic_test_routes'] = array();
+        $GLOBALS['digitalogic_test_capabilities'] = array();
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_meta_update_failures'] = array();
+        $GLOBALS['digitalogic_test_meta_delete_failures'] = array();
+        $GLOBALS['digitalogic_test_transaction_failures'] = array();
+        $GLOBALS['digitalogic_test_cache_deletes'] = array();
+        $GLOBALS['digitalogic_test_remote_posts'] = array();
+        $GLOBALS['digitalogic_test_remote_post_results'] = array();
+        $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
+        $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
+        $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
+        $_POST = array();
+
+        $this->resetSingleton(Digitalogic_Import_Freight_Service::class);
+        $this->resetSingleton(Digitalogic_Patris_Feed::class);
+        $this->resetSingleton(Digitalogic_Command_Dispatcher::class);
+        $this->resetSingleton(Digitalogic_REST_API::class);
+        $this->resetSingleton(Digitalogic_Report_Engine::class);
+        $this->resetSingleton(Digitalogic_Panel::class);
+        $this->resetSingleton(Digitalogic_Webhooks::class);
+        $this->service = Digitalogic_Import_Freight_Service::instance();
+    }
+
+    public function test_current_acf_migration_is_idempotent_and_preserves_reference_meta() {
+        $GLOBALS['digitalogic_test_posts'][101] = array(
+            'post_type' => 'product',
+            'meta' => array(
+                '_sku' => '113007045',
+                'shipping_method' => 'express',
+                '_shipping_method' => 'field_custom_existing',
+            ),
+        );
+
+        $first = $this->service->migrate_legacy_data();
+        $methods = $this->indexMethods($this->service->list_methods());
+
+        $this->assertTrue($first['catalog_seeded']);
+        $this->assertSame(1, $first['assignments_migrated']);
+        $this->assertSame(85.0, $methods['air_express']['price_per_kg_cny']);
+        $this->assertSame(80.0, $methods['air_freight']['price_per_kg_cny']);
+        $this->assertSame(50.0, $methods['sea_freight']['price_per_kg_cny']);
+        $this->assertSame('air_express', get_post_meta(101, '_digitalogic_import_freight_method_id', true));
+        $this->assertSame('field_custom_existing', get_post_meta(101, '_shipping_method', true));
+
+        $snapshot = $GLOBALS['digitalogic_test_options'][Digitalogic_Import_Freight_Service::METHODS_OPTION];
+        $second = $this->service->migrate_legacy_data();
+
+        $this->assertFalse($second['migrated']);
+        $this->assertSame(0, $second['assignments_migrated']);
+        $this->assertSame($snapshot, $GLOBALS['digitalogic_test_options'][Digitalogic_Import_Freight_Service::METHODS_OPTION]);
+        $this->assertSame('field_custom_existing', get_post_meta(101, '_shipping_method', true));
+    }
+
+    public function test_legacy_acf_changes_remain_bidirectionally_compatible() {
+        $GLOBALS['digitalogic_test_posts'][102] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'CODE-102', 'shipping_method' => 'aerial'),
+        );
+        $this->service->migrate_legacy_data();
+
+        $this->assertSame('air_freight', get_post_meta(102, '_digitalogic_import_freight_method_id', true));
+        $this->assertSame('field_694534693f9ba', get_post_meta(102, '_shipping_method', true));
+
+        update_post_meta(102, 'shipping_method', 'marine');
+        $this->assertSame('sea_freight', get_post_meta(102, '_digitalogic_import_freight_method_id', true));
+
+        $assignment = $this->service->assign_product_by_code('CODE-102', 'air_express');
+        $this->assertSame('air_express', $assignment['import_freight_method_id']);
+        $this->assertSame('express', get_post_meta(102, 'shipping_method', true));
+        $this->assertSame('field_694534693f9ba', get_post_meta(102, '_shipping_method', true));
+
+        $this->service->assign_product_by_code('CODE-102', null);
+        $this->assertSame('', get_post_meta(102, '_digitalogic_import_freight_method_id', true));
+        $this->assertSame('', get_post_meta(102, 'shipping_method', true));
+        $this->assertSame('field_694534693f9ba', get_post_meta(102, '_shipping_method', true));
+    }
+
+    public function test_catalog_revision_is_stable_and_covers_formula_rate_methods_and_warehouses() {
+        $this->service->migrate_legacy_data();
+        $first = $this->service->get_integration_catalog();
+        $again = $this->service->get_integration_catalog();
+
+        $this->assertSame('digitalogic.integration-catalog', $first['schema']);
+        $this->assertSame('landed_price_v1', $first['pricing']['formula_id']);
+        $this->assertSame(
+            '((weight_g * freight_cny_per_kg / 1000) + foreign_price_cny) * (1 + profit_percent / 100) * cny_to_irt',
+            $first['pricing']['expression']
+        );
+        $this->assertSame(25300.0, $first['currency']['cny_to_irt']);
+        $this->assertSame(25300.0, $first['currency']['cny_to_local']);
+        $this->assertSame('IRT', $first['currency']['local']);
+        $this->assertSame('2026-07-16', $first['currency']['effective_date']);
+        $this->assertSame('260716', $first['currency']['source_effective_date']);
+        $this->assertSame(array('shenzhen', 'tehran'), $first['selected_warehouses']);
+        $this->assertSame($first['revision'], $again['revision']);
+
+        $updated = $this->service->update_method('air_express', array('price_per_kg_cny' => 86));
+        $changed = $this->service->get_integration_catalog();
+
+        $this->assertSame(86.0, $updated['price_per_kg_cny']);
+        $this->assertSame(86.0, get_option('options_express'));
+        $this->assertNotSame($first['revision'], $changed['revision']);
+        $this->assertArrayHasKey('minimum_charge_cny', $updated);
+        $this->assertArrayHasKey('billable_weight_rule', $updated);
+        $this->assertArrayHasKey('volumetric_divisor_cm3_per_kg', $updated);
+        $this->assertArrayHasKey('transit_days_min', $updated);
+        $this->assertArrayHasKey('metadata', $updated);
+        $this->assertArrayHasKey('tiered_rates', $updated);
+
+        update_option('options_express', 87);
+        do_action('updated_option', 'options_express', 86, 87);
+        $this->assertSame(87.0, $this->service->get_method('air_express')['price_per_kg_cny']);
+    }
+
+    public function test_crud_enforces_immutable_ids_delete_conflict_and_disable_semantics() {
+        $GLOBALS['digitalogic_test_posts'][201] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'P-201'),
+        );
+        $GLOBALS['digitalogic_test_posts'][202] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'P-202'),
+        );
+        $this->service->migrate_legacy_data();
+
+        $created = $this->service->create_method(array(
+            'id' => 'rail_freight',
+            'name' => 'Rail Freight',
+            'price_per_kg_cny' => 42,
+            'minimum_charge_cny' => 10,
+            'billable_weight_rule' => 'greater_of',
+            'volumetric_divisor_cm3_per_kg' => 6000,
+            'transit_days_min' => 12,
+            'transit_days_max' => 20,
+            'metadata' => array('provider' => 'example'),
+            'tiered_rates' => array(
+                array('min_weight_kg' => 10, 'max_weight_kg' => null, 'price_per_kg_cny' => 39),
+            ),
+        ));
+        $this->assertSame('rail_freight', $created['id']);
+
+        $this->service->assign_product_by_code('P-201', 'rail_freight');
+        $conflict = $this->service->delete_method('rail_freight');
+        $this->assertTrue(is_wp_error($conflict));
+        $this->assertSame(409, $conflict->get_error_data()['status']);
+        $this->assertSame(1, $conflict->get_error_data()['assigned_products']);
+
+        $disabled = $this->service->update_method('rail_freight', array('enabled' => false));
+        $this->assertFalse($disabled['enabled']);
+        $this->assertSame('rail_freight', $this->service->get_product_assignment_by_code('P-201')['import_freight_method_id']);
+        $disabled_assignment = $this->service->assign_product_by_code('P-202', 'rail_freight');
+        $this->assertSame('digitalogic_import_freight_method_disabled', $disabled_assignment->get_error_code());
+
+        $immutable = $this->service->update_method('rail_freight', array('id' => 'renamed_freight'));
+        $this->assertSame('digitalogic_import_freight_method_id_immutable', $immutable->get_error_code());
+
+        $unassigned = $this->service->create_method(array('id' => 'courier_freight', 'name' => 'Courier', 'price_per_kg_cny' => 90));
+        $this->assertSame('courier_freight', $unassigned['id']);
+        $this->assertSame(array('deleted' => true, 'id' => 'courier_freight'), $this->service->delete_method('courier_freight'));
+
+        $legacy_delete = $this->service->delete_method('air_express');
+        $this->assertSame('digitalogic_import_freight_legacy_method_delete_forbidden', $legacy_delete->get_error_code());
+    }
+
+    public function test_resolution_is_exact_detects_ambiguity_and_batch_preflight_is_atomic() {
+        $GLOBALS['digitalogic_test_posts'] = array(
+            301 => array('post_type' => 'product', 'meta' => array('_sku' => 'EXACT-1')),
+            302 => array('post_type' => 'product', 'meta' => array('_digitalogic_patris_product_code' => 'EXACT-2')),
+            303 => array('post_type' => 'product', 'meta' => array('_sku' => 'DUPLICATE')),
+            304 => array('post_type' => 'product_variation', 'meta' => array('_sku' => 'DUPLICATE')),
+        );
+        $this->service->migrate_legacy_data();
+
+        $this->assertSame(301, $this->service->assign_product_by_code('EXACT-1', 'air_express')['product_id']);
+        $this->assertSame(302, $this->service->assign_product_by_code('EXACT-2', 'sea_freight')['product_id']);
+        $this->assertSame('digitalogic_product_code_not_found', $this->service->assign_product_by_code('exact-1', 'air_express')->get_error_code());
+        $this->assertSame('digitalogic_product_code_ambiguous', $this->service->assign_product_by_code('DUPLICATE', 'air_express')->get_error_code());
+
+        $before = get_post_meta(301, '_digitalogic_import_freight_method_id', true);
+        $batch = $this->service->batch_assign_products(array(
+            array('code' => 'EXACT-1', 'import_freight_method_id' => 'sea_freight'),
+            array('code' => 'MISSING', 'import_freight_method_id' => 'air_freight'),
+        ));
+        $this->assertSame('digitalogic_import_freight_batch_invalid', $batch->get_error_code());
+        $this->assertSame($before, get_post_meta(301, '_digitalogic_import_freight_method_id', true));
+    }
+
+    public function test_rest_and_dispatcher_share_identical_service_results_and_scoped_permissions() {
+        $this->service->migrate_legacy_data();
+        $GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
+        $dispatcher = Digitalogic_Command_Dispatcher::instance();
+        $api = Digitalogic_REST_API::instance();
+
+        $dispatcher_catalog = $dispatcher->get_integration_catalog(array());
+        $rest_response = $api->get_integration_catalog(new WP_REST_Request());
+        $this->assertSame(200, $rest_response->get_status());
+        $this->assertSame($dispatcher_catalog, $rest_response->get_data()['data']);
+
+        $create_request = new WP_REST_Request(array(), array(
+            'id' => 'road_freight',
+            'name' => 'Road Freight',
+            'price_per_kg_cny' => 35,
+        ));
+        $create_response = $api->create_import_freight_method($create_request);
+        $this->assertSame(201, $create_response->get_status());
+        $this->assertSame(
+            $dispatcher->get_import_freight_method(array('id' => 'road_freight')),
+            $create_response->get_data()['data']
+        );
+
+        $rename_response = $api->update_import_freight_method(new WP_REST_Request(
+            array('id' => 'road_freight'),
+            array('id' => 'renamed_road', 'name' => 'Renamed')
+        ));
+        $this->assertSame(400, $rename_response->get_status());
+        $this->assertSame('digitalogic_import_freight_method_id_immutable', $rename_response->get_data()['code']);
+
+        $GLOBALS['digitalogic_test_capabilities'] = array();
+        $this->assertFalse($api->check_read_permission(new WP_REST_Request()));
+        $this->assertFalse($api->check_write_permission(new WP_REST_Request()));
+        add_filter('digitalogic_rest_api_permission', function($allowed, $scope) {
+            return $scope === 'read';
+        }, 10, 2);
+        $this->assertTrue($api->check_read_permission(new WP_REST_Request()));
+        $this->assertFalse($api->check_write_permission(new WP_REST_Request()));
+    }
+
+    public function test_lock_failure_is_retryable_and_performs_no_write_or_domain_action() {
+        $before = $GLOBALS['digitalogic_test_options'];
+        $GLOBALS['wpdb']->acquire_result = 0;
+
+        $result = $this->service->migrate_legacy_data();
+
+        $this->assertSame('digitalogic_import_freight_catalog_busy', $result->get_error_code());
+        $this->assertSame(503, $result->get_error_data()['status']);
+        $this->assertSame($before, $GLOBALS['digitalogic_test_options']);
+        $this->assertArrayNotHasKey('digitalogic_import_freight_method_created', $GLOBALS['digitalogic_test_actions']);
+        $this->assertSame(0, $GLOBALS['wpdb']->release_count);
+    }
+
+    public function test_lock_is_released_when_a_mutation_callback_throws() {
+        $lock = new ReflectionMethod(Digitalogic_Import_Freight_Service::class, 'with_catalog_lock');
+        $lock->setAccessible(true);
+
+        $result = $lock->invoke($this->service, function() {
+            throw new RuntimeException('injected callback failure');
+        });
+
+        $this->assertSame('digitalogic_import_freight_unexpected_write_failure', $result->get_error_code());
+        $this->assertSame(1, $GLOBALS['wpdb']->acquire_count);
+        $this->assertSame(1, $GLOBALS['wpdb']->release_count);
+
+        $retry = $this->service->migrate_legacy_data();
+        $this->assertFalse(is_wp_error($retry));
+        $this->assertSame(2, $GLOBALS['wpdb']->release_count);
+    }
+
+    public function test_catalog_and_legacy_rate_failures_roll_back_without_events() {
+        $this->service->migrate_legacy_data();
+        $before_catalog = get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION);
+        $before_rate = get_option('options_express');
+        $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_update_failures'][] = Digitalogic_Import_Freight_Service::METHODS_OPTION;
+
+        $catalog_failure = $this->service->update_method('air_express', array('price_per_kg_cny' => 91));
+
+        $this->assertSame('digitalogic_import_freight_catalog_write_failed', $catalog_failure->get_error_code());
+        $this->assertSame($before_catalog, get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION));
+        $this->assertSame($before_rate, get_option('options_express'));
+        $this->assertArrayNotHasKey('digitalogic_import_freight_method_updated', $GLOBALS['digitalogic_test_actions']);
+        $this->assertContains(
+            array(Digitalogic_Import_Freight_Service::METHODS_OPTION, 'options'),
+            $GLOBALS['digitalogic_test_cache_deletes']
+        );
+
+        $GLOBALS['digitalogic_test_update_failures'] = array('options_express');
+        $legacy_failure = $this->service->update_method('air_express', array('price_per_kg_cny' => 92));
+
+        $this->assertSame('digitalogic_import_freight_legacy_rate_write_failed', $legacy_failure->get_error_code());
+        $this->assertSame($before_catalog, get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION));
+        $this->assertSame($before_rate, get_option('options_express'));
+        $this->assertArrayNotHasKey('digitalogic_import_freight_method_updated', $GLOBALS['digitalogic_test_actions']);
+        $this->assertSame($GLOBALS['wpdb']->acquire_count, $GLOBALS['wpdb']->release_count);
+    }
+
+    public function test_post_rollback_compensation_never_overwrites_a_newer_option_writer() {
+        $this->service->migrate_legacy_data();
+        $newer_catalog = get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION);
+        $newer_catalog['air_express']['price_per_kg_cny'] = 123.0;
+        $GLOBALS['digitalogic_test_update_failures'][] = 'options_express';
+        $GLOBALS['wpdb']->after_rollback = static function() use ($newer_catalog) {
+            $GLOBALS['digitalogic_test_options'][Digitalogic_Import_Freight_Service::METHODS_OPTION] = $newer_catalog;
+            $GLOBALS['digitalogic_test_options']['options_express'] = '123';
+        };
+
+        $failed = $this->service->update_method('air_express', array('price_per_kg_cny' => 92));
+
+        $this->assertSame('digitalogic_import_freight_legacy_rate_write_failed', $failed->get_error_code());
+        $this->assertSame(123.0, get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION)['air_express']['price_per_kg_cny']);
+        $this->assertSame('123', get_option('options_express'));
+    }
+
+    public function test_post_rollback_compensation_never_overwrites_a_newer_meta_writer() {
+        $GLOBALS['digitalogic_test_posts'][408] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'INTERLEAVE-408'),
+        );
+        $this->service->migrate_legacy_data();
+        $GLOBALS['digitalogic_test_meta_update_failures'][] = '408:shipping_method';
+        $GLOBALS['wpdb']->after_rollback = static function() {
+            $GLOBALS['digitalogic_test_posts'][408]['meta'][Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META] = 'sea_freight';
+            $GLOBALS['digitalogic_test_posts'][408]['meta']['shipping_method'] = 'marine';
+        };
+
+        $failed = $this->service->assign_product_by_code('INTERLEAVE-408', 'air_express');
+
+        $this->assertSame('digitalogic_import_freight_meta_write_failed', $failed->get_error_code());
+        $this->assertSame('sea_freight', get_post_meta(408, Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META, true));
+        $this->assertSame('marine', get_post_meta(408, 'shipping_method', true));
+    }
+
+    public function test_failed_rollback_query_is_reported_without_attempting_snapshot_rewrites() {
+        $this->service->migrate_legacy_data();
+        $GLOBALS['digitalogic_test_update_failures'][] = 'options_express';
+        $GLOBALS['digitalogic_test_transaction_failures'][] = 'ROLLBACK';
+
+        $failed = $this->service->update_method('air_express', array('price_per_kg_cny' => 92));
+
+        $this->assertSame('digitalogic_import_freight_rollback_failed', $failed->get_error_code());
+        $this->assertContains(
+            array(Digitalogic_Import_Freight_Service::METHODS_OPTION, 'options'),
+            $GLOBALS['digitalogic_test_cache_deletes']
+        );
+    }
+
+    public function test_direct_legacy_rate_write_is_restored_when_catalog_mirroring_fails() {
+        $this->service->migrate_legacy_data();
+        $before_catalog = get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION);
+        $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_update_failures'][] = Digitalogic_Import_Freight_Service::METHODS_OPTION;
+
+        update_option('options_express', 99, false);
+
+        $this->assertSame('85', get_option('options_express'));
+        $this->assertSame($before_catalog, get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION));
+        $this->assertArrayNotHasKey('digitalogic_import_freight_method_updated', $GLOBALS['digitalogic_test_actions']);
+        $this->assertSame($GLOBALS['wpdb']->acquire_count, $GLOBALS['wpdb']->release_count);
+    }
+
+    public function test_single_and_batch_meta_failures_restore_every_key_and_emit_no_domain_event() {
+        $GLOBALS['digitalogic_test_posts'] = array(
+            401 => array('post_type' => 'product', 'meta' => array('_sku' => 'ROLLBACK-1')),
+            402 => array('post_type' => 'product', 'meta' => array('_sku' => 'ROLLBACK-2')),
+        );
+        $this->service->migrate_legacy_data();
+        $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_meta_update_failures'][] = '401:shipping_method';
+
+        $single = $this->service->assign_product_by_code('ROLLBACK-1', 'air_express');
+
+        $this->assertSame('digitalogic_import_freight_meta_write_failed', $single->get_error_code());
+        $this->assertAssignmentMetaAbsent(401);
+        $this->assertArrayNotHasKey('digitalogic_product_import_freight_method_updated', $GLOBALS['digitalogic_test_actions']);
+        $this->assertContains(array(401, 'post_meta'), $GLOBALS['digitalogic_test_cache_deletes']);
+
+        $GLOBALS['digitalogic_test_meta_update_failures'] = array('402:shipping_method');
+        $batch = $this->service->batch_assign_products(array(
+            array('code' => 'ROLLBACK-1', 'method_id' => 'air_freight'),
+            array('code' => 'ROLLBACK-2', 'method_id' => 'sea_freight'),
+        ));
+
+        $this->assertSame('digitalogic_import_freight_meta_write_failed', $batch->get_error_code());
+        $this->assertAssignmentMetaAbsent(401);
+        $this->assertAssignmentMetaAbsent(402);
+        $this->assertArrayNotHasKey('digitalogic_product_import_freight_method_updated', $GLOBALS['digitalogic_test_actions']);
+    }
+
+    public function test_assignment_retries_are_idempotent_and_do_not_emit_duplicate_events() {
+        $GLOBALS['digitalogic_test_posts'][403] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'NOOP-403'),
+        );
+        $this->service->migrate_legacy_data();
+        $first = $this->service->assign_product_by_code('NOOP-403', 'air_express');
+        $this->assertTrue($first['changed']);
+        $GLOBALS['digitalogic_test_actions'] = array();
+
+        $retry = $this->service->assign_product_by_code('NOOP-403', 'air_express');
+        $batch_retry = $this->service->batch_assign_products(array(
+            array('code' => 'NOOP-403', 'method_id' => 'air_express'),
+        ));
+
+        $this->assertFalse($retry['changed']);
+        $this->assertSame(0, $batch_retry['updated']);
+        $this->assertSame(1, $batch_retry['unchanged']);
+        $this->assertFalse($batch_retry['assignments'][0]['changed']);
+        $this->assertArrayNotHasKey('digitalogic_product_import_freight_method_updated', $GLOBALS['digitalogic_test_actions']);
+    }
+
+    public function test_failed_migration_is_unstamped_and_a_retry_completes() {
+        $GLOBALS['digitalogic_test_posts'][404] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'MIGRATE-404', 'shipping_method' => 'marine'),
+        );
+        $GLOBALS['digitalogic_test_update_failures'][] = Digitalogic_Import_Freight_Service::MIGRATION_OPTION;
+
+        $failed = $this->service->migrate_legacy_data();
+
+        $this->assertSame('digitalogic_import_freight_migration_write_failed', $failed->get_error_code());
+        $this->assertFalse(get_option(Digitalogic_Import_Freight_Service::MIGRATION_OPTION, false));
+        $this->assertFalse(get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION, false));
+        $this->assertSame('', get_post_meta(404, Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META, true));
+
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $retry = $this->service->migrate_legacy_data();
+
+        $this->assertSame(1, $retry['assignments_migrated']);
+        $this->assertSame(1, get_option(Digitalogic_Import_Freight_Service::MIGRATION_OPTION));
+        $this->assertSame('sea_freight', get_post_meta(404, Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META, true));
+    }
+
+    public function test_mysql_string_roundtrip_accepts_scalar_migration_marker_and_legacy_rate() {
+        $GLOBALS['wpdb']->mysql_string_roundtrip = true;
+
+        $migration = $this->service->migrate_legacy_data();
+
+        $this->assertFalse(is_wp_error($migration));
+        $this->assertSame('1', get_option(Digitalogic_Import_Freight_Service::MIGRATION_OPTION));
+        $this->assertSame('85', get_option('options_express'));
+
+        $updated = $this->service->update_method('air_express', array('price_per_kg_cny' => 92.5));
+
+        $this->assertFalse(is_wp_error($updated));
+        $this->assertSame(92.5, $updated['price_per_kg_cny']);
+        $this->assertSame('92.5', get_option('options_express'));
+    }
+
+    public function test_migration_repairs_a_partial_catalog_even_when_the_old_marker_exists() {
+        $GLOBALS['digitalogic_test_options'][Digitalogic_Import_Freight_Service::METHODS_OPTION] = array(
+            'rail_freight' => array('id' => 'rail_freight', 'name' => 'Existing custom method'),
+        );
+        $GLOBALS['digitalogic_test_options'][Digitalogic_Import_Freight_Service::MIGRATION_OPTION] = 1;
+
+        $result = $this->service->maybe_migrate();
+        $stored = get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION);
+
+        $this->assertTrue($result['catalog_seeded']);
+        $this->assertArrayHasKey('rail_freight', $stored);
+        $this->assertArrayHasKey('air_express', $stored);
+        $this->assertArrayHasKey('air_freight', $stored);
+        $this->assertArrayHasKey('sea_freight', $stored);
+        $this->assertSame(1, get_option(Digitalogic_Import_Freight_Service::MIGRATION_OPTION));
+    }
+
+    public function test_acf_choices_support_custom_ids_and_reject_new_disabled_or_unknown_values() {
+        $GLOBALS['digitalogic_test_posts'][405] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'ACF-405'),
+        );
+        $this->service->migrate_legacy_data();
+        $this->service->create_method(array('id' => 'rail_freight', 'name' => 'Rail Freight', 'price_per_kg_cny' => 42));
+        $this->service->update_method('rail_freight', array('enabled' => false));
+
+        $field = $this->service->filter_acf_method_field(array('choices' => array('stale' => 'Stale')));
+        $this->assertArrayHasKey('express', $field['choices']);
+        $this->assertArrayHasKey('aerial', $field['choices']);
+        $this->assertArrayHasKey('marine', $field['choices']);
+        $this->assertArrayHasKey('rail_freight', $field['choices']);
+        $this->assertStringContainsString('disabled', $field['choices']['rail_freight']);
+        $this->assertTrue($this->service->validate_acf_method_value(true, 'express', array(), 'acf[field]'));
+        $this->assertIsString($this->service->validate_acf_method_value(true, 'unknown_method', array(), 'acf[field]'));
+        $this->assertIsString($this->service->validate_acf_method_value(true, 'rail_freight', array(), 'acf[field]'));
+
+        update_post_meta(405, 'shipping_method', 'rail_freight');
+        $this->assertSame('', get_post_meta(405, Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META, true));
+        $this->assertSame('', get_post_meta(405, 'shipping_method', true));
+
+        $this->service->update_method('rail_freight', array('enabled' => true));
+        $this->service->assign_product_by_code('ACF-405', 'rail_freight');
+        $this->service->update_method('rail_freight', array('enabled' => false));
+        $_POST['post_ID'] = 405;
+        $this->assertTrue($this->service->validate_acf_method_value(true, 'rail_freight', array(), 'acf[field]'));
+    }
+
+    public function test_assignment_markup_contract_is_explicit_for_percentage_fixed_and_missing_values() {
+        $GLOBALS['digitalogic_test_posts'][406] = array(
+            'post_type' => 'product',
+            'meta' => array(
+                '_sku' => 'MARKUP-406',
+                '_digitalogic_markup_type' => 'percentage',
+                '_digitalogic_markup' => '12.5',
+            ),
+        );
+        $this->service->migrate_legacy_data();
+
+        $percentage = $this->service->get_product_assignment_by_code('MARKUP-406');
+        $this->assertSame('percentage', $percentage['markup']['type']);
+        $this->assertSame(12.5, $percentage['markup']['value']);
+        $this->assertSame(12.5, $percentage['markup']['profit_percent']);
+        $this->assertSame(12.5, $percentage['profit_percent']);
+        $this->assertSame(array(), $percentage['pricing_warnings']);
+
+        update_post_meta(406, '_digitalogic_markup_type', 'fixed');
+        update_post_meta(406, '_digitalogic_markup', '250000');
+        $fixed = $this->service->get_product_assignment_by_code('MARKUP-406');
+        $this->assertSame('fixed', $fixed['markup']['type']);
+        $this->assertSame(250000.0, $fixed['markup']['value']);
+        $this->assertNull($fixed['markup']['profit_percent']);
+        $this->assertContains('fixed_markup_not_supported_by_landed_price_v1', $fixed['pricing_warnings']);
+
+        delete_post_meta(406, '_digitalogic_markup_type');
+        delete_post_meta(406, '_digitalogic_markup');
+        $missing = $this->service->get_product_assignment_by_code('MARKUP-406');
+        $this->assertNull($missing['markup']['type']);
+        $this->assertNull($missing['markup']['value']);
+        $this->assertContains('markup_missing', $missing['pricing_warnings']);
+    }
+
+    public function test_report_uses_the_canonical_catalog_and_tier_validation_rejects_bad_ranges() {
+        $this->service->migrate_legacy_data();
+        $report = Digitalogic_Report_Engine::instance()->get_report();
+        $method_ids = array_column($report['settings']['import_freight_methods'], 'id');
+
+        $this->assertSame($report['settings']['import_freight_methods'], $report['settings']['shipping_methods']);
+        $this->assertContains('air_express', $method_ids);
+        $this->assertNotContains('deprecated', $method_ids);
+        $this->assertNotNull($report['settings']['integration_catalog_revision']);
+
+        $invalid = $this->service->create_method(array(
+            'id' => 'bad_tiers',
+            'name' => 'Bad tiers',
+            'price_per_kg_cny' => 10,
+            'tiered_rates' => array(
+                array('min_weight_kg' => 0, 'max_weight_kg' => 10, 'price_per_kg_cny' => 9),
+                array('min_weight_kg' => 10, 'max_weight_kg' => 20, 'price_per_kg_cny' => 8),
+            ),
+        ));
+        $this->assertSame('digitalogic_import_freight_tiers_overlap', $invalid->get_error_code());
+    }
+
+    public function test_assignment_commands_require_an_explicit_method_field() {
+        $GLOBALS['digitalogic_test_posts'][501] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'REQUIRED-501'),
+        );
+        $this->service->migrate_legacy_data();
+        $dispatcher = Digitalogic_Command_Dispatcher::instance();
+        $api = Digitalogic_REST_API::instance();
+
+        $command = $dispatcher->assign_product_import_freight(array('code' => 'REQUIRED-501'));
+        $rest = $api->assign_product_import_freight(new WP_REST_Request(
+            array('code' => 'REQUIRED-501'),
+            array()
+        ));
+        $batch = $this->service->batch_assign_products(array(
+            array('code' => 'REQUIRED-501'),
+        ));
+
+        $this->assertSame('digitalogic_import_freight_method_required', $command->get_error_code());
+        $this->assertSame(400, $rest->get_status());
+        $this->assertSame('digitalogic_import_freight_method_required', $rest->get_data()['code']);
+        $this->assertSame('digitalogic_import_freight_batch_invalid', $batch->get_error_code());
+        $this->assertSame(
+            'digitalogic_import_freight_method_required',
+            $batch->get_error_data()['errors'][0]['code']
+        );
+        $this->assertAssignmentMetaAbsent(501);
+
+        $clear = $dispatcher->assign_product_import_freight(array(
+            'code' => 'REQUIRED-501',
+            'import_freight_method_id' => null,
+        ));
+        $this->assertFalse(is_wp_error($clear));
+        $this->assertFalse($clear['changed']);
+    }
+
+    public function test_custom_method_ids_cannot_collide_with_legacy_acf_values() {
+        $this->service->migrate_legacy_data();
+
+        foreach (array('express', 'aerial', 'marine') as $reserved_id) {
+            $result = $this->service->create_method(array(
+                'id' => $reserved_id,
+                'name' => 'Collision',
+                'price_per_kg_cny' => 10,
+            ));
+            $this->assertSame('digitalogic_import_freight_method_id_reserved', $result->get_error_code());
+        }
+
+        $methods = $this->indexMethods($this->service->list_methods());
+        $this->assertArrayNotHasKey('express', $methods);
+        $this->assertArrayNotHasKey('aerial', $methods);
+        $this->assertArrayNotHasKey('marine', $methods);
+    }
+
+    public function test_batch_rejects_two_codes_that_resolve_to_the_same_product() {
+        $GLOBALS['digitalogic_test_posts'][502] = array(
+            'post_type' => 'product',
+            'meta' => array(
+                '_sku' => 'SKU-502',
+                '_digitalogic_patris_product_code' => 'PATRIS-502',
+            ),
+        );
+        $this->service->migrate_legacy_data();
+
+        $result = $this->service->batch_assign_products(array(
+            array('code' => 'SKU-502', 'method_id' => 'air_express'),
+            array('code' => 'PATRIS-502', 'method_id' => 'sea_freight'),
+        ));
+
+        $this->assertSame('digitalogic_import_freight_batch_invalid', $result->get_error_code());
+        $errors = $result->get_error_data()['errors'];
+        $this->assertSame('digitalogic_duplicate_product_target', $errors[1]['code']);
+        $this->assertSame(502, $errors[1]['product_id']);
+        $this->assertSame(0, $errors[1]['first_index']);
+        $this->assertAssignmentMetaAbsent(502);
+    }
+
+    public function test_existing_disabled_assignment_can_be_replayed_as_an_idempotent_noop() {
+        $GLOBALS['digitalogic_test_posts'][503] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'DISABLED-503'),
+        );
+        $this->service->migrate_legacy_data();
+        $this->service->assign_product_by_code('DISABLED-503', 'air_express');
+        $this->service->update_method('air_express', array('enabled' => false));
+        $GLOBALS['digitalogic_test_actions'] = array();
+
+        $result = $this->service->assign_product_by_code('DISABLED-503', 'air_express');
+
+        $this->assertFalse(is_wp_error($result));
+        $this->assertFalse($result['changed']);
+        $this->assertSame('air_express', $result['import_freight_method_id']);
+        $this->assertArrayNotHasKey('digitalogic_product_import_freight_method_updated', $GLOBALS['digitalogic_test_actions']);
+    }
+
+    public function test_committed_mutation_uses_shared_panel_queue_and_redis_once() {
+        $GLOBALS['digitalogic_test_posts'][504] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'EVENT-504'),
+        );
+        $this->service->migrate_legacy_data();
+        $redis = new Digitalogic_Test_Redis_Client();
+        add_filter('digitalogic_panel_redis_client', static function() use ($redis) {
+            return $redis;
+        });
+        $GLOBALS['digitalogic_test_options']['digitalogic_webhook_urls'] = array('https://n8n.test/webhook/freight');
+        $GLOBALS['digitalogic_test_options']['digitalogic_webhook_secret'] = 'test-secret';
+        Digitalogic_Panel::instance();
+        Digitalogic_Webhooks::instance();
+
+        $result = $this->service->assign_product_by_code('EVENT-504', 'air_express');
+
+        $this->assertTrue($result['changed']);
+        $events = get_option('digitalogic_panel_events', array());
+        $this->assertCount(1, $events);
+        $this->assertSame('import_freight.assignment.updated', $events[0]['name']);
+        $this->assertSame(504, $events[0]['data']['product_id']);
+        $this->assertSame('air_express', $events[0]['data']['import_freight_method_id']);
+        $this->assertCount(1, $redis->published);
+        $this->assertSame($events[0], json_decode($redis->published[0][1], true));
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+        $webhook_payload = json_decode($GLOBALS['digitalogic_test_remote_posts'][0]['args']['body'], true);
+        $this->assertSame('import_freight.assignment.updated', $webhook_payload['event']);
+        $this->assertSame(504, $webhook_payload['data']['product_id']);
+
+        $retry = $this->service->assign_product_by_code('EVENT-504', 'air_express');
+        $this->assertFalse($retry['changed']);
+        $this->assertCount(1, get_option('digitalogic_panel_events', array()));
+        $this->assertCount(1, $redis->published);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+
+        $webhook_source = file_get_contents(dirname(__DIR__) . '/includes/api/class-webhooks.php');
+        $panel_source = file_get_contents(dirname(__DIR__) . '/includes/panel/class-panel.php');
+        $this->assertStringContainsString('digitalogic_product_import_freight_method_updated', $webhook_source);
+        $this->assertStringContainsString('import_freight.assignment.updated', $webhook_source);
+        $this->assertStringNotContainsString("add_action('digitalogic_import_freight", $webhook_source);
+        $this->assertStringNotContainsString("add_action('digitalogic_product_import_freight", $webhook_source);
+        $this->assertStringNotContainsString("add_action('digitalogic_import_freight", $panel_source);
+        $this->assertStringNotContainsString("add_action('digitalogic_product_import_freight", $panel_source);
+    }
+
+    public function test_delivery_channels_attempt_all_transports_and_aggregate_redis_webhook_void_and_exception_failures() {
+        $GLOBALS['digitalogic_test_posts'][509] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'DELIVERY-509'),
+        );
+        $this->service->migrate_legacy_data();
+
+        $redis = new Digitalogic_Test_Redis_Client();
+        $redis->publish_result = false;
+        add_filter('digitalogic_panel_redis_client', static function() use ($redis) {
+            return $redis;
+        });
+        $GLOBALS['digitalogic_test_options']['digitalogic_webhook_urls'] = array(
+            'https://n8n.test/webhook/one',
+            'https://n8n.test/webhook/two',
+        );
+        $GLOBALS['digitalogic_test_remote_post_results'] = array(
+            new WP_Error('transport_down', 'first destination unavailable'),
+            array('response' => array('code' => 503)),
+        );
+        Digitalogic_Panel::instance();
+        Digitalogic_Webhooks::instance();
+
+        $successful_channel_calls = 0;
+        $this->service->register_delivery_channel('void_channel', static function() {
+            // A legacy void callback must be observable as unconfirmed.
+        });
+        $this->service->register_delivery_channel('throwing_channel', static function() {
+            throw new RuntimeException('injected delivery exception');
+        });
+        $this->service->register_delivery_channel('successful_channel', static function() use (&$successful_channel_calls) {
+            $successful_channel_calls++;
+            return true;
+        });
+        add_action('digitalogic_product_import_freight_method_updated', static function() {
+            throw new RuntimeException('legacy action listener failed');
+        }, 1, 2);
+
+        $result = $this->service->assign_product_by_code('DELIVERY-509', 'air_freight');
+
+        $this->assertTrue($result['changed']);
+        $this->assertCount(1, get_option('digitalogic_panel_events', array()));
+        $this->assertCount(1, $redis->published);
+        $this->assertCount(2, $GLOBALS['digitalogic_test_remote_posts']);
+        $this->assertSame(1, $successful_channel_calls);
+        $this->assertContains('event_delivery_failed:panel:digitalogic_panel_delivery_failed', $result['delivery_warnings']);
+        $this->assertContains('event_delivery_failed:webhook:digitalogic_webhook_delivery_failed', $result['delivery_warnings']);
+        $this->assertContains('event_delivery_unconfirmed:void_channel', $result['delivery_warnings']);
+        $this->assertContains('event_delivery_failed:throwing_channel:exception', $result['delivery_warnings']);
+        $this->assertContains('event_delivery_failed:digitalogic_product_import_freight_method_updated', $result['delivery_warnings']);
+
+        $retry = $this->service->assign_product_by_code('DELIVERY-509', 'air_freight');
+        $this->assertFalse($retry['changed']);
+        $this->assertArrayNotHasKey('delivery_warnings', $retry);
+        $this->assertCount(1, get_option('digitalogic_panel_events', array()));
+        $this->assertCount(1, $redis->published);
+        $this->assertCount(2, $GLOBALS['digitalogic_test_remote_posts']);
+        $this->assertSame(1, $successful_channel_calls);
+    }
+
+    public function test_panel_queue_failure_is_reported_while_webhook_and_later_channels_still_run() {
+        $GLOBALS['digitalogic_test_posts'][510] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'QUEUE-510'),
+        );
+        $this->service->migrate_legacy_data();
+        $redis = new Digitalogic_Test_Redis_Client();
+        add_filter('digitalogic_panel_redis_client', static function() use ($redis) {
+            return $redis;
+        });
+        $GLOBALS['digitalogic_test_options']['digitalogic_webhook_urls'] = array('https://n8n.test/webhook/queue');
+        $GLOBALS['digitalogic_test_update_failures'][] = 'digitalogic_panel_events';
+        Digitalogic_Panel::instance();
+        Digitalogic_Webhooks::instance();
+
+        $result = $this->service->assign_product_by_code('QUEUE-510', 'sea_freight');
+
+        $this->assertTrue($result['changed']);
+        $this->assertContains('event_delivery_failed:panel:digitalogic_panel_queue_write_failed', $result['delivery_warnings']);
+        $this->assertCount(0, $redis->published);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+    }
+
+    public function test_delivery_channel_names_cannot_be_replaced_without_explicit_unregister() {
+        $GLOBALS['digitalogic_test_posts'][511] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'CHANNEL-511'),
+        );
+        $this->service->migrate_legacy_data();
+        $first_calls = 0;
+        $replacement_calls = 0;
+        $first = static function() use (&$first_calls) {
+            $first_calls++;
+            return true;
+        };
+        $replacement = static function() use (&$replacement_calls) {
+            $replacement_calls++;
+            return true;
+        };
+
+        $this->assertTrue($this->service->register_delivery_channel('stable_name', $first));
+        $this->assertFalse($this->service->register_delivery_channel('stable_name', $replacement));
+        $this->service->assign_product_by_code('CHANNEL-511', 'air_express');
+        $this->assertSame(1, $first_calls);
+        $this->assertSame(0, $replacement_calls);
+
+        $this->assertTrue($this->service->unregister_delivery_channel('stable_name'));
+        $this->assertTrue($this->service->register_delivery_channel('stable_name', $replacement));
+        $this->service->assign_product_by_code('CHANNEL-511', 'sea_freight');
+        $this->assertSame(1, $first_calls);
+        $this->assertSame(1, $replacement_calls);
+    }
+
+    public function test_empty_webhook_configuration_is_a_confirmed_disabled_channel() {
+        $GLOBALS['digitalogic_test_posts'][513] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'NO-WEBHOOK-513'),
+        );
+        $this->service->migrate_legacy_data();
+        Digitalogic_Webhooks::instance();
+
+        $result = $this->service->assign_product_by_code('NO-WEBHOOK-513', 'air_freight');
+
+        $this->assertTrue($result['changed']);
+        $this->assertArrayNotHasKey('delivery_warnings', $result);
+        $this->assertCount(0, $GLOBALS['digitalogic_test_remote_posts']);
+    }
+
+    public function test_panel_and_webhook_singletons_reregister_after_service_reset_without_duplicate_delivery() {
+        $GLOBALS['digitalogic_test_posts'][512] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'RESET-512'),
+        );
+        $this->service->migrate_legacy_data();
+        $redis = new Digitalogic_Test_Redis_Client();
+        add_filter('digitalogic_panel_redis_client', static function() use ($redis) {
+            return $redis;
+        });
+        $GLOBALS['digitalogic_test_options']['digitalogic_webhook_urls'] = array('https://n8n.test/webhook/reset');
+        Digitalogic_Panel::instance();
+        Digitalogic_Webhooks::instance();
+
+        $this->resetSingleton(Digitalogic_Import_Freight_Service::class);
+        $this->service = Digitalogic_Import_Freight_Service::instance();
+        Digitalogic_Panel::instance();
+        Digitalogic_Webhooks::instance();
+
+        $result = $this->service->assign_product_by_code('RESET-512', 'air_express');
+
+        $this->assertTrue($result['changed']);
+        $this->assertArrayNotHasKey('delivery_warnings', $result);
+        $this->assertCount(1, get_option('digitalogic_panel_events', array()));
+        $this->assertCount(1, $redis->published);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+    }
+
+    public function test_throwing_post_commit_listener_returns_success_with_delivery_warning() {
+        $GLOBALS['digitalogic_test_posts'][505] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'THROW-505'),
+        );
+        $this->service->migrate_legacy_data();
+        add_action('digitalogic_product_import_freight_method_updated', static function() {
+            throw new RuntimeException('injected listener failure');
+        }, 1, 2);
+
+        $result = $this->service->assign_product_by_code('THROW-505', 'sea_freight');
+
+        $this->assertFalse(is_wp_error($result));
+        $this->assertTrue($result['changed']);
+        $this->assertSame('sea_freight', get_post_meta(505, Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META, true));
+        $this->assertContains(
+            'event_delivery_failed:digitalogic_product_import_freight_method_updated',
+            $result['delivery_warnings']
+        );
+        $this->assertSame($GLOBALS['wpdb']->acquire_count, $GLOBALS['wpdb']->release_count);
+
+        $retry = $this->service->assign_product_by_code('THROW-505', 'sea_freight');
+        $this->assertFalse($retry['changed']);
+        $this->assertArrayNotHasKey('delivery_warnings', $retry);
+    }
+
+    public function test_storage_bypasses_stale_shared_cache_and_invalidates_after_commit_before_hooks() {
+        $GLOBALS['digitalogic_test_posts'][506] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'CACHE-506'),
+        );
+        $this->service->migrate_legacy_data();
+        $stale_catalog = get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION);
+        $stale_catalog['air_express']['price_per_kg_cny'] = 1.0;
+        $GLOBALS['digitalogic_test_option_cache'][Digitalogic_Import_Freight_Service::METHODS_OPTION] = $stale_catalog;
+
+        $updated = $this->service->update_method('air_express', array('price_per_kg_cny' => 88));
+        $this->assertSame(88.0, $updated['price_per_kg_cny']);
+        $this->assertSame(88.0, get_option(Digitalogic_Import_Freight_Service::METHODS_OPTION)['air_express']['price_per_kg_cny']);
+
+        $GLOBALS['digitalogic_test_cache_deletes'] = array();
+        $GLOBALS['digitalogic_test_post_meta_cache'][506] = array(
+            '_sku' => 'CACHE-506',
+            Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META => 'stale_method',
+        );
+        $hook_observations = array();
+        add_action('added_post_meta', static function() use (&$hook_observations) {
+            $queries = $GLOBALS['wpdb']->queries;
+            $hook_observations[] = array(
+                'last_query' => end($queries),
+                'cache_invalidated' => in_array(array(506, 'post_meta'), $GLOBALS['digitalogic_test_cache_deletes'], true),
+            );
+        }, 30, 4);
+
+        $assignment = $this->service->assign_product_by_code('CACHE-506', 'air_freight');
+
+        $this->assertTrue($assignment['changed']);
+        $this->assertSame('air_freight', get_post_meta(506, Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META, true));
+        $this->assertNotEmpty($hook_observations);
+        foreach ($hook_observations as $observation) {
+            $this->assertSame('COMMIT', $observation['last_query']);
+            $this->assertTrue($observation['cache_invalidated']);
+        }
+    }
+
+    public function test_stale_legacy_hooks_never_overwrite_a_newer_value() {
+        $GLOBALS['digitalogic_test_posts'][507] = array(
+            'post_type' => 'product',
+            'meta' => array('_sku' => 'CAS-507'),
+        );
+        $this->service->migrate_legacy_data();
+        $this->service->assign_product_by_code('CAS-507', 'air_express');
+        update_post_meta(507, 'shipping_method', 'marine');
+        $this->assertSame('sea_freight', get_post_meta(507, Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META, true));
+
+        $this->service->sync_legacy_assignment(1, 507, 'shipping_method', 'express');
+        $this->assertSame('marine', get_post_meta(507, 'shipping_method', true));
+        $this->assertSame('sea_freight', get_post_meta(507, Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META, true));
+
+        update_option('options_express', 99, false);
+        $this->assertSame(99.0, $this->service->get_method('air_express')['price_per_kg_cny']);
+        $this->service->sync_updated_legacy_rate('options_express', 85, 90);
+        $this->assertSame(99, get_option('options_express'));
+        $this->assertSame(99.0, $this->service->get_method('air_express')['price_per_kg_cny']);
+    }
+
+    public function test_invalid_currency_rate_is_null_with_warning_and_transit_days_are_strict() {
+        $this->service->migrate_legacy_data();
+        foreach (array(null, 'not-a-rate', 0, -1) as $invalid_rate) {
+            if (is_null($invalid_rate)) {
+                unset($GLOBALS['digitalogic_test_options']['options_yuan_price']);
+            } else {
+                $GLOBALS['digitalogic_test_options']['options_yuan_price'] = $invalid_rate;
+            }
+            $GLOBALS['digitalogic_test_option_cache'] = array();
+            $catalog = $this->service->get_integration_catalog();
+            $this->assertNull($catalog['currency']['cny_to_local']);
+            $this->assertNull($catalog['currency']['cny_to_irt']);
+            $this->assertContains('cny_to_local_missing_or_invalid', $catalog['currency']['warnings']);
+        }
+
+        foreach (array(-1, '1.5', 2.5, 'two') as $index => $invalid_transit) {
+            $method = $this->service->create_method(array(
+                'id' => 'invalid_transit_' . $index,
+                'name' => 'Invalid transit',
+                'price_per_kg_cny' => 10,
+                'transit_days_min' => $invalid_transit,
+            ));
+            $this->assertSame('digitalogic_import_freight_transit_invalid', $method->get_error_code());
+        }
+    }
+
+    public function test_routes_and_implementation_do_not_register_customer_delivery_apis() {
+        $api = Digitalogic_REST_API::instance();
+        $api->register_routes();
+
+        $freight_routes = array();
+        foreach ($GLOBALS['digitalogic_test_routes'] as $registration) {
+            if (strpos($registration['route'], 'import-freight') !== false || $registration['route'] === '/integration/catalog' || strpos($registration['route'], 'import-pricing') !== false) {
+                $freight_routes[] = $registration['route'];
+            }
+        }
+        $this->assertContains('/integration/catalog', $freight_routes);
+        $this->assertContains('/import-freight-methods', $freight_routes);
+        $this->assertContains('/products/import-pricing/batch', $freight_routes);
+
+        $source = file_get_contents(dirname(__DIR__) . '/includes/class-import-freight-service.php')
+            . file_get_contents(dirname(__DIR__) . '/includes/api/class-rest-api.php');
+        $this->assertStringNotContainsString('WC_' . 'Shipping_Method', $source);
+        $this->assertStringNotContainsString('woocommerce_' . 'shipping_method', $source);
+        $this->assertStringNotContainsString('woocommerce_' . 'checkout', $source);
+    }
+
+    private function indexMethods($methods) {
+        $indexed = array();
+        foreach ($methods as $method) {
+            $indexed[$method['id']] = $method;
+        }
+        return $indexed;
+    }
+
+    private function assertAssignmentMetaAbsent($product_id) {
+        $this->assertFalse(metadata_exists('post', $product_id, Digitalogic_Import_Freight_Service::PRODUCT_METHOD_META));
+        $this->assertFalse(metadata_exists('post', $product_id, Digitalogic_Import_Freight_Service::LEGACY_PRODUCT_METHOD_META));
+        $this->assertFalse(metadata_exists('post', $product_id, Digitalogic_Import_Freight_Service::LEGACY_ACF_REFERENCE_META));
+    }
+
+    private function resetSingleton($class_name) {
+        $property = new ReflectionProperty($class_name, 'instance');
+        $property->setAccessible(true);
+        $property->setValue(null, null);
+    }
+}

--- a/tests/PatrisFeedResolutionTest.php
+++ b/tests/PatrisFeedResolutionTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class PatrisFeedResolutionTest extends TestCase {
+
+    /** @var Digitalogic_Patris_Feed */
+    private $feed;
+
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_options'] = array('woocommerce_weight_unit' => 'kg');
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_posts'] = array();
+        $GLOBALS['digitalogic_test_post_meta_cache'] = array();
+        $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_action_callbacks'] = array();
+        $GLOBALS['digitalogic_test_wc_products'] = array();
+        $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+        $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
+
+        $this->resetSingleton(Digitalogic_Product_Identifier_Resolver::class);
+        $this->resetSingleton(Digitalogic_Patris_Feed::class);
+        $this->feed = Digitalogic_Patris_Feed::instance();
+    }
+
+    public function test_patris_meta_only_match_updates_product_and_not_found_remains_in_normalized_snapshot(): void {
+        $GLOBALS['digitalogic_test_posts'][701] = array(
+            'post_type' => 'product',
+            'meta' => array(
+                '_digitalogic_patris_product_code' => 'PATRIS-ONLY',
+                '_existing_sentinel' => 'keep-me',
+            ),
+        );
+        $matched_row = array(
+            'product_code' => 'PATRIS-ONLY',
+            'name' => 'Patris-only product',
+            'weight_grams' => 240,
+            'total_stock' => 5,
+            'final_price' => 2009410,
+            'source_marker' => 'preserve-in-raw-snapshot',
+        );
+        $missing_row = array(
+            'product_code' => 'NOT-IN-WOO',
+            'name' => 'Upstream-only product',
+            'source_marker' => 'still-reportable',
+        );
+
+        $result = $this->feed->import_payload(array('products' => array($matched_row, $missing_row)), 'test');
+
+        $this->assertSame(2, $result['total']);
+        $this->assertSame(1, $result['updated']);
+        $this->assertSame(1, $result['missing_in_woocommerce']);
+        $this->assertSame(0, $result['failed']);
+        $this->assertSame(array(701), $GLOBALS['digitalogic_test_wc_product_saves']);
+        $this->assertSame('keep-me', $GLOBALS['digitalogic_test_posts'][701]['meta']['_existing_sentinel']);
+        $this->assertSame('PATRIS-ONLY', $GLOBALS['digitalogic_test_posts'][701]['meta']['_digitalogic_patris_product_code']);
+        $this->assertSame('0.24', $GLOBALS['digitalogic_test_wc_products'][701]->weight);
+
+        $snapshot = get_option('digitalogic_patris_feed_products');
+        $this->assertSame('preserve-in-raw-snapshot', $snapshot['PATRIS-ONLY']['raw']['source_marker']);
+        $this->assertSame('still-reportable', $snapshot['NOT-IN-WOO']['raw']['source_marker']);
+        $this->assertSame('Upstream-only product', $snapshot['NOT-IN-WOO']['name']);
+    }
+
+    public function test_generic_code_prefers_exact_sku_over_a_different_products_patris_code(): void {
+        $GLOBALS['digitalogic_test_posts'] = array(
+            702 => array(
+                'post_type' => 'product',
+                'meta' => array('_sku' => 'COLLISION', '_existing_sentinel' => 'sku-target'),
+            ),
+            703 => array(
+                'post_type' => 'product',
+                'meta' => array('_digitalogic_patris_product_code' => 'COLLISION', '_existing_sentinel' => 'patris-nontarget'),
+            ),
+        );
+
+        $result = $this->feed->import_payload(array('products' => array(array(
+            'product_code' => 'COLLISION',
+            'name' => 'SKU wins',
+            'total_stock' => 2,
+            'final_price' => 12345,
+        ))), 'test');
+
+        $this->assertSame(1, $result['updated']);
+        $this->assertSame(array(702), $GLOBALS['digitalogic_test_wc_product_saves']);
+        $this->assertSame('SKU wins', $GLOBALS['digitalogic_test_posts'][702]['meta']['_digitalogic_patris_name']);
+        $this->assertSame('patris-nontarget', $GLOBALS['digitalogic_test_posts'][703]['meta']['_existing_sentinel']);
+        $this->assertArrayNotHasKey('_digitalogic_patris_name', $GLOBALS['digitalogic_test_posts'][703]['meta']);
+    }
+
+    public function test_ambiguous_and_invalid_identifiers_fail_safely_without_product_writes_but_remain_reportable(): void {
+        $GLOBALS['digitalogic_test_posts'] = array(
+            704 => array('post_type' => 'product', 'meta' => array('_sku' => 'AMBIGUOUS', '_existing_sentinel' => 'first')),
+            705 => array('post_type' => 'product_variation', 'meta' => array('_sku' => 'AMBIGUOUS', '_existing_sentinel' => 'second')),
+        );
+        $invalid_code = str_repeat('X', 192);
+        $ambiguous_row = array(
+            'product_code' => 'AMBIGUOUS',
+            'name' => 'Must not write',
+            'source_marker' => 'ambiguous-snapshot',
+        );
+        $invalid_row = array(
+            'product_code' => $invalid_code,
+            'name' => 'Invalid identifier',
+            'source_marker' => 'invalid-snapshot',
+        );
+
+        $result = $this->feed->import_payload(array('products' => array($ambiguous_row, $invalid_row)), 'test');
+
+        $this->assertSame(2, $result['total']);
+        $this->assertSame(0, $result['updated']);
+        $this->assertSame(0, $result['missing_in_woocommerce']);
+        $this->assertSame(2, $result['failed']);
+        $this->assertSame(array(
+            'Skipped product because its exact Code/SKU is ambiguous.',
+            'Skipped product because its Code/SKU could not be resolved.',
+        ), $result['errors']);
+        $this->assertSame(array(), $GLOBALS['digitalogic_test_wc_product_saves']);
+        $this->assertSame('first', $GLOBALS['digitalogic_test_posts'][704]['meta']['_existing_sentinel']);
+        $this->assertSame('second', $GLOBALS['digitalogic_test_posts'][705]['meta']['_existing_sentinel']);
+        $this->assertArrayNotHasKey('_digitalogic_patris_name', $GLOBALS['digitalogic_test_posts'][704]['meta']);
+        $this->assertArrayNotHasKey('_digitalogic_patris_name', $GLOBALS['digitalogic_test_posts'][705]['meta']);
+
+        $snapshot = get_option('digitalogic_patris_feed_products');
+        $this->assertSame('ambiguous-snapshot', $snapshot['AMBIGUOUS']['raw']['source_marker']);
+        $this->assertSame('invalid-snapshot', $snapshot[$invalid_code]['raw']['source_marker']);
+    }
+
+    private function resetSingleton($class) {
+        $property = new ReflectionProperty($class, 'instance');
+        $property->setAccessible(true);
+        $property->setValue(null, null);
+    }
+}

--- a/tests/ProductIdentifierResolverTest.php
+++ b/tests/ProductIdentifierResolverTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ProductIdentifierResolverTest extends TestCase {
+
+    /** @var Digitalogic_Product_Identifier_Resolver */
+    private $resolver;
+
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_posts'] = array(
+            601 => array(
+                'post_type' => 'product',
+                'meta' => array('_sku' => 'SKU-601', '_digitalogic_patris_product_code' => 'PATRIS-601'),
+            ),
+            602 => array(
+                'post_type' => 'product_variation',
+                'post_status' => 'draft',
+                'meta' => array('_sku' => 'SKU-602', '_digitalogic_patris_product_code' => 'PATRIS-602'),
+            ),
+            603 => array('post_type' => 'product', 'meta' => array('_sku' => 'DUP-SKU')),
+            604 => array('post_type' => 'product_variation', 'meta' => array('_sku' => 'DUP-SKU')),
+            605 => array('post_type' => 'product', 'meta' => array('_digitalogic_patris_product_code' => 'DUP-PATRIS')),
+            606 => array('post_type' => 'product_variation', 'meta' => array('_digitalogic_patris_product_code' => 'DUP-PATRIS')),
+            607 => array('post_type' => 'product', 'meta' => array('_sku' => 'CROSS')),
+            608 => array('post_type' => 'product', 'meta' => array('_digitalogic_patris_product_code' => 'CROSS')),
+            609 => array('post_type' => 'product', 'meta' => array('_sku' => '00123')),
+            610 => array(
+                'post_type' => 'product',
+                'meta' => array(),
+                'meta_rows' => array('_sku' => array('STALE-SKU', 'CURRENT-SKU')),
+            ),
+            611 => array('post_type' => 'product', 'post_status' => 'trash', 'meta' => array('_sku' => 'TRASH-SKU')),
+            612 => array('post_type' => 'product_variation', 'post_status' => 'auto-draft', 'meta' => array('_sku' => 'AUTO-SKU')),
+            700 => array('post_type' => 'post', 'meta' => array('_sku' => 'NOT-A-PRODUCT')),
+        );
+        $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
+
+        $instance = new ReflectionProperty(Digitalogic_Product_Identifier_Resolver::class, 'instance');
+        $instance->setAccessible(true);
+        $instance->setValue(null, null);
+        $this->resolver = Digitalogic_Product_Identifier_Resolver::instance();
+    }
+
+    public function test_supplied_identifier_precedence_prefers_explicit_woo_id_then_sku_then_patris_code(): void {
+        $input = array(
+            'woocommerce_id' => '602',
+            'sku' => 'SKU-601',
+            'patris_code' => 'PATRIS-601',
+        );
+        $before = $input;
+
+        $resolved = $this->resolver->resolve($input);
+
+        $this->assertSame('602', $resolved['woocommerce_id']);
+        $this->assertSame('product_variation', $resolved['post_type']);
+        $this->assertSame('woocommerce_id', $resolved['resolved_by']);
+        $this->assertSame('602', $resolved['identifier']);
+        $this->assertSame($before, $input);
+        $this->assertSame(1, $GLOBALS['wpdb']->identifier_query_count);
+
+        $GLOBALS['wpdb']->identifier_query_count = 0;
+        $resolved = $this->resolver->resolve(array('sku' => 'SKU-601', 'patris_code' => 'PATRIS-602'));
+        $this->assertSame('601', $resolved['woocommerce_id']);
+        $this->assertSame('sku', $resolved['resolved_by']);
+        $this->assertSame(1, $GLOBALS['wpdb']->identifier_query_count);
+    }
+
+    public function test_generic_code_uses_exact_sku_before_exact_patris_code_without_integer_coercion(): void {
+        $cross = $this->resolver->resolve(array('code' => 'CROSS'));
+        $numeric_looking = $this->resolver->resolve(array('code' => '00123'));
+        $wrong_case = $this->resolver->resolve(array('code' => 'sku-601'));
+
+        $this->assertSame('607', $cross['woocommerce_id']);
+        $this->assertSame('sku', $cross['resolved_by']);
+        $this->assertSame('609', $numeric_looking['woocommerce_id']);
+        $this->assertSame('00123', $numeric_looking['identifier']);
+        $this->assertSame('digitalogic_product_identifier_not_found', $wrong_case->get_error_code());
+        $this->assertSame(3, $GLOBALS['wpdb']->identifier_query_count);
+    }
+
+    public function test_non_woo_identifiers_require_strings_and_latest_duplicate_meta_row_is_deterministic(): void {
+        foreach (array('sku', 'patris_code', 'code') as $field) {
+            $invalid = $this->resolver->resolve(array($field => 601));
+            $this->assertSame('digitalogic_invalid_product_identifier', $invalid->get_error_code());
+        }
+
+        $stale = $this->resolver->resolve(array('sku' => 'STALE-SKU'));
+        $current = $this->resolver->resolve(array('sku' => 'CURRENT-SKU'));
+        $trash = $this->resolver->resolve(array('sku' => 'TRASH-SKU'));
+        $auto_draft = $this->resolver->resolve(array('sku' => 'AUTO-SKU'));
+
+        $this->assertSame('digitalogic_product_identifier_not_found', $stale->get_error_code());
+        $this->assertSame('610', $current['woocommerce_id']);
+        $this->assertSame('digitalogic_product_identifier_not_found', $trash->get_error_code());
+        $this->assertSame('digitalogic_product_identifier_not_found', $auto_draft->get_error_code());
+    }
+
+    public function test_same_source_duplicates_are_ambiguous_for_products_and_variations(): void {
+        $sku = $this->resolver->resolve(array('sku' => 'DUP-SKU'));
+        $patris = $this->resolver->resolve(array('patris_code' => 'DUP-PATRIS'));
+
+        $this->assertSame('digitalogic_product_identifier_ambiguous', $sku->get_error_code());
+        $this->assertSame(array('603', '604'), $sku->get_error_data()['woocommerce_ids']);
+        $this->assertSame('digitalogic_product_identifier_ambiguous', $patris->get_error_code());
+        $this->assertSame(array('605', '606'), $patris->get_error_data()['woocommerce_ids']);
+    }
+
+    public function test_invalid_or_non_product_explicit_ids_fail_without_fallback(): void {
+        $integer_id = $this->resolver->resolve(array('woocommerce_id' => 602));
+        $this->assertSame('602', $integer_id['woocommerce_id']);
+        $this->assertSame('product_variation', $integer_id['post_type']);
+
+        foreach (array('0', '0601', '601x', '', array('601')) as $invalid) {
+            $result = $this->resolver->resolve(array(
+                'woocommerce_id' => $invalid,
+                'sku' => 'SKU-601',
+            ));
+            $this->assertSame('digitalogic_invalid_product_identifier', $result->get_error_code());
+        }
+
+        $not_product = $this->resolver->resolve(array('woocommerce_id' => '700', 'sku' => 'SKU-601'));
+        $this->assertSame('digitalogic_product_identifier_not_found', $not_product->get_error_code());
+    }
+}

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -229,8 +229,13 @@ final class RestApiPermissionsTest extends TestCase {
 
         $actual = array();
         foreach ($GLOBALS['digitalogic_test_routes'] as $registration) {
-            $permission_callback = $registration['args']['permission_callback'];
-            $actual[$registration['args']['methods'] . ' ' . $registration['route']] = $permission_callback[1];
+            $definitions = isset($registration['args']['callback'])
+                ? array($registration['args'])
+                : $registration['args'];
+            foreach ($definitions as $definition) {
+                $permission_callback = $definition['permission_callback'];
+                $actual[$definition['methods'] . ' ' . $registration['route']] = $permission_callback[1];
+            }
         }
 
         $expected = array(
@@ -245,15 +250,31 @@ final class RestApiPermissionsTest extends TestCase {
             'GET /reports' => 'check_diagnostic_permission',
             'POST /patris/sync' => 'check_write_permission',
             'POST /patris/push' => 'check_patris_push_permission',
+            'GET /integration/catalog' => 'check_read_permission',
+            'GET /import-freight-methods' => 'check_read_permission',
+            'POST /import-freight-methods' => 'check_write_permission',
+            'GET /import-freight-methods/(?P<id>[a-z][a-z0-9_]{1,63})' => 'check_read_permission',
+            'PUT /import-freight-methods/(?P<id>[a-z][a-z0-9_]{1,63})' => 'check_write_permission',
+            'DELETE /import-freight-methods/(?P<id>[a-z][a-z0-9_]{1,63})' => 'check_write_permission',
+            'GET /products/by-code/(?P<code>[^/]+)/import-pricing' => 'check_read_permission',
+            'PUT /products/by-code/(?P<code>[^/]+)/import-pricing' => 'check_write_permission',
+            'POST /products/import-pricing/batch' => 'check_write_permission',
         );
 
         $this->assertSame($expected, $actual);
     }
 
     public function test_patris_push_delegates_to_its_scoped_verifier() {
-        $request = new WP_REST_Request();
+        $GLOBALS['digitalogic_test_options']['digitalogic_patris_feed_push_token'] = 'scoped-patris-token';
+        unset($GLOBALS['digitalogic_test_option_cache']['digitalogic_patris_feed_push_token']);
+        $authorized = new WP_REST_Request(array(), array(), array(
+            'x-digitalogic-token' => 'scoped-patris-token',
+        ));
+        $unauthorized = new WP_REST_Request(array(), array(), array(
+            'x-digitalogic-token' => 'wrong-token',
+        ));
 
-        $this->assertSame('patris-verifier-result', $this->api->check_patris_push_permission($request));
-        $this->assertSame($request, Digitalogic_Patris_Feed::instance()->verified_request);
+        $this->assertTrue($this->api->check_patris_push_permission($authorized));
+        $this->assertFalse($this->api->check_patris_push_permission($unauthorized));
     }
 }

--- a/tests/UnitConverterTest.php
+++ b/tests/UnitConverterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class UnitConverterTest extends TestCase {
+
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_options'] = array();
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+    }
+
+    public function test_grams_are_preserved_for_a_gram_store(): void {
+        $GLOBALS['digitalogic_test_options']['woocommerce_weight_unit'] = 'g';
+
+        $this->assertSame(240.0, Digitalogic_Unit_Converter::grams_to_store_weight(240));
+    }
+
+    public function test_grams_are_converted_to_kilograms_for_a_kilogram_store(): void {
+        $GLOBALS['digitalogic_test_options']['woocommerce_weight_unit'] = 'kg';
+
+        $this->assertSame(0.24, Digitalogic_Unit_Converter::grams_to_store_weight(240));
+    }
+
+    public function test_invalid_non_finite_and_non_positive_weights_are_rejected(): void {
+        foreach (array(null, '', 'not-a-number', 0, -1, INF, NAN) as $weight) {
+            $this->assertNull(Digitalogic_Unit_Converter::grams_to_store_weight($weight));
+        }
+    }
+
+    public function test_patris_feed_uses_the_canonical_store_unit_converter(): void {
+        $source = file_get_contents(dirname(__DIR__) . '/includes/class-patris-feed.php');
+
+        $this->assertStringContainsString('Digitalogic_Unit_Converter::grams_to_store_weight', $source);
+        $this->assertStringNotContainsString("weight_grams'] / 1000", $source);
+    }
+}

--- a/tests/WebSocketLifecycleTest.php
+++ b/tests/WebSocketLifecycleTest.php
@@ -11,9 +11,15 @@ final class WebSocketLifecycleTest extends TestCase {
         $GLOBALS['digitalogic_test_options'] = array();
         $GLOBALS['digitalogic_test_filters'] = array();
         $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_action_callbacks'] = array();
+        $GLOBALS['digitalogic_test_posts'] = array();
         $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_meta_update_failures'] = array();
+        $GLOBALS['digitalogic_test_meta_delete_failures'] = array();
+        $GLOBALS['digitalogic_test_transaction_failures'] = array();
         $GLOBALS['digitalogic_test_cache_deletes'] = array();
         $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
+        $_POST = array();
         WP_CLI::$errors = array();
         WP_CLI::$warnings = array();
         WP_CLI::$logs = array();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,7 @@
 
 define('ABSPATH', __DIR__ . '/');
 define('WP_CLI', true);
+define('ARRAY_A', 'ARRAY_A');
 
 $GLOBALS['digitalogic_test_capabilities'] = array();
 $GLOBALS['digitalogic_test_filters'] = array();
@@ -14,37 +15,121 @@ $GLOBALS['digitalogic_test_rest_prefix'] = 'wp-json';
 $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
 $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
 $GLOBALS['digitalogic_test_options'] = array();
+$GLOBALS['digitalogic_test_option_cache'] = array();
 $GLOBALS['digitalogic_test_actions'] = array();
+$GLOBALS['digitalogic_test_action_callbacks'] = array();
+$GLOBALS['digitalogic_test_posts'] = array();
+$GLOBALS['digitalogic_test_post_meta_cache'] = array();
 $GLOBALS['digitalogic_test_update_failures'] = array();
+$GLOBALS['digitalogic_test_meta_update_failures'] = array();
+$GLOBALS['digitalogic_test_meta_delete_failures'] = array();
+$GLOBALS['digitalogic_test_transaction_failures'] = array();
 $GLOBALS['digitalogic_test_cache_deletes'] = array();
+$GLOBALS['digitalogic_test_remote_posts'] = array();
+$GLOBALS['digitalogic_test_remote_post_results'] = array();
+$GLOBALS['digitalogic_test_wc_products'] = array();
+$GLOBALS['digitalogic_test_wc_product_saves'] = array();
 
-class WP_REST_Request {
-    public function __construct($method = '', $route = '') {
+class WP_Error {
+    private $code;
+    private $message;
+    private $data;
+
+    public function __construct($code = '', $message = '', $data = null) {
+        $this->code = $code;
+        $this->message = $message;
+        $this->data = $data;
+    }
+
+    public function get_error_code() {
+        return $this->code;
+    }
+
+    public function get_error_message() {
+        return $this->message;
+    }
+
+    public function get_error_data() {
+        return $this->data;
     }
 }
 
-class Digitalogic_Patris_Feed {
-    private static $instance;
+class WP_REST_Request implements ArrayAccess {
+    private $params;
+    private $json;
+    private $headers;
 
-    public $verified_request;
-
-    public static function instance() {
-        if (!self::$instance) {
-            self::$instance = new self();
-        }
-
-        return self::$instance;
+    public function __construct($params = array(), $json = array(), $headers = array()) {
+        $this->params = is_array($params) ? $params : array();
+        $this->json = is_array($json) ? $json : array();
+        $this->headers = array_change_key_case(is_array($headers) ? $headers : array(), CASE_LOWER);
     }
 
-    public function verify_push_request($request) {
-        $this->verified_request = $request;
+    public function get_params() {
+        return array_merge($this->json, $this->params);
+    }
 
-        return 'patris-verifier-result';
+    public function get_json_params() {
+        return $this->json;
+    }
+
+    public function get_param($key) {
+        $params = $this->get_params();
+        return array_key_exists($key, $params) ? $params[$key] : null;
+    }
+
+    public function get_header($key) {
+        $key = strtolower((string) $key);
+        return isset($this->headers[$key]) ? $this->headers[$key] : '';
+    }
+
+    public function offsetExists($offset): bool {
+        return array_key_exists($offset, $this->params);
+    }
+
+    public function offsetGet($offset): mixed {
+        return array_key_exists($offset, $this->params) ? $this->params[$offset] : null;
+    }
+
+    public function offsetSet($offset, $value): void {
+        $this->params[$offset] = $value;
+    }
+
+    public function offsetUnset($offset): void {
+        unset($this->params[$offset]);
+    }
+}
+
+class WP_REST_Response {
+    private $data;
+    private $status;
+
+    public function __construct($data = null, $status = 200) {
+        $this->data = $data;
+        $this->status = $status;
+    }
+
+    public function get_data() {
+        return $this->data;
+    }
+
+    public function get_status() {
+        return $this->status;
     }
 }
 
 function add_action($hook_name, $callback, $priority = 10, $accepted_args = 1) {
+    $GLOBALS['digitalogic_test_action_callbacks'][$hook_name][] = array(
+        'callback' => $callback,
+        'priority' => $priority,
+        'accepted_args' => $accepted_args,
+    );
+
     return true;
+}
+
+function has_action($hook_name) {
+    return !empty($GLOBALS['digitalogic_test_action_callbacks'][$hook_name]);
 }
 
 function current_user_can($capability) {
@@ -60,6 +145,7 @@ function add_filter($hook_name, $callback, $priority = 10, $accepted_args = 1) {
 
     $GLOBALS['digitalogic_test_filters'][$hook_name][] = array(
         'callback' => $callback,
+        'priority' => $priority,
         'accepted_args' => $accepted_args,
     );
 
@@ -70,6 +156,32 @@ function remove_all_filters($hook_name) {
     unset($GLOBALS['digitalogic_test_filters'][$hook_name]);
 
     return true;
+}
+
+function remove_filter($hook_name, $callback = null) {
+    if (is_null($callback)) {
+        unset($GLOBALS['digitalogic_test_filters'][$hook_name]);
+        return true;
+    }
+
+    if (empty($GLOBALS['digitalogic_test_filters'][$hook_name])) {
+        return false;
+    }
+
+    $removed = false;
+    $GLOBALS['digitalogic_test_filters'][$hook_name] = array_values(array_filter(
+        $GLOBALS['digitalogic_test_filters'][$hook_name],
+        function($filter) use ($callback, &$removed) {
+            if (isset($filter['callback']) && $filter['callback'] === $callback) {
+                $removed = true;
+                return false;
+            }
+
+            return true;
+        }
+    ));
+
+    return $removed;
 }
 
 function apply_filters($hook_name, $value, ...$args) {
@@ -85,6 +197,11 @@ function apply_filters($hook_name, $value, ...$args) {
     if (!is_array($registered)) {
         return $value;
     }
+
+    usort($registered, function($left, $right) {
+        return (isset($left['priority']) ? $left['priority'] : 10)
+            <=> (isset($right['priority']) ? $right['priority'] : 10);
+    });
 
     foreach ($registered as $filter) {
         if (!is_array($filter) || !isset($filter['callback']) || !is_callable($filter['callback'])) {
@@ -105,6 +222,16 @@ function do_action($hook_name, ...$args) {
     }
 
     $GLOBALS['digitalogic_test_actions'][$hook_name][] = $args;
+
+    $callbacks = isset($GLOBALS['digitalogic_test_action_callbacks'][$hook_name])
+        ? $GLOBALS['digitalogic_test_action_callbacks'][$hook_name]
+        : array();
+    usort($callbacks, function($left, $right) {
+        return $left['priority'] <=> $right['priority'];
+    });
+    foreach ($callbacks as $item) {
+        call_user_func_array($item['callback'], array_slice($args, 0, $item['accepted_args']));
+    }
 }
 
 function register_rest_route($namespace, $route, $args = array(), $override = false) {
@@ -128,6 +255,10 @@ function rest_url($path = '') {
 }
 
 function get_option($name, $default = false) {
+    if (array_key_exists($name, $GLOBALS['digitalogic_test_option_cache'])) {
+        return $GLOBALS['digitalogic_test_option_cache'][$name];
+    }
+
     return array_key_exists($name, $GLOBALS['digitalogic_test_options'])
         ? $GLOBALS['digitalogic_test_options'][$name]
         : $default;
@@ -138,17 +269,205 @@ function update_option($name, $value, $autoload = null) {
         return false;
     }
 
-    $changed = !array_key_exists($name, $GLOBALS['digitalogic_test_options'])
-        || $GLOBALS['digitalogic_test_options'][$name] !== $value;
+    $exists = array_key_exists($name, $GLOBALS['digitalogic_test_options']);
+    $old_value = $exists ? $GLOBALS['digitalogic_test_options'][$name] : null;
+    $changed = !$exists || $old_value !== $value;
     $GLOBALS['digitalogic_test_options'][$name] = $value;
+    $GLOBALS['digitalogic_test_option_cache'][$name] = $value;
+
+    if ($changed) {
+        do_action('updated_option', $name, $old_value, $value);
+        do_action('update_option_' . $name, $old_value, $value, $name);
+    }
 
     return $changed;
+}
+
+function add_option($name, $value = '', $deprecated = '', $autoload = 'yes') {
+    if (array_key_exists($name, $GLOBALS['digitalogic_test_options'])) {
+        return false;
+    }
+
+    $GLOBALS['digitalogic_test_options'][$name] = $value;
+    $GLOBALS['digitalogic_test_option_cache'][$name] = $value;
+    do_action('added_option', $name, $value);
+
+    return true;
+}
+
+function delete_option($name) {
+    if (!array_key_exists($name, $GLOBALS['digitalogic_test_options'])) {
+        return false;
+    }
+
+    unset($GLOBALS['digitalogic_test_options'][$name]);
+    unset($GLOBALS['digitalogic_test_option_cache'][$name]);
+    return true;
 }
 
 function wp_cache_delete($key, $group = '') {
     $GLOBALS['digitalogic_test_cache_deletes'][] = array($key, $group);
 
+    if ('options' === $group) {
+        if ('alloptions' === $key || 'notoptions' === $key) {
+            $GLOBALS['digitalogic_test_option_cache'] = array();
+        } else {
+            unset($GLOBALS['digitalogic_test_option_cache'][$key]);
+        }
+    } elseif ('post_meta' === $group) {
+        unset($GLOBALS['digitalogic_test_post_meta_cache'][(int) $key]);
+    }
+
     return true;
+}
+
+function clean_post_cache($post_id) {
+    return wp_cache_delete((int) $post_id, 'post_meta');
+}
+
+function is_wp_error($value) {
+    return $value instanceof WP_Error;
+}
+
+function wp_parse_args($args, $defaults = array()) {
+    return array_merge($defaults, is_array($args) ? $args : array());
+}
+
+function wp_parse_url($url, $component = -1) {
+    return parse_url($url, $component);
+}
+
+function wp_unslash($value) {
+    return $value;
+}
+
+function maybe_serialize($value) {
+    return is_array($value) || is_object($value) ? serialize($value) : $value;
+}
+
+function maybe_unserialize($value) {
+    if (!is_string($value) || !preg_match('/^(?:a|O|s|i|b|d|N):/', $value)) {
+        return $value;
+    }
+
+    $unserialized = @unserialize($value);
+    return false === $unserialized && 'b:0;' !== $value ? $value : $unserialized;
+}
+
+function get_post_type($post_id) {
+    return isset($GLOBALS['digitalogic_test_posts'][$post_id])
+        ? $GLOBALS['digitalogic_test_posts'][$post_id]['post_type']
+        : null;
+}
+
+function get_post_meta($post_id, $key = '', $single = false) {
+    if (!isset($GLOBALS['digitalogic_test_posts'][$post_id])) {
+        return $single ? '' : array();
+    }
+
+    $meta = isset($GLOBALS['digitalogic_test_post_meta_cache'][$post_id])
+        ? $GLOBALS['digitalogic_test_post_meta_cache'][$post_id]
+        : $GLOBALS['digitalogic_test_posts'][$post_id]['meta'];
+    if ($key === '') {
+        return $meta;
+    }
+    if (!array_key_exists($key, $meta)) {
+        return $single ? '' : array();
+    }
+
+    return $single ? $meta[$key] : array($meta[$key]);
+}
+
+function metadata_exists($meta_type, $object_id, $meta_key) {
+    return 'post' === $meta_type
+        && isset($GLOBALS['digitalogic_test_posts'][$object_id]['meta'])
+        && array_key_exists($meta_key, $GLOBALS['digitalogic_test_posts'][$object_id]['meta']);
+}
+
+function update_post_meta($post_id, $key, $value) {
+    $failure_key = (int) $post_id . ':' . $key;
+    if (in_array($failure_key, $GLOBALS['digitalogic_test_meta_update_failures'], true)) {
+        return false;
+    }
+
+    if (!isset($GLOBALS['digitalogic_test_posts'][$post_id])) {
+        $GLOBALS['digitalogic_test_posts'][$post_id] = array('post_type' => 'product', 'meta' => array());
+    }
+
+    $exists = array_key_exists($key, $GLOBALS['digitalogic_test_posts'][$post_id]['meta']);
+    if ($exists && $GLOBALS['digitalogic_test_posts'][$post_id]['meta'][$key] === $value) {
+        return false;
+    }
+
+    $GLOBALS['digitalogic_test_posts'][$post_id]['meta'][$key] = $value;
+    if (!isset($GLOBALS['digitalogic_test_post_meta_cache'][$post_id])) {
+        $GLOBALS['digitalogic_test_post_meta_cache'][$post_id] = $GLOBALS['digitalogic_test_posts'][$post_id]['meta'];
+    }
+    $GLOBALS['digitalogic_test_post_meta_cache'][$post_id][$key] = $value;
+    do_action($exists ? 'updated_post_meta' : 'added_post_meta', 1, $post_id, $key, $value);
+
+    return 1;
+}
+
+function delete_post_meta($post_id, $key, $value = '') {
+    $failure_key = (int) $post_id . ':' . $key;
+    if (in_array($failure_key, $GLOBALS['digitalogic_test_meta_delete_failures'], true)) {
+        return false;
+    }
+    if (!isset($GLOBALS['digitalogic_test_posts'][$post_id]['meta'][$key])) {
+        return false;
+    }
+
+    $old = $GLOBALS['digitalogic_test_posts'][$post_id]['meta'][$key];
+    if (!isset($GLOBALS['digitalogic_test_post_meta_cache'][$post_id])) {
+        $GLOBALS['digitalogic_test_post_meta_cache'][$post_id] = $GLOBALS['digitalogic_test_posts'][$post_id]['meta'];
+    }
+    unset($GLOBALS['digitalogic_test_posts'][$post_id]['meta'][$key]);
+    unset($GLOBALS['digitalogic_test_post_meta_cache'][$post_id][$key]);
+    do_action('deleted_post_meta', array(1), $post_id, $key, $old);
+
+    return true;
+}
+
+function get_posts($args = array()) {
+    $result = array();
+    foreach ($GLOBALS['digitalogic_test_posts'] as $id => $post) {
+        $types = isset($args['post_type']) ? (array) $args['post_type'] : array();
+        if (!empty($types) && !in_array($post['post_type'], $types, true)) {
+            continue;
+        }
+
+        $matches = true;
+        if (isset($args['meta_key'])) {
+            $matches = array_key_exists($args['meta_key'], $post['meta']);
+            if ($matches && array_key_exists('meta_value', $args)) {
+                $matches = (string) $post['meta'][$args['meta_key']] === (string) $args['meta_value'];
+            }
+        } elseif (!empty($args['meta_query'])) {
+            $query = $args['meta_query'];
+            $relation = isset($query['relation']) ? strtoupper($query['relation']) : 'AND';
+            unset($query['relation']);
+            $clause_results = array();
+            foreach ($query as $clause) {
+                if (!is_array($clause) || !isset($clause['key'])) {
+                    continue;
+                }
+                $exists = array_key_exists($clause['key'], $post['meta']);
+                if (isset($clause['compare']) && strtoupper($clause['compare']) === 'EXISTS') {
+                    $clause_results[] = $exists;
+                } else {
+                    $clause_results[] = $exists && (string) $post['meta'][$clause['key']] === (string) $clause['value'];
+                }
+            }
+            $matches = $relation === 'OR' ? in_array(true, $clause_results, true) : !in_array(false, $clause_results, true);
+        }
+
+        if ($matches) {
+            $result[] = (int) $id;
+        }
+    }
+
+    return $result;
 }
 
 function absint($value) {
@@ -163,12 +482,61 @@ function sanitize_text_field($value) {
     return trim(strip_tags((string) $value));
 }
 
-function current_time($type) {
-    return '2026-07-16 12:00:00';
+function sanitize_email($value) {
+    $email = filter_var((string) $value, FILTER_SANITIZE_EMAIL);
+    return filter_var($email, FILTER_VALIDATE_EMAIL) ? $email : '';
 }
 
-function wp_json_encode($value) {
-    return json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+function wp_kses_post($value) {
+    return (string) $value;
+}
+
+function esc_url_raw($value) {
+    return trim((string) $value);
+}
+
+function wp_http_validate_url($value) {
+    return filter_var($value, FILTER_VALIDATE_URL) !== false;
+}
+
+function wp_generate_uuid4() {
+    return '00000000-0000-4000-8000-000000000001';
+}
+
+function get_bloginfo($field = '') {
+    return 'Digitalogic Test';
+}
+
+function home_url($path = '') {
+    return 'https://digitalogic.test' . $path;
+}
+
+function wp_remote_post($url, $args = array()) {
+    $GLOBALS['digitalogic_test_remote_posts'][] = array('url' => $url, 'args' => $args);
+
+    if (!empty($GLOBALS['digitalogic_test_remote_post_results'])) {
+        $result = array_shift($GLOBALS['digitalogic_test_remote_post_results']);
+        if ($result instanceof Throwable) {
+            throw $result;
+        }
+        return $result;
+    }
+
+    return array('response' => array('code' => 202));
+}
+
+function wp_remote_retrieve_response_code($response) {
+    return is_array($response) && isset($response['response']['code'])
+        ? (int) $response['response']['code']
+        : 0;
+}
+
+function current_time($type, $gmt = 0) {
+    return $type === 'mysql' ? '2026-07-16 12:00:00' : time();
+}
+
+function wp_json_encode($value, $flags = 0, $depth = 512) {
+    return json_encode($value, $flags, $depth);
 }
 
 function __($message, $domain = null) {
@@ -176,9 +544,21 @@ function __($message, $domain = null) {
 }
 
 class Digitalogic_Test_WPDB {
+    public $prefix = 'wp_';
+    public $posts = 'wp_posts';
+    public $options = 'wp_options';
+    public $postmeta = 'wp_postmeta';
+    public $insert_id = 0;
     public $acquire_result = 1;
     public $acquire_count = 0;
     public $release_count = 0;
+    public $queries = array();
+    public $mysql_string_roundtrip = false;
+    public $after_rollback = null;
+    public $identifier_query_count = 0;
+    private $transaction_snapshot = null;
+    private $meta_ids = array();
+    private $next_meta_id = 1;
 
     public function prepare($query, ...$args) {
         return array(
@@ -201,6 +581,395 @@ class Digitalogic_Test_WPDB {
 
         return null;
     }
+
+    public function get_row($prepared, $output = ARRAY_A) {
+        $query = is_array($prepared) && isset($prepared['query']) ? $prepared['query'] : (string) $prepared;
+        $args = is_array($prepared) && isset($prepared['args']) ? $prepared['args'] : array();
+
+        if (strpos($query, $this->options) !== false) {
+            $name = isset($args[0]) ? (string) $args[0] : '';
+            return array_key_exists($name, $GLOBALS['digitalogic_test_options'])
+                ? array('option_value' => $this->database_raw_value($GLOBALS['digitalogic_test_options'][$name]))
+                : null;
+        }
+
+        if (strpos($query, $this->postmeta) !== false) {
+            $post_id = isset($args[0]) ? (int) $args[0] : 0;
+            $key = isset($args[1]) ? (string) $args[1] : '';
+            if (!isset($GLOBALS['digitalogic_test_posts'][$post_id]['meta']) || !array_key_exists($key, $GLOBALS['digitalogic_test_posts'][$post_id]['meta'])) {
+                return null;
+            }
+            $meta_id = $this->ensure_meta_id($post_id, $key);
+            return array(
+                'meta_id' => $meta_id,
+                'meta_value' => $this->database_raw_value($GLOBALS['digitalogic_test_posts'][$post_id]['meta'][$key]),
+            );
+        }
+
+        return null;
+    }
+
+    public function get_results($prepared, $output = ARRAY_A) {
+        $query = is_array($prepared) && isset($prepared['query']) ? $prepared['query'] : (string) $prepared;
+        $args = is_array($prepared) && isset($prepared['args']) ? $prepared['args'] : array();
+        if (strpos($query, 'digitalogic_identifier:') === false) {
+            return array();
+        }
+
+        $this->identifier_query_count++;
+        $rows = array();
+        foreach ($GLOBALS['digitalogic_test_posts'] as $post_id => $post) {
+            if (!in_array($post['post_type'], array('product', 'product_variation'), true)) {
+                continue;
+            }
+            $post_status = isset($post['post_status']) ? (string) $post['post_status'] : 'publish';
+            if (in_array($post_status, array('trash', 'auto-draft'), true)) {
+                continue;
+            }
+            $sku = $this->current_test_meta_value($post, '_sku');
+            $patris_code = $this->current_test_meta_value($post, '_digitalogic_patris_product_code');
+
+            $matches = false;
+            if (strpos($query, 'digitalogic_identifier:woocommerce_id') !== false) {
+                $matches = (int) $post_id === (int) $args[0];
+            } elseif (strpos($query, 'digitalogic_identifier:sku') !== false) {
+                $matches = isset($args[1]) && $sku === (string) $args[1];
+            } elseif (strpos($query, 'digitalogic_identifier:patris_code') !== false) {
+                $matches = isset($args[1]) && $patris_code === (string) $args[1];
+            } elseif (strpos($query, 'digitalogic_identifier:code') !== false) {
+                $matches = isset($args[0]) && ($sku === (string) $args[0] || $patris_code === (string) $args[0]);
+            }
+
+            if ($matches) {
+                $rows[] = array(
+                    'ID' => (int) $post_id,
+                    'post_type' => $post['post_type'],
+                    'sku' => $sku,
+                    'patris_code' => $patris_code,
+                );
+            }
+        }
+
+        usort($rows, static function($left, $right) {
+            return (int) $left['ID'] <=> (int) $right['ID'];
+        });
+        return $rows;
+    }
+
+    private function current_test_meta_value($post, $key) {
+        if (isset($post['meta_rows'][$key]) && is_array($post['meta_rows'][$key]) && !empty($post['meta_rows'][$key])) {
+            $values = array_values($post['meta_rows'][$key]);
+            return (string) end($values);
+        }
+
+        return isset($post['meta'][$key]) ? (string) $post['meta'][$key] : '';
+    }
+
+    public function insert($table, $data, $formats = null) {
+        if ($table === $this->options) {
+            $name = (string) $data['option_name'];
+            if (in_array($name, $GLOBALS['digitalogic_test_update_failures'], true)) {
+                return false;
+            }
+            $GLOBALS['digitalogic_test_options'][$name] = $this->stored_database_value($data['option_value']);
+            $this->insert_id++;
+            return 1;
+        }
+
+        if ($table === $this->postmeta) {
+            $post_id = (int) $data['post_id'];
+            $key = (string) $data['meta_key'];
+            if (in_array($post_id . ':' . $key, $GLOBALS['digitalogic_test_meta_update_failures'], true)) {
+                return false;
+            }
+            if (!isset($GLOBALS['digitalogic_test_posts'][$post_id])) {
+                $GLOBALS['digitalogic_test_posts'][$post_id] = array('post_type' => 'product', 'meta' => array());
+            }
+            $GLOBALS['digitalogic_test_posts'][$post_id]['meta'][$key] = $this->stored_database_value($data['meta_value']);
+            $this->insert_id = $this->next_meta_id++;
+            $this->meta_ids[$post_id][$key] = $this->insert_id;
+            return 1;
+        }
+
+        return false;
+    }
+
+    public function update($table, $data, $where, $formats = null, $where_formats = null) {
+        if ($table === $this->options) {
+            $name = (string) $where['option_name'];
+            if (in_array($name, $GLOBALS['digitalogic_test_update_failures'], true)) {
+                return false;
+            }
+            if (!array_key_exists($name, $GLOBALS['digitalogic_test_options'])) {
+                return 0;
+            }
+            $GLOBALS['digitalogic_test_options'][$name] = $this->stored_database_value($data['option_value']);
+            return 1;
+        }
+
+        if ($table === $this->postmeta && isset($where['meta_id'])) {
+            foreach ($GLOBALS['digitalogic_test_posts'] as $post_id => &$post) {
+                foreach ($post['meta'] as $key => &$value) {
+                    if ($this->ensure_meta_id($post_id, $key) !== (int) $where['meta_id']) {
+                        continue;
+                    }
+                    if (in_array($post_id . ':' . $key, $GLOBALS['digitalogic_test_meta_update_failures'], true)) {
+                        return false;
+                    }
+                    $value = $this->stored_database_value($data['meta_value']);
+                    return 1;
+                }
+                unset($value);
+            }
+            unset($post);
+            return 0;
+        }
+
+        return false;
+    }
+
+    public function delete($table, $where, $formats = null) {
+        if ($table === $this->options) {
+            $name = (string) $where['option_name'];
+            if (in_array($name, $GLOBALS['digitalogic_test_update_failures'], true)) {
+                return false;
+            }
+            if (!array_key_exists($name, $GLOBALS['digitalogic_test_options'])) {
+                return 0;
+            }
+            unset($GLOBALS['digitalogic_test_options'][$name]);
+            return 1;
+        }
+
+        if ($table === $this->postmeta) {
+            $post_id = (int) $where['post_id'];
+            $key = (string) $where['meta_key'];
+            if (in_array($post_id . ':' . $key, $GLOBALS['digitalogic_test_meta_delete_failures'], true)) {
+                return false;
+            }
+            if (!isset($GLOBALS['digitalogic_test_posts'][$post_id]['meta'][$key])) {
+                return 0;
+            }
+            unset($GLOBALS['digitalogic_test_posts'][$post_id]['meta'][$key], $this->meta_ids[$post_id][$key]);
+            return 1;
+        }
+
+        return false;
+    }
+
+    private function ensure_meta_id($post_id, $key) {
+        if (!isset($this->meta_ids[$post_id][$key])) {
+            $this->meta_ids[$post_id][$key] = $this->next_meta_id++;
+        }
+        return $this->meta_ids[$post_id][$key];
+    }
+
+    private function database_raw_value($value) {
+        $serialized = maybe_serialize($value);
+        return $this->mysql_string_roundtrip ? (string) $serialized : $serialized;
+    }
+
+    private function stored_database_value($value) {
+        $stored = maybe_unserialize($value);
+        if ($this->mysql_string_roundtrip && !is_array($stored) && !is_object($stored)) {
+            return (string) $stored;
+        }
+
+        return $stored;
+    }
+
+    public function query($query) {
+        $normalized = strtoupper(trim((string) $query));
+        $this->queries[] = $normalized;
+        if (in_array($normalized, $GLOBALS['digitalogic_test_transaction_failures'], true)) {
+            return false;
+        }
+
+        if ('START TRANSACTION' === $normalized) {
+            $this->transaction_snapshot = array(
+                'options' => $GLOBALS['digitalogic_test_options'],
+                'posts' => $GLOBALS['digitalogic_test_posts'],
+                'meta_ids' => $this->meta_ids,
+                'next_meta_id' => $this->next_meta_id,
+            );
+            return 1;
+        }
+        if ('ROLLBACK' === $normalized) {
+            if (is_array($this->transaction_snapshot)) {
+                $GLOBALS['digitalogic_test_options'] = $this->transaction_snapshot['options'];
+                $GLOBALS['digitalogic_test_posts'] = $this->transaction_snapshot['posts'];
+                $this->meta_ids = $this->transaction_snapshot['meta_ids'];
+                $this->next_meta_id = $this->transaction_snapshot['next_meta_id'];
+            }
+            $this->transaction_snapshot = null;
+            $after_rollback = $this->after_rollback;
+            $this->after_rollback = null;
+            if (is_callable($after_rollback)) {
+                call_user_func($after_rollback, $this);
+            }
+            return 1;
+        }
+        if ('COMMIT' === $normalized) {
+            $this->transaction_snapshot = null;
+            return 1;
+        }
+
+        return 1;
+    }
+}
+
+class Digitalogic_Options {
+    private static $instance;
+
+    public static function instance() {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public function get_yuan_price() {
+        return (float) get_option('options_yuan_price', get_option('yuan_price', 0));
+    }
+
+    public function get_update_date() {
+        return (string) get_option('options_update_date', get_option('update_date', ''));
+    }
+}
+
+class Digitalogic_Product_Manager {
+    private static $instance;
+
+    public static function instance() {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public function get_products($args = array()) {
+        return array();
+    }
+}
+
+class Digitalogic_Logger {
+    private static $instance;
+    public $entries = array();
+
+    public static function instance() {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function log(...$args) {
+        $this->entries[] = $args;
+        return true;
+    }
+}
+
+class WC_Product {
+    public $id;
+    public $meta = array();
+    public $weight = null;
+    public $manage_stock = false;
+    public $stock_quantity = null;
+    public $stock_status = null;
+    public $regular_price = null;
+    public $price = null;
+    public $save_count = 0;
+
+    public function __construct($id) {
+        $this->id = (int) $id;
+        $this->meta = isset($GLOBALS['digitalogic_test_posts'][$this->id]['meta'])
+            ? $GLOBALS['digitalogic_test_posts'][$this->id]['meta']
+            : array();
+    }
+
+    public function update_meta_data($key, $value) {
+        $this->meta[$key] = $value;
+    }
+
+    public function set_weight($value) {
+        $this->weight = (string) $value;
+    }
+
+    public function set_manage_stock($value) {
+        $this->manage_stock = (bool) $value;
+    }
+
+    public function set_stock_quantity($value) {
+        $this->stock_quantity = (int) $value;
+    }
+
+    public function set_stock_status($value) {
+        $this->stock_status = (string) $value;
+    }
+
+    public function set_regular_price($value) {
+        $this->regular_price = (string) $value;
+    }
+
+    public function set_price($value) {
+        $this->price = (string) $value;
+    }
+
+    public function save() {
+        $this->save_count++;
+        $GLOBALS['digitalogic_test_posts'][$this->id]['meta'] = $this->meta;
+        $GLOBALS['digitalogic_test_wc_product_saves'][] = $this->id;
+        return $this->id;
+    }
+}
+
+function wc_get_product($product_id) {
+    $product_id = (int) $product_id;
+    if (
+        !isset($GLOBALS['digitalogic_test_posts'][$product_id])
+        || !in_array($GLOBALS['digitalogic_test_posts'][$product_id]['post_type'], array('product', 'product_variation'), true)
+    ) {
+        return false;
+    }
+
+    if (!isset($GLOBALS['digitalogic_test_wc_products'][$product_id])) {
+        $GLOBALS['digitalogic_test_wc_products'][$product_id] = new WC_Product($product_id);
+    }
+
+    return $GLOBALS['digitalogic_test_wc_products'][$product_id];
+}
+
+function get_woocommerce_currency() {
+    return 'IRT';
+}
+
+function wc_get_weight($weight, $to_unit, $from_unit = '') {
+    $weight = (float) $weight;
+    $from_unit = $from_unit !== '' ? $from_unit : 'kg';
+    $grams = array(
+        'g' => $weight,
+        'kg' => $weight * 1000,
+        'lbs' => $weight * 453.59237,
+        'oz' => $weight * 28.349523125,
+    );
+
+    if (!isset($grams[$from_unit])) {
+        return 0;
+    }
+
+    $divisors = array(
+        'g' => 1,
+        'kg' => 1000,
+        'lbs' => 453.59237,
+        'oz' => 28.349523125,
+    );
+
+    return isset($divisors[$to_unit]) ? $grams[$from_unit] / $divisors[$to_unit] : 0;
+}
+
+function wc_get_price_decimals() {
+    return 0;
 }
 
 class Digitalogic_Test_Redis_Client {
@@ -271,7 +1040,14 @@ class WP_CLI {
 
 $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
 
+require_once dirname(__DIR__) . '/includes/class-unit-converter.php';
+require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';
+require_once dirname(__DIR__) . '/includes/class-patris-feed.php';
+require_once dirname(__DIR__) . '/includes/class-import-freight-service.php';
+require_once dirname(__DIR__) . '/includes/class-command-dispatcher.php';
 require_once dirname(__DIR__) . '/includes/api/class-rest-api.php';
+require_once dirname(__DIR__) . '/includes/api/class-webhooks.php';
+require_once dirname(__DIR__) . '/includes/class-report-engine.php';
 require_once dirname(__DIR__) . '/includes/panel/class-panel.php';
 require_once dirname(__DIR__) . '/includes/websocket/class-websocket-server.php';
 require_once dirname(__DIR__) . '/includes/cli/class-cli-commands.php';


### PR DESCRIPTION
﻿## Summary
- add a canonical supplier import-freight catalog, explicitly separate from WooCommerce customer delivery methods
- migrate legacy `express` / `aerial` / `marine` ACF values to immutable `air_express` / `air_freight` / `sea_freight` IDs
- expose authenticated catalog, method CRUD, exact Code/SKU assignment, atomic batch assignment, and admin UI
- add the current `landed_price` inputs and markup fields consumed by Patris Export
- reuse one shared exact Woo ID ? SKU ? Patris Code resolver across freight and Patris feed paths
- normalize Patris gram weights to the configured WooCommerce unit
- connect committed changes to the durable Panel queue, Redis/WebSocket, and signed outbound webhooks with observable delivery warnings

## Safety and consistency
- advisory-lock serialization and verified InnoDB transactions
- direct uncached option/meta reads and writes, post-commit cache invalidation/hooks, fail-closed rollback handling
- compare-and-swap reconciliation for legacy ACF/option writes
- missing assignment fields cannot clear data; explicit null still clears
- reserved legacy aliases, duplicate resolved-product batch targets, disabled-method replays, malformed FX/transit inputs, and ambiguous identifiers are handled explicitly
- no WooCommerce shipping zones/rates/customer delivery APIs are changed

## Validation
- 87 PHPUnit tests / 504 assertions
- all PHP files pass `php -l`
- 11 JavaScript files pass `node --check`
- `composer validate --strict` and lock dry-run pass (CI targets PHP 8.3)
- public-tree guard and staged/unstaged diff checks pass
- independent final review reproduced the former race, cache, scalar-readback, event, unit, and resolver failures and found the final branch merge-ready

## Deployment
Version is bumped to 1.1.0. Production migration should run under maintenance mode after a database backup, before reactivation; the migration marker is written only after the catalog and all legacy assignments read back successfully.

Closes #36

