### PR TITLE
Add safe transformed Patris product-sync receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced plugin page with action links and row meta links
 - Fixed WP-CLI command registration to prevent "can't have subcommands" error
 
+## [1.2.0] - 2026-07-16
+
+### Added
+- Dedicated authenticated `digitalogic.product-sync` v1 REST receiver, kept separate from the legacy Patris push route.
+- Strict typed envelope validation, recursive raw-field rejection, Go-compatible record/source/event hash verification, and duplicate-key-safe JSON decoding.
+- Ordered per-source snapshots, update merging, bounded event replay protection, quarantine preservation, and deletion-only tombstones that never delete WooCommerce products.
+- Receiver contract and staged rollout documentation.
+
+### Changed
+- The normalized Patris WooCommerce writer is shared by legacy and v1 ingestion so Code resolution, weight, stock, price, and metadata behavior stay aligned.
+
 ## [1.1.0] - 2026-07-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Dedicated authenticated `digitalogic.product-sync` v1 REST receiver, kept separate from the legacy Patris push route.
-- Strict typed envelope validation, recursive raw-field rejection, Go-compatible record/source/event hash verification, and duplicate-key-safe JSON decoding.
-- Ordered per-source snapshots, update merging, bounded event replay protection, quarantine preservation, and deletion-only tombstones that never delete WooCommerce products.
+- Strict typed envelope validation, recursive raw-field rejection, receiver-side exact `landed_price_v1` evaluation, Go-compatible record/source/occurrence hash verification, and duplicate-key-safe JSON decoding.
+- Ordered per-source snapshots, timestamp-bound event identities, update merging, bounded replay protection, quarantine preservation, and deletion-only tombstones that never delete WooCommerce products.
+- Dedicated header-only v1 receiver secrets with optional exact source scopes, plus a durable per-product WooCommerce outbox with record-hash CAS recovery.
 - Receiver contract and staged rollout documentation.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ curl -X POST https://yoursite.com/wp-json/digitalogic/v1/products/batch \
 Import freight is distinct from customer delivery and WooCommerce checkout
 shipping. See [Import Freight Integration Contract](docs/IMPORT-FREIGHT-API.md).
 
+#### Patris Product Sync v1
+- `POST /wp-json/digitalogic/v1/patris/product-sync` - Accept a verified, transformed-only snapshot or delta
+- `POST /wp-json/digitalogic/v1/patris/push` - Legacy feed route; not safe for v1 deltas
+
+The v1 receiver verifies record, source, and event hashes; merges deltas;
+deduplicates event IDs; and treats deleted Codes as receiver-state tombstones,
+never WooCommerce deletions. See [Patris Product Sync v1](docs/PATRIS-PRODUCT-SYNC-V1.md).
+
 #### Export
 - `GET /wp-json/digitalogic/v1/export?format=csv` - Export products as CSV
 - `GET /wp-json/digitalogic/v1/export?format=json` - Export products as JSON
@@ -348,6 +356,11 @@ GPL v2 or later. See LICENSE file for details.
 Developed for Digitalogic electronic components shop.
 
 ## Changelog
+
+### 1.2.0
+- Added the authenticated, transformed-only `digitalogic.product-sync` v1 receiver with deterministic integrity and ordering checks.
+- Added snapshot/delta merging, bounded replay protection, quarantine preservation, and non-destructive Code tombstones.
+- Reused the exact Code/SKU resolver and normalized Patris WooCommerce writer without changing the legacy feed route.
 
 ### 1.1.0
 - Added the canonical supplier import-freight catalog, Code/SKU assignments, landed-price contract, and Patris integration API.

--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ shipping. See [Import Freight Integration Contract](docs/IMPORT-FREIGHT-API.md).
 - `POST /wp-json/digitalogic/v1/patris/product-sync` - Accept a verified, transformed-only snapshot or delta
 - `POST /wp-json/digitalogic/v1/patris/push` - Legacy feed route; not safe for v1 deltas
 
-The v1 receiver verifies record, source, and event hashes; merges deltas;
-deduplicates event IDs; and treats deleted Codes as receiver-state tombstones,
-never WooCommerce deletions. See [Patris Product Sync v1](docs/PATRIS-PRODUCT-SYNC-V1.md).
+The v1 receiver uses a dedicated header-only secret, independently recomputes
+`landed_price_v1`, verifies record/source/occurrence hashes, merges deltas, and
+keeps failed Woo writes in a durable idempotent outbox. Patris Code is canonical
+and deleted Codes are receiver-state tombstones, never WooCommerce deletions.
+See [Patris Product Sync v1](docs/PATRIS-PRODUCT-SYNC-V1.md).
 
 #### Export
 - `GET /wp-json/digitalogic/v1/export?format=csv` - Export products as CSV
@@ -360,7 +362,8 @@ Developed for Digitalogic electronic components shop.
 ### 1.2.0
 - Added the authenticated, transformed-only `digitalogic.product-sync` v1 receiver with deterministic integrity and ordering checks.
 - Added snapshot/delta merging, bounded replay protection, quarantine preservation, and non-destructive Code tombstones.
-- Reused the exact Code/SKU resolver and normalized Patris WooCommerce writer without changing the legacy feed route.
+- Added exact receiver-side landed-price verification, a durable per-product Woo delivery outbox, and a separate source-scopeable header secret.
+- Reused the exact collision-safe Patris Code/SKU resolver and normalized Patris WooCommerce writer without changing the legacy feed route.
 
 ### 1.1.0
 - Added the canonical supplier import-freight catalog, Code/SKU assignments, landed-price contract, and Patris integration API.

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('DIGITALOGIC_VERSION', '1.1.0');
+define('DIGITALOGIC_VERSION', '1.2.0');
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.2');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('DIGITALOGIC_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -115,6 +115,7 @@ final class Digitalogic {
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-unit-converter.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-identifier-resolver.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-patris-feed.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-sync-receiver.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-import-freight-service.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-report-engine.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-command-dispatcher.php';

--- a/docs/PATRIS-PRODUCT-SYNC-V1.md
+++ b/docs/PATRIS-PRODUCT-SYNC-V1.md
@@ -20,10 +20,23 @@ stored receiver state and WooCommerce canary products.
 
 Use either:
 
-- `X-Digitalogic-Token: <Patris push token>`; this v1 route accepts the token in
-  a header only, never in the query string; or
+- `X-Digitalogic-Product-Sync-Secret: <v1 receiver secret>`; this credential is
+  separate from the legacy Patris push token and is accepted in this header
+  only, never in the query string or `X-Digitalogic-Token`; or
 - an authenticated Digitalogic write scope, including a WooCommerce REST API
   key whose user can manage WooCommerce.
+
+The receiver secret is stored in `digitalogic_product_sync_v1_secret` and is
+generated on first read. Deployments should configure exact source scopes in
+`digitalogic_product_sync_v1_source_scopes` as a JSON list of `{id,dataset}`
+objects. An empty list is unscoped for initial setup; a non-empty list denies
+every source pair not present exactly. For example:
+
+```bash
+wp option update digitalogic_product_sync_v1_source_scopes \
+  '[{"id":"patris-office","dataset":"kala.db"}]' --format=json
+wp eval 'echo Digitalogic_Patris_Feed::instance()->get_product_sync_secret();'
+```
 
 Patris may also send `X-Patris-Contract`, `X-Patris-Contract-Version`, and
 `X-Patris-Event-ID`. When present, each header must match the JSON body.
@@ -71,18 +84,43 @@ case, and separator variants of `Sharh`, `Sharh1`, `Sharh2`, `FOROSH`,
 The receiver independently verifies:
 
 - each `record_hash` from the typed product in Go-compatible JSON field order;
+- every non-null `final_price` by independently evaluating
+  `landed_price_v1` as bounded exact decimals, with one half-up round to the
+  final IRT integer; incomplete formula inputs require `final_price: null`;
 - `source.revision` from the resulting complete source snapshot; and
 - `event_id` from the schema, source identity, sorted record hashes,
-  tombstones, and quarantined Codes.
+  occurrence timestamp, tombstones, and quarantined Codes.
+
+The exact `event_id` hash material is the compact Go `encoding/json` object in
+this field order:
+
+```text
+schema, schema_version, event_type, local_currency, formula_id,
+formula_revision, source{id,dataset,revision}, generated_at, products,
+[deleted_codes when non-empty], [quarantined_codes when non-empty]
+```
+
+`products` is a lexicographically sorted string list whose entries are
+`<product_code>=<record_hash>`. `generated_at` is the exact validated RFC3339
+wire string. Binding it into the identity makes same-content occurrences at
+different timestamps distinct and ensures a newer same-content event advances
+the ordering watermark.
 
 The JSON decoder rejects duplicate object keys and preserves exact decimal
 tokens while hashing. Events are ordered per `{source.id, source.dataset}` by
 RFC3339-nanosecond `generated_at`. An update requires an existing snapshot.
 Older events and conflicting events at the same source timestamp are rejected.
 
+Formula operands allow at most 15 integer digits and 12 fractional digits;
+percentage markup is bounded to `0..1000`. Required price, weight, freight,
+markup, and exchange-rate inputs must be present (and the freight method must
+be selected) for a non-null final price. Binary floating point is not used.
+
 The most recent 128 event IDs per source are retained. Replaying one of those
-IDs returns `status: replayed` without another option write, WooCommerce save,
-log entry, or domain event.
+IDs after full delivery returns `status: replayed` without another option
+write, WooCommerce save, log entry, or domain event. If products remain in the
+durable outbox, the identical replay retries only those pending products and
+returns `recovered` or `retry_pending`.
 
 ## Snapshot, update, deletion, and quarantine behavior
 
@@ -95,13 +133,19 @@ log entry, or domain event.
   quarantined Code cannot also appear as a product or tombstone in the event.
 
 Incoming changed products are optionally mirrored to WooCommerce only through
-the shared exact Code/SKU resolver. Missing or ambiguous identifiers are
-reported and never resolved by fuzzy name matching.
+the shared exact Code/SKU resolver. Patris Code is canonical. SKU is used only
+when no exact Patris Code exists; a distinct exact SKU and Patris Code collision
+is ambiguous. Missing or ambiguous identifiers are reported and never resolved
+by fuzzy name matching.
 
 Receiver state is written under `digitalogic_product_sync_v1_state`, evicted
 from the option cache, and read back with a digest check before WooCommerce
-writes and the `digitalogic_product_sync_v1_applied` domain action. This state
-is independent of the legacy Patris feed option.
+writes. Each source has a durable per-product pending outbox plus an applied
+`{record_hash,woocommerce_id}` CAS record. A successful persisted Woo record
+hash acknowledges crash-window retries without a duplicate save. Missing,
+ambiguous, and failed writes stay pending. The final outbox state is read back
+before the result-aware `digitalogic_product_sync_v1_applied` domain action.
+This state is independent of the legacy Patris feed option.
 
 ## Successful response
 
@@ -116,6 +160,9 @@ is independent of the legacy Patris feed option.
     "received_products": 1,
     "stored_products": 2,
     "deleted_codes": 0,
+    "fully_applied": true,
+    "retryable": false,
+    "pending_products": 0,
     "persistence_verified": true,
     "woocommerce": {
       "updated": 1,
@@ -130,3 +177,13 @@ is independent of the legacy Patris feed option.
 
 Validation errors use HTTP 400 or 422. Ordering conflicts use 409. A busy
 advisory lock or unavailable lock service returns retryable HTTP 503.
+
+When any WooCommerce target is missing, ambiguous, or fails to save, the HTTP
+request remains a verified receiver commit but `data.status` is
+`partially_applied`, `retryable` is true, and `pending_products` is non-zero.
+Send the identical event again after correcting the product or write failure.
+
+The synthetic cross-project fixture is 2,760 bytes with SHA-256
+`810bdf4d8fd5e3c2a87750a02f241363f6403736c899a625f615967fea259da5`.
+Its occurrence identity is
+`sha256:25d5afce95dfdcf598c28f9c9639cbd54ed7f2e838a6c285844eee75d972ef06`.

--- a/docs/PATRIS-PRODUCT-SYNC-V1.md
+++ b/docs/PATRIS-PRODUCT-SYNC-V1.md
@@ -1,0 +1,132 @@
+# Patris Product Sync v1 Receiver
+
+Digitalogic exposes a dedicated receiver for the transformed Patris Export
+contract:
+
+```text
+POST /wp-json/digitalogic/v1/patris/product-sync
+```
+
+This endpoint is intentionally separate from the legacy `/patris/push` route.
+The legacy route accepts historical product/customer snapshots and keeps its
+existing replacement behavior. New Patris integrations must use
+`/patris/product-sync`; sending a v1 delta to the legacy route is unsupported.
+
+Do not enable production delivery merely by deploying this code. First run the
+cross-project contract tests, send a read-only staging snapshot, and verify the
+stored receiver state and WooCommerce canary products.
+
+## Authentication
+
+Use either:
+
+- `X-Digitalogic-Token: <Patris push token>`; this v1 route accepts the token in
+  a header only, never in the query string; or
+- an authenticated Digitalogic write scope, including a WooCommerce REST API
+  key whose user can manage WooCommerce.
+
+Patris may also send `X-Patris-Contract`, `X-Patris-Contract-Version`, and
+`X-Patris-Event-ID`. When present, each header must match the JSON body.
+
+## Envelope
+
+The receiver accepts schema major version 1. The current producer sends:
+
+```json
+{
+  "schema": "digitalogic.product-sync",
+  "schema_version": "1.0",
+  "event": "digitalogic.product-sync",
+  "event_type": "snapshot",
+  "event_id": "sha256:...",
+  "local_currency": "IRT",
+  "formula_id": "landed_price_v1",
+  "formula_revision": "1.0.0",
+  "formula_version": "landed_price_v1",
+  "source": {
+    "id": "patris-office",
+    "dataset": "kala.db",
+    "revision": "sha256:..."
+  },
+  "generated_at": "2026-07-16T08:00:00Z",
+  "products": [],
+  "deleted_codes": [],
+  "quarantined_codes": [],
+  "warnings": []
+}
+```
+
+Every product is the fixed typed `digitalogic.product-sync` v1 shape emitted by
+Patris Export. `product_code` is always a non-empty JSON string, even when it
+contains only digits. Product output currency is CNY, final prices are
+non-negative integer IRT values or `null`, and the product formula must be
+`landed_price_v1`.
+
+The receiver recursively rejects raw Patris/Paradox keys, including spelling,
+case, and separator variants of `Sharh`, `Sharh1`, `Sharh2`, `FOROSH`,
+`KHARYD`, `ALLANBAR`, and `ANBAR*`. Only transformed fields cross this boundary.
+
+## Integrity and ordering
+
+The receiver independently verifies:
+
+- each `record_hash` from the typed product in Go-compatible JSON field order;
+- `source.revision` from the resulting complete source snapshot; and
+- `event_id` from the schema, source identity, sorted record hashes,
+  tombstones, and quarantined Codes.
+
+The JSON decoder rejects duplicate object keys and preserves exact decimal
+tokens while hashing. Events are ordered per `{source.id, source.dataset}` by
+RFC3339-nanosecond `generated_at`. An update requires an existing snapshot.
+Older events and conflicting events at the same source timestamp are rejected.
+
+The most recent 128 event IDs per source are retained. Replaying one of those
+IDs returns `status: replayed` without another option write, WooCommerce save,
+log entry, or domain event.
+
+## Snapshot, update, deletion, and quarantine behavior
+
+- `snapshot` replaces the receiver snapshot for that source.
+- `update` merges complete changed products into the existing snapshot.
+- `deleted_codes` is valid on updates, including an update containing only
+  tombstones. It removes exact Codes from receiver state only.
+- A tombstone never trashes, drafts, or deletes a WooCommerce product.
+- `quarantined_codes` protects the previously stored record for that Code. A
+  quarantined Code cannot also appear as a product or tombstone in the event.
+
+Incoming changed products are optionally mirrored to WooCommerce only through
+the shared exact Code/SKU resolver. Missing or ambiguous identifiers are
+reported and never resolved by fuzzy name matching.
+
+Receiver state is written under `digitalogic_product_sync_v1_state`, evicted
+from the option cache, and read back with a digest check before WooCommerce
+writes and the `digitalogic_product_sync_v1_applied` domain action. This state
+is independent of the legacy Patris feed option.
+
+## Successful response
+
+```json
+{
+  "success": true,
+  "data": {
+    "status": "accepted",
+    "replayed": false,
+    "event_id": "sha256:...",
+    "event_type": "update",
+    "received_products": 1,
+    "stored_products": 2,
+    "deleted_codes": 0,
+    "persistence_verified": true,
+    "woocommerce": {
+      "updated": 1,
+      "missing": 0,
+      "ambiguous": 0,
+      "failed": 0,
+      "errors": []
+    }
+  }
+}
+```
+
+Validation errors use HTTP 400 or 422. Ordering conflicts use 409. A busy
+advisory lock or unavailable lock service returns retryable HTTP 503.

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -253,6 +253,14 @@ class Digitalogic_REST_API {
             'permission_callback' => array($this, 'check_patris_push_permission')
         ));
 
+        // Versioned transformed-only contract. This is intentionally distinct
+        // from the legacy full-replacement /patris/push parser.
+        register_rest_route('digitalogic/v1', '/patris/product-sync', array(
+            'methods' => 'POST',
+            'callback' => array($this, 'receive_patris_product_sync'),
+            'permission_callback' => array($this, 'check_patris_product_sync_permission')
+        ));
+
         // Supplier import freight (not WooCommerce customer delivery methods).
         register_rest_route('digitalogic/v1', '/integration/catalog', array(
             'methods' => 'GET',
@@ -388,6 +396,21 @@ class Digitalogic_REST_API {
 
     public function check_patris_push_permission(WP_REST_Request $request) {
         return Digitalogic_Patris_Feed::instance()->verify_push_request($request);
+    }
+
+    /**
+     * Authenticate the contract-aware receiver via its header-only Patris token
+     * or the normal write scope (including WooCommerce REST API credentials).
+     *
+     * @param WP_REST_Request $request Current request.
+     * @return bool
+     */
+    public function check_patris_product_sync_permission(WP_REST_Request $request) {
+        if (Digitalogic_Patris_Feed::instance()->verify_product_sync_request($request)) {
+            return true;
+        }
+
+        return $this->check_write_permission($request);
     }
 
     /**
@@ -608,6 +631,43 @@ class Digitalogic_REST_API {
         ), 200);
     }
 
+    /**
+     * POST /patris/product-sync
+     *
+     * Consume the deterministic digitalogic.product-sync v1 envelope. Patris
+     * identity headers are optional, but when present they must agree with the
+     * body so proxies cannot accidentally pair stale metadata with new JSON.
+     */
+    public function receive_patris_product_sync(WP_REST_Request $request) {
+        $payload = $request->get_json_params();
+        $header_contract = $request->get_header('x-patris-contract');
+        $header_version = $request->get_header('x-patris-contract-version');
+        $header_event_id = $request->get_header('x-patris-event-id');
+        $header_checks = array(
+            'x-patris-contract' => array($header_contract, is_array($payload) ? ($payload['schema'] ?? null) : null),
+            'x-patris-contract-version' => array($header_version, is_array($payload) ? ($payload['schema_version'] ?? null) : null),
+            'x-patris-event-id' => array($header_event_id, is_array($payload) ? ($payload['event_id'] ?? null) : null),
+        );
+        foreach ($header_checks as $header => $values) {
+            if ('' !== $values[0] && (!is_string($values[1]) || !hash_equals((string) $values[0], $values[1]))) {
+                return new WP_REST_Response(array(
+                    'success' => false,
+                    'code' => 'digitalogic_product_sync_header_mismatch',
+                    'message' => 'Patris identity headers must match the product-sync body.',
+                    'details' => array('header' => $header),
+                ), 400);
+            }
+        }
+
+        $body = method_exists($request, 'get_body') ? $request->get_body() : '';
+        if (!is_string($body) || '' === trim($body)) {
+            $body = wp_json_encode(is_array($payload) ? $payload : array());
+        }
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive_json($body);
+
+        return $this->product_sync_response($result);
+    }
+
     public function get_integration_catalog(WP_REST_Request $request) {
         return $this->import_freight_response(
             Digitalogic_Command_Dispatcher::instance()->get_integration_catalog($request->get_params())
@@ -691,5 +751,21 @@ class Digitalogic_REST_API {
         }
 
         return new WP_REST_Response(array('success' => true, 'data' => $result), $success_status);
+    }
+
+    private function product_sync_response($result) {
+        if (is_wp_error($result)) {
+            $details = $result->get_error_data();
+            $status = is_array($details) && isset($details['status']) ? (int) $details['status'] : 400;
+
+            return new WP_REST_Response(array(
+                'success' => false,
+                'code' => $result->get_error_code(),
+                'message' => $result->get_error_message(),
+                'details' => $details,
+            ), $status);
+        }
+
+        return new WP_REST_Response(array('success' => true, 'data' => $result), 200);
     }
 }

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -399,8 +399,8 @@ class Digitalogic_REST_API {
     }
 
     /**
-     * Authenticate the contract-aware receiver via its header-only Patris token
-     * or the normal write scope (including WooCommerce REST API credentials).
+     * Authenticate the contract-aware receiver via its dedicated header-only
+     * secret or the normal write scope (including WooCommerce credentials).
      *
      * @param WP_REST_Request $request Current request.
      * @return bool

--- a/includes/class-patris-feed.php
+++ b/includes/class-patris-feed.php
@@ -25,6 +25,8 @@ class Digitalogic_Patris_Feed {
     private const CUSTOMERS_OPTION = 'digitalogic_patris_feed_customers';
     private const LAST_SYNC_OPTION = 'digitalogic_patris_feed_last_sync';
     private const TOKEN_OPTION = 'digitalogic_patris_feed_push_token';
+    public const PRODUCT_SYNC_SECRET_OPTION = 'digitalogic_product_sync_v1_secret';
+    public const PRODUCT_SYNC_SCOPES_OPTION = 'digitalogic_product_sync_v1_source_scopes';
 
     private static $instance = null;
 
@@ -320,18 +322,86 @@ class Digitalogic_Patris_Feed {
     }
 
     /**
-     * Authenticate the versioned receiver without accepting query-string
-     * credentials. The token remains shared with the legacy integration so an
-     * operator can migrate endpoints without provisioning a second secret.
+     * Return the dedicated v1 receiver secret.
+     *
+     * This credential is intentionally independent of the legacy push token.
+     */
+    public function get_product_sync_secret() {
+        $secret = (string) get_option(self::PRODUCT_SYNC_SECRET_OPTION, '');
+        if ('' !== $secret) {
+            return $secret;
+        }
+
+        $generated = wp_generate_password(64, false, false);
+        if (add_option(self::PRODUCT_SYNC_SECRET_OPTION, $generated, '', 'no')) {
+            return $generated;
+        }
+
+        return (string) get_option(self::PRODUCT_SYNC_SECRET_OPTION, '');
+    }
+
+    /**
+     * Return normalized exact source scopes for the v1 secret.
+     *
+     * An empty list is deliberately unscoped for backwards-compatible setup;
+     * once configured, every request must match one exact {id,dataset} pair.
+     */
+    public function get_product_sync_source_scopes() {
+        $configured = get_option(self::PRODUCT_SYNC_SCOPES_OPTION, array());
+        $scopes = array();
+        foreach ((array) $configured as $scope) {
+            if (!is_array($scope)) {
+                continue;
+            }
+            $id = isset($scope['id']) && is_string($scope['id']) ? trim($scope['id']) : '';
+            $dataset = isset($scope['dataset']) && is_string($scope['dataset']) ? trim($scope['dataset']) : '';
+            if ('' === $id || '' === $dataset || strlen($id) > 191 || strlen($dataset) > 191) {
+                continue;
+            }
+            $scopes[$id . "\n" . $dataset] = array('id' => $id, 'dataset' => $dataset);
+        }
+
+        ksort($scopes, SORT_STRING);
+        return array_values($scopes);
+    }
+
+    /**
+     * Authenticate the versioned receiver with its dedicated header-only
+     * secret and, when configured, an exact source ID/dataset scope.
      *
      * @param WP_REST_Request $request Current request.
      * @return bool
      */
     public function verify_product_sync_request(WP_REST_Request $request) {
-        $expected = $this->get_push_token();
-        $provided = $request->get_header('x-digitalogic-token');
+        $expected = $this->get_product_sync_secret();
+        $provided = $request->get_header('x-digitalogic-product-sync-secret');
 
-        return is_string($provided) && '' !== $provided && hash_equals($expected, $provided);
+        if (!is_string($provided) || '' === $provided || '' === $expected || !hash_equals($expected, $provided)) {
+            return false;
+        }
+
+        $configured_scopes = get_option(self::PRODUCT_SYNC_SCOPES_OPTION, array());
+        $scopes = $this->get_product_sync_source_scopes();
+        if (empty($configured_scopes)) {
+            return true;
+        }
+        if (empty($scopes)) {
+            return false;
+        }
+
+        $payload = $request->get_json_params();
+        $source = is_array($payload) && isset($payload['source']) && is_array($payload['source'])
+            ? $payload['source']
+            : array();
+        $source_id = isset($source['id']) && is_string($source['id']) ? $source['id'] : '';
+        $dataset = isset($source['dataset']) && is_string($source['dataset']) ? $source['dataset'] : '';
+        foreach ($scopes as $scope) {
+            if (hash_equals($scope['id'], $source_id) && hash_equals($scope['dataset'], $dataset)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function normalize_product($row) {

--- a/includes/class-patris-feed.php
+++ b/includes/class-patris-feed.php
@@ -319,6 +319,21 @@ class Digitalogic_Patris_Feed {
         return is_string($provided) && hash_equals($expected, $provided);
     }
 
+    /**
+     * Authenticate the versioned receiver without accepting query-string
+     * credentials. The token remains shared with the legacy integration so an
+     * operator can migrate endpoints without provisioning a second secret.
+     *
+     * @param WP_REST_Request $request Current request.
+     * @return bool
+     */
+    public function verify_product_sync_request(WP_REST_Request $request) {
+        $expected = $this->get_push_token();
+        $provided = $request->get_header('x-digitalogic-token');
+
+        return is_string($provided) && '' !== $provided && hash_equals($expected, $provided);
+    }
+
     private function normalize_product($row) {
         $row = is_array($row) ? $row : array();
         $warehouse_stock = isset($row['warehouse_stock']) && is_array($row['warehouse_stock']) ? $row['warehouse_stock'] : array();
@@ -377,12 +392,23 @@ class Digitalogic_Patris_Feed {
         return $normalized;
     }
 
-    private function apply_product_feed(WC_Product $product, $data) {
+    /**
+     * Apply a normalized Patris product through the shared WooCommerce writer.
+     *
+     * Both the legacy feed and the versioned transformed-only receiver use this
+     * method so stock, weight, pricing, and Patris metadata cannot drift into
+     * parallel implementations. Canonical callers do not pass a raw payload.
+     *
+     * @param WC_Product $product WooCommerce product.
+     * @param array      $data    Validated normalized product.
+     * @return void
+     */
+    public function apply_product_feed(WC_Product $product, $data) {
         $product->update_meta_data('_digitalogic_patris_product_code', $data['product_code']);
         $product->update_meta_data('_digitalogic_patris_name', $data['name']);
         $product->update_meta_data('_digitalogic_patris_serial', $data['serial']);
         $product->update_meta_data('_digitalogic_patris_unit', $data['unit']);
-        $product->update_meta_data('_digitalogic_patris_unit_id', $data['unit_id']);
+        $product->update_meta_data('_digitalogic_patris_unit_id', $data['unit_id'] ?? '');
         $product->update_meta_data('_digitalogic_patris_sale_price_source', $data['sale_price_source']);
         $product->update_meta_data('_digitalogic_patris_purchase_price_source', $data['purchase_price_source']);
         $product->update_meta_data('_digitalogic_patris_warehouse_stock', wp_json_encode($data['warehouse_stock']));
@@ -393,9 +419,36 @@ class Digitalogic_Patris_Feed {
         $product->update_meta_data('_digitalogic_patris_weight_grams', $data['weight_grams']);
         $product->update_meta_data('_digitalogic_patris_location', $data['location']);
         $product->update_meta_data('_digitalogic_patris_final_price', $data['final_price']);
-        $product->update_meta_data('_digitalogic_patris_updated_at', $data['updated_at']);
-        $product->update_meta_data('_digitalogic_patris_flags', wp_json_encode($data['flags']));
-        $product->update_meta_data('_digitalogic_patris_last_feed', wp_json_encode($data['raw'], JSON_UNESCAPED_UNICODE));
+        $product->update_meta_data(
+            '_digitalogic_patris_updated_at',
+            isset($data['source_updated_at']) ? $data['source_updated_at'] : ($data['updated_at'] ?? '')
+        );
+        if (array_key_exists('flags', $data)) {
+            $product->update_meta_data('_digitalogic_patris_flags', wp_json_encode($data['flags']));
+        }
+        if (array_key_exists('raw', $data)) {
+            $product->update_meta_data('_digitalogic_patris_last_feed', wp_json_encode($data['raw'], JSON_UNESCAPED_UNICODE));
+        }
+
+        $canonical_meta = array(
+            'import_freight_method_id' => '_digitalogic_patris_import_freight_method_id',
+            'freight_cny_per_kg' => '_digitalogic_patris_freight_cny_per_kg',
+            'markup_percent' => '_digitalogic_patris_markup_percent',
+            'irt_per_cny' => '_digitalogic_patris_irt_per_cny',
+            'pricing_catalog_revision' => '_digitalogic_patris_pricing_catalog_revision',
+            'pricing_catalog_status' => '_digitalogic_patris_pricing_catalog_status',
+            'currency_effective_date' => '_digitalogic_patris_currency_effective_date',
+            'formula_version' => '_digitalogic_patris_formula_version',
+            'record_hash' => '_digitalogic_patris_record_hash',
+        );
+        foreach ($canonical_meta as $field => $meta_key) {
+            if (array_key_exists($field, $data)) {
+                $product->update_meta_data($meta_key, $data[$field]);
+            }
+        }
+        if (array_key_exists('warnings', $data)) {
+            $product->update_meta_data('_digitalogic_patris_warnings', wp_json_encode($data['warnings']));
+        }
 
         $store_weight = Digitalogic_Unit_Converter::grams_to_store_weight($data['weight_grams']);
         if (!is_null($store_weight)) {

--- a/includes/class-product-identifier-resolver.php
+++ b/includes/class-product-identifier-resolver.php
@@ -29,7 +29,7 @@ final class Digitalogic_Product_Identifier_Resolver {
      * Resolve the highest-precedence supplied identifier.
      *
      * Precedence is explicit WooCommerce ID, exact SKU, exact Patris Code,
-     * then the generic exact code adapter (SKU before Patris Code).
+     * then the collision-safe generic exact code adapter.
      *
      * @param array $identifiers String identifiers.
      * @return array|WP_Error
@@ -73,7 +73,11 @@ final class Digitalogic_Product_Identifier_Resolver {
     }
 
     /**
-     * Resolve a legacy generic code using exact SKU-before-Patris precedence.
+     * Resolve a generic Patris code without crossing identifier namespaces.
+     *
+     * Patris Code is canonical. SKU is only a compatibility fallback when no
+     * exact Patris Code exists. If the same text names a Patris Code target and
+     * a distinct SKU target, the identifier is ambiguous and no write is safe.
      */
     public function resolve_code($code) {
         $code = $this->normalize_identifier($code, 'Code/SKU');
@@ -106,11 +110,27 @@ final class Digitalogic_Product_Identifier_Resolver {
             }
         }
 
-        if (!empty($sku_matches)) {
-            return $this->one_or_ambiguous($sku_matches, 'sku', $code);
-        }
         if (!empty($patris_matches)) {
-            return $this->one_or_ambiguous($patris_matches, 'patris_code', $code);
+            if (count($patris_matches) > 1) {
+                return $this->ambiguous($patris_matches, 'patris_code', 'duplicate_patris_code');
+            }
+
+            $patris_match = reset($patris_matches);
+            $distinct_sku_matches = array_values(array_filter($sku_matches, static function($row) use ($patris_match) {
+                return (string) $row['ID'] !== (string) $patris_match['ID'];
+            }));
+            if (!empty($distinct_sku_matches)) {
+                return $this->ambiguous(
+                    array_merge(array($patris_match), $distinct_sku_matches),
+                    'patris_code',
+                    'cross_namespace_collision'
+                );
+            }
+
+            return $this->format_match($patris_match, 'patris_code', $code);
+        }
+        if (!empty($sku_matches)) {
+            return $this->one_or_ambiguous($sku_matches, 'sku_fallback', $code);
         }
 
         return $this->not_found('No product has that exact Code or SKU.');
@@ -182,20 +202,28 @@ final class Digitalogic_Product_Identifier_Resolver {
 
     private function one_or_ambiguous($rows, $resolved_by, $value) {
         if (count($rows) > 1) {
-            return new WP_Error(
-                'digitalogic_product_identifier_ambiguous',
-                __('More than one product has that exact identifier.', 'digitalogic'),
-                array(
-                    'status' => 409,
-                    'resolved_by' => $resolved_by,
-                    'woocommerce_ids' => array_values(array_map(static function($row) {
-                        return (string) $row['ID'];
-                    }, $rows)),
-                )
-            );
+            return $this->ambiguous($rows, $resolved_by, 'duplicate_identifier');
         }
 
         return $this->format_match(reset($rows), $resolved_by, $value);
+    }
+
+    private function ambiguous($rows, $resolved_by, $reason) {
+        $ids = array_values(array_unique(array_map(static function($row) {
+            return (string) $row['ID'];
+        }, $rows)));
+        sort($ids, SORT_STRING);
+
+        return new WP_Error(
+            'digitalogic_product_identifier_ambiguous',
+            __('More than one product has that exact identifier.', 'digitalogic'),
+            array(
+                'status' => 409,
+                'resolved_by' => $resolved_by,
+                'reason' => (string) $reason,
+                'woocommerce_ids' => $ids,
+            )
+        );
     }
 
     private function format_match($row, $resolved_by, $identifier) {

--- a/includes/class-product-sync-receiver.php
+++ b/includes/class-product-sync-receiver.php
@@ -1,0 +1,1439 @@
+<?php
+/**
+ * Versioned, transformed-only Patris product-sync receiver.
+ *
+ * This service deliberately does not share the legacy /patris/push storage
+ * semantics. It accepts the typed digitalogic.product-sync v1 contract,
+ * verifies its deterministic identities, and maintains an ordered snapshot
+ * per Patris source.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('Digitalogic_Product_Identifier_Resolver')) {
+    require_once __DIR__ . '/class-product-identifier-resolver.php';
+}
+if (!class_exists('Digitalogic_Patris_Feed')) {
+    require_once __DIR__ . '/class-patris-feed.php';
+}
+
+/**
+ * JSON number token retained exactly as it appeared on the wire.
+ *
+ * Go's canonical contract hashes decimal JSON lexemes before transport. PHP's
+ * normal JSON decoder converts them to IEEE-754 values, which can silently
+ * change high-precision inputs. Keeping the token lets the receiver reproduce
+ * Go encoding/json byte-for-byte while still converting validated values for
+ * WordPress storage and WooCommerce writes.
+ */
+final class Digitalogic_Product_Sync_JSON_Number {
+    /** @var string */
+    public $value;
+
+    public function __construct($value) {
+        $this->value = (string) $value;
+    }
+}
+
+/**
+ * Strict JSON decoder with duplicate-key rejection and exact number tokens.
+ */
+final class Digitalogic_Product_Sync_JSON_Decoder {
+    private const MAX_DEPTH = 32;
+
+    /** @var string */
+    private $json;
+
+    /** @var int */
+    private $length;
+
+    /** @var int */
+    private $position = 0;
+
+    public static function decode($json) {
+        $decoder = new self((string) $json);
+        $value = $decoder->parse_value(0);
+        $decoder->skip_whitespace();
+        if ($decoder->position !== $decoder->length) {
+            throw new RuntimeException('Unexpected data after the JSON document.');
+        }
+
+        return $value;
+    }
+
+    private function __construct($json) {
+        $this->json = $json;
+        $this->length = strlen($json);
+    }
+
+    private function parse_value($depth) {
+        if ($depth > self::MAX_DEPTH) {
+            throw new RuntimeException('The JSON document is nested too deeply.');
+        }
+
+        $this->skip_whitespace();
+        if ($this->position >= $this->length) {
+            throw new RuntimeException('Unexpected end of JSON input.');
+        }
+
+        $character = $this->json[$this->position];
+        if ('{' === $character) {
+            return $this->parse_object($depth + 1);
+        }
+        if ('[' === $character) {
+            return $this->parse_array($depth + 1);
+        }
+        if ('"' === $character) {
+            return $this->parse_string();
+        }
+        if ('t' === $character && $this->consume_literal('true')) {
+            return true;
+        }
+        if ('f' === $character && $this->consume_literal('false')) {
+            return false;
+        }
+        if ('n' === $character && $this->consume_literal('null')) {
+            return null;
+        }
+
+        return $this->parse_number();
+    }
+
+    private function parse_object($depth) {
+        $result = array();
+        $this->position++;
+        $this->skip_whitespace();
+        if ($this->consume_character('}')) {
+            return $result;
+        }
+
+        while (true) {
+            $this->skip_whitespace();
+            if ($this->position >= $this->length || '"' !== $this->json[$this->position]) {
+                throw new RuntimeException('JSON object keys must be strings.');
+            }
+            $key = $this->parse_string();
+            if (array_key_exists($key, $result)) {
+                throw new RuntimeException('Duplicate JSON object key: ' . $key);
+            }
+            $this->skip_whitespace();
+            if (!$this->consume_character(':')) {
+                throw new RuntimeException('Expected a colon after a JSON object key.');
+            }
+            $result[$key] = $this->parse_value($depth);
+            $this->skip_whitespace();
+            if ($this->consume_character('}')) {
+                break;
+            }
+            if (!$this->consume_character(',')) {
+                throw new RuntimeException('Expected a comma between JSON object members.');
+            }
+        }
+
+        return $result;
+    }
+
+    private function parse_array($depth) {
+        $result = array();
+        $this->position++;
+        $this->skip_whitespace();
+        if ($this->consume_character(']')) {
+            return $result;
+        }
+
+        while (true) {
+            $result[] = $this->parse_value($depth);
+            $this->skip_whitespace();
+            if ($this->consume_character(']')) {
+                break;
+            }
+            if (!$this->consume_character(',')) {
+                throw new RuntimeException('Expected a comma between JSON array values.');
+            }
+        }
+
+        return $result;
+    }
+
+    private function parse_string() {
+        $start = $this->position;
+        $this->position++;
+        $escaped = false;
+        while ($this->position < $this->length) {
+            $character = $this->json[$this->position++];
+            if ($escaped) {
+                $escaped = false;
+                continue;
+            }
+            if ('\\' === $character) {
+                $escaped = true;
+                continue;
+            }
+            if ('"' === $character) {
+                $token = substr($this->json, $start, $this->position - $start);
+                try {
+                    return json_decode($token, true, 2, JSON_THROW_ON_ERROR);
+                } catch (JsonException $exception) {
+                    throw new RuntimeException('Invalid JSON string.', 0, $exception);
+                }
+            }
+            if (ord($character) < 0x20) {
+                throw new RuntimeException('Unescaped control character in JSON string.');
+            }
+        }
+
+        throw new RuntimeException('Unterminated JSON string.');
+    }
+
+    private function parse_number() {
+        if (!preg_match(
+            '/\G-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+\-]?[0-9]+)?/',
+            $this->json,
+            $matches,
+            0,
+            $this->position
+        )) {
+            throw new RuntimeException('Invalid JSON value.');
+        }
+        $token = $matches[0];
+        $this->position += strlen($token);
+
+        return new Digitalogic_Product_Sync_JSON_Number($token);
+    }
+
+    private function consume_literal($literal) {
+        if (substr($this->json, $this->position, strlen($literal)) !== $literal) {
+            return false;
+        }
+        $this->position += strlen($literal);
+
+        return true;
+    }
+
+    private function consume_character($character) {
+        if ($this->position >= $this->length || $this->json[$this->position] !== $character) {
+            return false;
+        }
+        $this->position++;
+
+        return true;
+    }
+
+    private function skip_whitespace() {
+        while ($this->position < $this->length) {
+            $character = $this->json[$this->position];
+            if (' ' !== $character && "\n" !== $character && "\r" !== $character && "\t" !== $character) {
+                break;
+            }
+            $this->position++;
+        }
+    }
+}
+
+class Digitalogic_Product_Sync_Receiver {
+    public const STATE_OPTION = 'digitalogic_product_sync_v1_state';
+    public const CONTRACT_NAME = 'digitalogic.product-sync';
+    public const FORMULA_ID = 'landed_price_v1';
+
+    private const STATE_VERSION = 1;
+    private const LOCK_NAME = 'digitalogic_product_sync_v1';
+    private const LOCK_TIMEOUT_SECONDS = 15;
+    private const MAX_BODY_BYTES = 8388608;
+    private const MAX_STATE_BYTES = 16777216;
+    private const MAX_PRODUCTS = 10000;
+    private const MAX_SOURCES = 16;
+    private const MAX_RECENT_EVENTS = 128;
+    private const MAX_RESULT_ERRORS = 100;
+    private const MAX_CODE_LENGTH = 191;
+
+    private const ENVELOPE_FIELDS = array(
+        'schema',
+        'schema_version',
+        'event',
+        'event_type',
+        'event_id',
+        'local_currency',
+        'formula_id',
+        'formula_revision',
+        'formula_version',
+        'source',
+        'generated_at',
+        'products',
+        'deleted_codes',
+        'quarantined_codes',
+        'warnings',
+    );
+
+    private const PRODUCT_FIELDS = array(
+        'product_code',
+        'name',
+        'serial',
+        'unit',
+        'sale_price_source',
+        'purchase_price_source',
+        'warehouse_stock',
+        'total_stock',
+        'minimum_stock',
+        'foreign_currency',
+        'foreign_price',
+        'weight_grams',
+        'location',
+        'import_freight_method_id',
+        'freight_cny_per_kg',
+        'markup_percent',
+        'irt_per_cny',
+        'pricing_catalog_revision',
+        'pricing_catalog_status',
+        'currency_effective_date',
+        'final_price',
+        'formula_version',
+        'source_updated_at',
+        'warnings',
+        'record_hash',
+    );
+
+    private const PRODUCT_STRING_FIELDS = array(
+        'name',
+        'serial',
+        'unit',
+        'location',
+        'import_freight_method_id',
+        'pricing_catalog_revision',
+        'pricing_catalog_status',
+        'currency_effective_date',
+        'source_updated_at',
+    );
+
+    private const PRODUCT_NULLABLE_NUMBER_FIELDS = array(
+        'sale_price_source',
+        'purchase_price_source',
+        'total_stock',
+        'minimum_stock',
+        'foreign_price',
+        'weight_grams',
+        'freight_cny_per_kg',
+        'markup_percent',
+        'irt_per_cny',
+    );
+
+    private const PRODUCT_DECIMAL_FIELDS = array(
+        'foreign_price',
+        'weight_grams',
+        'freight_cny_per_kg',
+        'markup_percent',
+        'irt_per_cny',
+    );
+
+    private const FORBIDDEN_RAW_KEYS = array(
+        'raw',
+        'sharh',
+        'sharh1',
+        'sharh2',
+        'forosh',
+        'kharyd',
+        'allanbar',
+        'priceinfo',
+        'shortdesc',
+        'feekol',
+        'sefaresh',
+        'weight',
+    );
+
+    private static $instance = null;
+
+    private $lock_depth = 0;
+
+    public static function instance() {
+        if (is_null(self::$instance)) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {}
+
+    /**
+     * Receive an exact JSON document while preserving numeric wire tokens.
+     *
+     * @param string $json Request body.
+     * @return array|WP_Error
+     */
+    public function receive_json($json) {
+        if (!is_string($json) || '' === trim($json)) {
+            return $this->error('digitalogic_product_sync_invalid_json', 'A JSON request body is required.', 400);
+        }
+        if (strlen($json) > self::MAX_BODY_BYTES) {
+            return $this->error('digitalogic_product_sync_payload_too_large', 'The product-sync payload is too large.', 413);
+        }
+
+        try {
+            $payload = Digitalogic_Product_Sync_JSON_Decoder::decode($json);
+        } catch (RuntimeException $exception) {
+            return $this->error(
+                'digitalogic_product_sync_invalid_json',
+                'The product-sync request is not valid JSON.',
+                400,
+                array('reason' => $exception->getMessage())
+            );
+        }
+
+        return $this->receive($payload);
+    }
+
+    /**
+     * Validate, order, persist, and apply a typed v1 envelope.
+     *
+     * @param array $payload Decoded envelope.
+     * @return array|WP_Error
+     */
+    public function receive($payload) {
+        if (!is_array($payload) || array_is_list($payload)) {
+            return $this->error('digitalogic_product_sync_invalid_payload', 'The product-sync payload must be an object.', 400);
+        }
+
+        $forbidden = $this->find_forbidden_raw_key($payload);
+        if (null !== $forbidden) {
+            return $this->error(
+                'digitalogic_product_sync_raw_key_forbidden',
+                'Raw Patris fields are forbidden on the transformed product-sync endpoint.',
+                422,
+                array('path' => $forbidden)
+            );
+        }
+
+        $envelope = $this->validate_envelope($payload);
+        if (is_wp_error($envelope)) {
+            return $envelope;
+        }
+
+        $locked = $this->acquire_lock();
+        if (is_wp_error($locked)) {
+            return $locked;
+        }
+
+        try {
+            return $this->receive_locked($envelope);
+        } catch (Throwable $exception) {
+            return $this->error(
+                'digitalogic_product_sync_unexpected_failure',
+                'The product-sync event could not be applied.',
+                500,
+                array('exception' => get_class($exception))
+            );
+        } finally {
+            $this->release_lock();
+        }
+    }
+
+    /**
+     * Return the stored state for diagnostics and tests.
+     *
+     * @return array
+     */
+    public function get_state() {
+        $state = get_option(self::STATE_OPTION, array());
+        if (!is_array($state) || (int) ($state['version'] ?? 0) !== self::STATE_VERSION) {
+            return array('version' => self::STATE_VERSION, 'sources' => array());
+        }
+        $state['sources'] = isset($state['sources']) && is_array($state['sources']) ? $state['sources'] : array();
+
+        return $state;
+    }
+
+    public function get_source_state($source_id, $dataset) {
+        $state = $this->get_state();
+        $key = $this->source_key((string) $source_id, (string) $dataset);
+
+        return isset($state['sources'][$key]) && is_array($state['sources'][$key])
+            ? $state['sources'][$key]
+            : array();
+    }
+
+    private function receive_locked($envelope) {
+        $state = $this->get_state();
+        $source_key = $this->source_key($envelope['source']['id'], $envelope['source']['dataset']);
+        $existing = isset($state['sources'][$source_key]) && is_array($state['sources'][$source_key])
+            ? $state['sources'][$source_key]
+            : null;
+
+        if (null === $existing && count($state['sources']) >= self::MAX_SOURCES) {
+            return $this->error('digitalogic_product_sync_source_limit', 'The configured source limit has been reached.', 409);
+        }
+
+        if (is_array($existing) && isset($existing['recent_events'][$envelope['event_id']])) {
+            return $this->replay_result($envelope, $existing);
+        }
+        if ('update' === $envelope['event_type'] && !is_array($existing)) {
+            return $this->error(
+                'digitalogic_product_sync_baseline_required',
+                'An update event cannot be applied before its source snapshot.',
+                409
+            );
+        }
+
+        if (is_array($existing)) {
+            $comparison = $this->compare_timestamp_order($envelope['generated_at_order'], $existing['generated_at_order'] ?? array());
+            if ($comparison < 0) {
+                return $this->error('digitalogic_product_sync_stale_event', 'The event is older than the stored source state.', 409);
+            }
+            if (0 === $comparison && $envelope['event_id'] !== ($existing['last_event_id'] ?? '')) {
+                return $this->error(
+                    'digitalogic_product_sync_order_conflict',
+                    'A different event already occupies this source timestamp.',
+                    409
+                );
+            }
+        }
+
+        $transition = $this->build_transition($envelope, $existing);
+        if (is_wp_error($transition)) {
+            return $transition;
+        }
+        if (
+            is_array($existing)
+            && $envelope['source']['revision'] === ($existing['source']['revision'] ?? '')
+        ) {
+            return array(
+                'status' => 'already_current',
+                'replayed' => true,
+                'event_id' => $envelope['event_id'],
+                'source' => $envelope['source'],
+                'stored_products' => count($existing['products'] ?? array()),
+            );
+        }
+
+        $recent_events = is_array($existing['recent_events'] ?? null) ? $existing['recent_events'] : array();
+        $recent_events[$envelope['event_id']] = array(
+            'generated_at' => $envelope['generated_at'],
+            'source_revision' => $envelope['source']['revision'],
+            'event_type' => $envelope['event_type'],
+        );
+        while (count($recent_events) > self::MAX_RECENT_EVENTS) {
+            array_shift($recent_events);
+        }
+
+        $source_state = array(
+            'source' => $envelope['source'],
+            'generated_at' => $envelope['generated_at'],
+            'generated_at_order' => $envelope['generated_at_order'],
+            'last_event_id' => $envelope['event_id'],
+            'last_event_type' => $envelope['event_type'],
+            'local_currency' => $envelope['local_currency'],
+            'formula_id' => $envelope['formula_id'],
+            'formula_revision' => $envelope['formula_revision'],
+            'products' => $transition['products'],
+            'quarantined_codes' => $envelope['quarantined_codes'],
+            'recent_events' => $recent_events,
+            'received_at' => current_time('mysql'),
+        );
+        $state['sources'][$source_key] = $source_state;
+
+        $stored = $this->persist_and_read_back($state);
+        if (is_wp_error($stored)) {
+            return $stored;
+        }
+
+        $woo = $this->apply_woocommerce_updates($transition['changed_products']);
+        $result = array(
+            'status' => 'accepted',
+            'replayed' => false,
+            'event_id' => $envelope['event_id'],
+            'event_type' => $envelope['event_type'],
+            'source' => $envelope['source'],
+            'received_products' => count($envelope['products']),
+            'stored_products' => count($transition['products']),
+            'deleted_codes' => $transition['deleted_count'],
+            'preserved_quarantined' => $transition['preserved_quarantined'],
+            'woocommerce' => $woo,
+            'persistence_verified' => true,
+        );
+
+        try {
+            do_action('digitalogic_product_sync_v1_applied', $result, array(
+                'schema' => $envelope['schema'],
+                'schema_version' => $envelope['schema_version'],
+                'event_id' => $envelope['event_id'],
+                'event_type' => $envelope['event_type'],
+                'source' => $envelope['source'],
+                'generated_at' => $envelope['generated_at'],
+            ));
+        } catch (Throwable $exception) {
+            $result['delivery_warnings'][] = array(
+                'code' => 'digitalogic_product_sync_listener_failed',
+                'exception' => get_class($exception),
+            );
+        }
+
+        try {
+            Digitalogic_Logger::instance()->log(
+                'product_sync_v1_applied',
+                'patris_feed',
+                null,
+                null,
+                wp_json_encode($result),
+                'Versioned Patris product-sync event applied'
+            );
+        } catch (Throwable $exception) {
+            $result['delivery_warnings'][] = array(
+                'code' => 'digitalogic_product_sync_log_failed',
+                'exception' => get_class($exception),
+            );
+        }
+
+        return $result;
+    }
+
+    private function validate_envelope($payload) {
+        $unknown = array_values(array_diff(array_keys($payload), self::ENVELOPE_FIELDS));
+        if (!empty($unknown)) {
+            return $this->error('digitalogic_product_sync_unknown_field', 'The envelope contains unsupported fields.', 422, array('fields' => $unknown));
+        }
+
+        $required = array_slice(self::ENVELOPE_FIELDS, 0, 12);
+        $missing = array_values(array_diff($required, array_keys($payload)));
+        if (!empty($missing)) {
+            return $this->error('digitalogic_product_sync_missing_field', 'The envelope is missing required fields.', 422, array('fields' => $missing));
+        }
+
+        foreach (array('schema', 'schema_version', 'event', 'event_type', 'event_id', 'local_currency', 'formula_id', 'formula_revision', 'formula_version', 'generated_at') as $field) {
+            if (!is_string($payload[$field])) {
+                return $this->field_error($field, 'must be a string');
+            }
+        }
+        if (self::CONTRACT_NAME !== $payload['schema'] || self::CONTRACT_NAME !== $payload['event']) {
+            return $this->error('digitalogic_product_sync_schema_unsupported', 'Only digitalogic.product-sync envelopes are accepted.', 422);
+        }
+        if (!$this->is_supported_major_version($payload['schema_version'])) {
+            return $this->error('digitalogic_product_sync_version_unsupported', 'Only product-sync schema major version 1 is supported.', 422);
+        }
+        if (!in_array($payload['event_type'], array('snapshot', 'update'), true)) {
+            return $this->field_error('event_type', 'must be snapshot or update');
+        }
+        if ('IRT' !== $payload['local_currency']) {
+            return $this->error('digitalogic_product_sync_currency_unsupported', 'The receiver currently supports IRT output only.', 422);
+        }
+        if (function_exists('get_woocommerce_currency') && 'IRT' !== strtoupper((string) get_woocommerce_currency())) {
+            return $this->error(
+                'digitalogic_product_sync_store_currency_mismatch',
+                'WooCommerce must use IRT before transformed IRT prices can be applied.',
+                409
+            );
+        }
+        if (self::FORMULA_ID !== $payload['formula_id'] || self::FORMULA_ID !== $payload['formula_version']) {
+            return $this->error('digitalogic_product_sync_formula_unsupported', 'The landed_price_v1 formula is required.', 422);
+        }
+        if (!$this->is_supported_major_version($payload['formula_revision'])) {
+            return $this->error('digitalogic_product_sync_formula_revision_unsupported', 'Only formula major revision 1 is supported.', 422);
+        }
+        if (!$this->is_hash($payload['event_id'])) {
+            return $this->field_error('event_id', 'must be a sha256 identity');
+        }
+
+        $source = $this->validate_source($payload['source']);
+        if (is_wp_error($source)) {
+            return $source;
+        }
+        $generated_at_order = $this->timestamp_order($payload['generated_at']);
+        if (is_wp_error($generated_at_order)) {
+            return $generated_at_order;
+        }
+        if (!is_array($payload['products']) || !array_is_list($payload['products'])) {
+            return $this->field_error('products', 'must be an array');
+        }
+        if (count($payload['products']) > self::MAX_PRODUCTS) {
+            return $this->error('digitalogic_product_sync_product_limit', 'The event contains too many products.', 413);
+        }
+
+        $products = array();
+        $seen_codes = array();
+        foreach ($payload['products'] as $index => $product) {
+            $validated = $this->validate_product($product, $index);
+            if (is_wp_error($validated)) {
+                return $validated;
+            }
+            $code = $validated['product_code'];
+            if (isset($seen_codes[$code])) {
+                return $this->error('digitalogic_product_sync_duplicate_code', 'Product codes must be unique inside an event.', 422, array('product_code' => $code));
+            }
+            $seen_codes[$code] = true;
+            $products[] = $validated;
+        }
+
+        $deleted_codes = $this->validate_tombstones($payload['deleted_codes'] ?? array(), $payload['event_type']);
+        if (is_wp_error($deleted_codes)) {
+            return $deleted_codes;
+        }
+        $quarantined_codes = $this->validate_string_set($payload['quarantined_codes'] ?? array(), 'quarantined_codes');
+        if (is_wp_error($quarantined_codes)) {
+            return $quarantined_codes;
+        }
+        $warnings = $this->validate_string_set($payload['warnings'] ?? array(), 'warnings', false);
+        if (is_wp_error($warnings)) {
+            return $warnings;
+        }
+
+        $deleted_lookup = array_fill_keys(array_column($deleted_codes, 'product_code'), true);
+        $quarantined_lookup = array_fill_keys($quarantined_codes, true);
+        foreach (array_keys($seen_codes) as $code) {
+            if (isset($deleted_lookup[$code]) || isset($quarantined_lookup[$code])) {
+                return $this->error('digitalogic_product_sync_code_overlap', 'A code cannot be both a product and a tombstone or quarantine entry.', 422, array('product_code' => $code));
+            }
+        }
+        foreach (array_keys($deleted_lookup) as $code) {
+            if (isset($quarantined_lookup[$code])) {
+                return $this->error('digitalogic_product_sync_code_overlap', 'Quarantined codes cannot be tombstoned.', 422, array('product_code' => $code));
+            }
+        }
+
+        $envelope = array(
+            'schema' => $payload['schema'],
+            'schema_version' => $payload['schema_version'],
+            'event' => $payload['event'],
+            'event_type' => $payload['event_type'],
+            'event_id' => $payload['event_id'],
+            'local_currency' => $payload['local_currency'],
+            'formula_id' => $payload['formula_id'],
+            'formula_revision' => $payload['formula_revision'],
+            'formula_version' => $payload['formula_version'],
+            'source' => $source,
+            'generated_at' => $payload['generated_at'],
+            'generated_at_order' => $generated_at_order,
+            'products' => $products,
+            'deleted_codes' => $deleted_codes,
+            'quarantined_codes' => $quarantined_codes,
+            'warnings' => $warnings,
+        );
+
+        $expected_event_id = $this->event_id($envelope);
+        if (!hash_equals($expected_event_id, $envelope['event_id'])) {
+            return $this->error(
+                'digitalogic_product_sync_event_hash_mismatch',
+                'The event_id does not match the canonical event contents.',
+                422,
+                array('expected' => $expected_event_id)
+            );
+        }
+
+        return $envelope;
+    }
+
+    private function validate_source($source) {
+        if (!is_array($source) || array_is_list($source)) {
+            return $this->field_error('source', 'must be an object');
+        }
+        if (
+            !empty(array_diff(array('id', 'dataset', 'revision'), array_keys($source)))
+            || !empty(array_diff(array_keys($source), array('id', 'dataset', 'revision')))
+        ) {
+            return $this->field_error('source', 'must contain exactly id, dataset, and revision');
+        }
+        foreach (array('id', 'dataset', 'revision') as $field) {
+            if (!is_string($source[$field])) {
+                return $this->field_error('source.' . $field, 'must be a string');
+            }
+        }
+        if (
+            '' === trim($source['id'])
+            || '' === trim($source['dataset'])
+            || trim($source['id']) !== $source['id']
+            || trim($source['dataset']) !== $source['dataset']
+        ) {
+            return $this->field_error('source', 'id and dataset must not be empty');
+        }
+        if (strlen($source['id']) > 191 || strlen($source['dataset']) > 191) {
+            return $this->field_error('source', 'id and dataset are too long');
+        }
+        if (!$this->is_hash($source['revision'])) {
+            return $this->field_error('source.revision', 'must be a sha256 identity');
+        }
+
+        return $source;
+    }
+
+    private function validate_product($product, $index) {
+        $path = 'products[' . (int) $index . ']';
+        if (!is_array($product) || array_is_list($product)) {
+            return $this->field_error($path, 'must be an object');
+        }
+        $missing = array_values(array_diff(self::PRODUCT_FIELDS, array_keys($product)));
+        $unknown = array_values(array_diff(array_keys($product), self::PRODUCT_FIELDS));
+        if (!empty($missing) || !empty($unknown)) {
+            return $this->error(
+                'digitalogic_product_sync_product_shape_invalid',
+                'A product does not match the typed v1 shape.',
+                422,
+                array('path' => $path, 'missing' => $missing, 'unknown' => $unknown)
+            );
+        }
+        if (
+            !is_string($product['product_code'])
+            || '' === trim($product['product_code'])
+            || trim($product['product_code']) !== $product['product_code']
+        ) {
+            return $this->field_error($path . '.product_code', 'must be a non-empty string');
+        }
+        if (strlen($product['product_code']) > self::MAX_CODE_LENGTH) {
+            return $this->field_error($path . '.product_code', 'is too long');
+        }
+        foreach (self::PRODUCT_STRING_FIELDS as $field) {
+            if (!is_string($product[$field])) {
+                return $this->field_error($path . '.' . $field, 'must be a string');
+            }
+        }
+        if (!is_string($product['foreign_currency']) || 'CNY' !== $product['foreign_currency']) {
+            return $this->field_error($path . '.foreign_currency', 'must be CNY');
+        }
+        if (!is_string($product['formula_version']) || self::FORMULA_ID !== $product['formula_version']) {
+            return $this->field_error($path . '.formula_version', 'must be landed_price_v1');
+        }
+        foreach (self::PRODUCT_NULLABLE_NUMBER_FIELDS as $field) {
+            if (null !== $product[$field] && !$this->is_json_number($product[$field])) {
+                return $this->field_error($path . '.' . $field, 'must be a JSON number or null');
+            }
+            if (
+                null !== $product[$field]
+                && in_array($field, self::PRODUCT_DECIMAL_FIELDS, true)
+                && !$this->is_plain_decimal($product[$field])
+            ) {
+                return $this->field_error($path . '.' . $field, 'must be a base-10 decimal without exponent notation');
+            }
+        }
+        foreach (array('foreign_price', 'weight_grams', 'freight_cny_per_kg', 'irt_per_cny') as $field) {
+            if (null !== $product[$field] && $this->number_compare_zero($product[$field]) <= 0) {
+                return $this->field_error($path . '.' . $field, 'must be greater than zero when provided');
+            }
+        }
+        if (null !== $product['markup_percent'] && $this->number_compare_zero($product['markup_percent']) < 0) {
+            return $this->field_error($path . '.markup_percent', 'must not be negative');
+        }
+        if (null !== $product['final_price'] && !$this->is_nonnegative_integer($product['final_price'])) {
+            return $this->field_error($path . '.final_price', 'must be a non-negative integer or null');
+        }
+        if (!is_array($product['warehouse_stock']) || (!empty($product['warehouse_stock']) && array_is_list($product['warehouse_stock']))) {
+            return $this->field_error($path . '.warehouse_stock', 'must be an object');
+        }
+        foreach ($product['warehouse_stock'] as $warehouse => $stock) {
+            if ('' === trim((string) $warehouse) || !$this->is_json_number($stock)) {
+                return $this->field_error($path . '.warehouse_stock', 'must map non-empty string keys to JSON numbers');
+            }
+        }
+        $warnings = $this->validate_string_set($product['warnings'], $path . '.warnings', false);
+        if (is_wp_error($warnings)) {
+            return $warnings;
+        }
+        if (!is_string($product['record_hash']) || !$this->is_hash($product['record_hash'])) {
+            return $this->field_error($path . '.record_hash', 'must be a sha256 identity');
+        }
+
+        $hash_product = $product;
+        $hash_product['warnings'] = $warnings;
+        $expected_hash = $this->record_hash($hash_product);
+        if (!hash_equals($expected_hash, $product['record_hash'])) {
+            return $this->error(
+                'digitalogic_product_sync_record_hash_mismatch',
+                'A record_hash does not match its typed product.',
+                422,
+                array('path' => $path . '.record_hash', 'expected' => $expected_hash)
+            );
+        }
+
+        $stored = array();
+        foreach (self::PRODUCT_FIELDS as $field) {
+            if ('warehouse_stock' === $field) {
+                $stocks = $product[$field];
+                ksort($stocks, SORT_STRING);
+                $stored[$field] = array_map(array($this, 'number_to_storage'), $stocks);
+            } elseif (in_array($field, self::PRODUCT_DECIMAL_FIELDS, true)) {
+                $stored[$field] = null === $product[$field] ? null : $this->decimal_to_storage($product[$field]);
+            } elseif (in_array($field, self::PRODUCT_NULLABLE_NUMBER_FIELDS, true) || 'final_price' === $field) {
+                $stored[$field] = null === $product[$field] ? null : $this->number_to_storage($product[$field]);
+            } elseif ('warnings' === $field) {
+                $stored[$field] = $warnings;
+            } else {
+                $stored[$field] = $product[$field];
+            }
+        }
+
+        return $stored;
+    }
+
+    private function validate_tombstones($values, $event_type) {
+        if (!is_array($values) || !array_is_list($values)) {
+            return $this->field_error('deleted_codes', 'must be an array');
+        }
+        if ('snapshot' === $event_type && !empty($values)) {
+            return $this->field_error('deleted_codes', 'is only valid on update events');
+        }
+        $result = array();
+        $seen = array();
+        foreach ($values as $index => $value) {
+            if (
+                !is_array($value)
+                || !empty(array_diff(array('product_code', 'deleted'), array_keys($value)))
+                || !empty(array_diff(array_keys($value), array('product_code', 'deleted')))
+            ) {
+                return $this->field_error('deleted_codes[' . $index . ']', 'must contain exactly product_code and deleted');
+            }
+            if (
+                !is_string($value['product_code'])
+                || '' === trim($value['product_code'])
+                || trim($value['product_code']) !== $value['product_code']
+                || true !== $value['deleted']
+            ) {
+                return $this->field_error('deleted_codes[' . $index . ']', 'must contain a non-empty string code and deleted=true');
+            }
+            if (strlen($value['product_code']) > self::MAX_CODE_LENGTH || isset($seen[$value['product_code']])) {
+                return $this->field_error('deleted_codes[' . $index . '].product_code', 'must be unique and within the code limit');
+            }
+            $seen[$value['product_code']] = true;
+            $result[] = array('product_code' => $value['product_code'], 'deleted' => true);
+        }
+        usort($result, static function($left, $right) {
+            return strcmp($left['product_code'], $right['product_code']);
+        });
+
+        return $result;
+    }
+
+    private function validate_string_set($values, $field, $code_rules = true) {
+        if (!is_array($values) || !array_is_list($values)) {
+            return $this->field_error($field, 'must be an array of unique strings');
+        }
+        $result = array();
+        $seen = array();
+        foreach ($values as $index => $value) {
+            if (!is_string($value) || '' === trim($value) || ($code_rules && trim($value) !== $value)) {
+                return $this->field_error($field . '[' . $index . ']', 'must be a non-empty string');
+            }
+            $limit = $code_rules ? self::MAX_CODE_LENGTH : 255;
+            if (strlen($value) > $limit || isset($seen[$value])) {
+                return $this->field_error($field . '[' . $index . ']', 'must be unique and within the length limit');
+            }
+            $seen[$value] = true;
+            $result[] = $value;
+        }
+        sort($result, SORT_STRING);
+
+        return $result;
+    }
+
+    private function build_transition($envelope, $existing) {
+        $previous = is_array($existing['products'] ?? null) ? $existing['products'] : array();
+        $incoming = array();
+        foreach ($envelope['products'] as $product) {
+            $incoming[$product['product_code']] = $product;
+        }
+        $quarantined = array_fill_keys($envelope['quarantined_codes'], true);
+        $preserved = 0;
+
+        if ('snapshot' === $envelope['event_type']) {
+            $next = $incoming;
+            foreach ($quarantined as $code => $_unused) {
+                if (isset($previous[$code])) {
+                    $next[$code] = $previous[$code];
+                    $preserved++;
+                }
+            }
+            $revision_products = $incoming;
+        } else {
+            $next = $previous;
+            foreach ($incoming as $code => $product) {
+                $next[$code] = $product;
+            }
+            $deleted = 0;
+            foreach ($envelope['deleted_codes'] as $tombstone) {
+                $code = $tombstone['product_code'];
+                if (isset($next[$code])) {
+                    unset($next[$code]);
+                    $deleted++;
+                }
+            }
+            foreach ($quarantined as $code => $_unused) {
+                if (isset($previous[$code])) {
+                    $next[$code] = $previous[$code];
+                    $preserved++;
+                }
+            }
+            $revision_products = $next;
+            foreach ($quarantined as $code => $_unused) {
+                unset($revision_products[$code]);
+            }
+        }
+
+        ksort($next, SORT_STRING);
+        ksort($revision_products, SORT_STRING);
+        $expected_revision = $this->source_revision($revision_products, $envelope['quarantined_codes']);
+        if (!hash_equals($expected_revision, $envelope['source']['revision'])) {
+            return $this->error(
+                'digitalogic_product_sync_source_revision_mismatch',
+                'The source revision does not match the resulting source snapshot.',
+                422,
+                array('expected' => $expected_revision)
+            );
+        }
+
+        return array(
+            'products' => $next,
+            'changed_products' => array_values($incoming),
+            'deleted_count' => 'snapshot' === $envelope['event_type']
+                ? count(array_diff(array_keys($previous), array_merge(array_keys($next), $envelope['quarantined_codes'])))
+                : ($deleted ?? 0),
+            'preserved_quarantined' => $preserved,
+        );
+    }
+
+    private function apply_woocommerce_updates($products) {
+        $result = array(
+            'updated' => 0,
+            'missing' => 0,
+            'ambiguous' => 0,
+            'failed' => 0,
+            'errors' => array(),
+            'errors_truncated' => 0,
+        );
+        foreach ($products as $product_data) {
+            $resolved = Digitalogic_Product_Identifier_Resolver::instance()->resolve(array(
+                'code' => $product_data['product_code'],
+            ));
+            if (is_wp_error($resolved)) {
+                if ('digitalogic_product_identifier_not_found' === $resolved->get_error_code()) {
+                    $result['missing']++;
+                } elseif ('digitalogic_product_identifier_ambiguous' === $resolved->get_error_code()) {
+                    $result['ambiguous']++;
+                } else {
+                    $result['failed']++;
+                }
+                $this->append_woo_error($result, array(
+                    'product_code' => $product_data['product_code'],
+                    'code' => $resolved->get_error_code(),
+                ));
+                continue;
+            }
+
+            $product = wc_get_product((int) $resolved['woocommerce_id']);
+            if (!$product) {
+                $result['failed']++;
+                $this->append_woo_error($result, array(
+                    'product_code' => $product_data['product_code'],
+                    'code' => 'digitalogic_product_sync_woocommerce_product_unavailable',
+                ));
+                continue;
+            }
+
+            try {
+                Digitalogic_Patris_Feed::instance()->apply_product_feed($product, $product_data);
+                $result['updated']++;
+            } catch (Throwable $exception) {
+                $result['failed']++;
+                $this->append_woo_error($result, array(
+                    'product_code' => $product_data['product_code'],
+                    'code' => 'digitalogic_product_sync_woocommerce_write_failed',
+                ));
+            }
+        }
+
+        return $result;
+    }
+
+    private function append_woo_error(&$result, $error) {
+        if (count($result['errors']) < self::MAX_RESULT_ERRORS) {
+            $result['errors'][] = $error;
+        } else {
+            $result['errors_truncated']++;
+        }
+    }
+
+    private function persist_and_read_back($state) {
+        global $wpdb;
+        if (
+            !is_object($wpdb)
+            || !isset($wpdb->options)
+            || !method_exists($wpdb, 'query')
+            || !method_exists($wpdb, 'get_row')
+            || !method_exists($wpdb, 'prepare')
+            || !method_exists($wpdb, 'insert')
+            || !method_exists($wpdb, 'update')
+        ) {
+            return $this->error('digitalogic_product_sync_storage_unavailable', 'The receiver storage service is unavailable.', 503);
+        }
+        if (false === $wpdb->query('START TRANSACTION')) {
+            return $this->error('digitalogic_product_sync_transaction_unavailable', 'The receiver could not start a storage transaction.', 503);
+        }
+
+        $serialized = maybe_serialize($state);
+        if (!is_string($serialized) || strlen($serialized) > self::MAX_STATE_BYTES) {
+            $wpdb->query('ROLLBACK');
+
+            return $this->error('digitalogic_product_sync_state_too_large', 'The combined receiver state is too large.', 413);
+        }
+        $row = $wpdb->get_row($wpdb->prepare(
+            "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s FOR UPDATE",
+            self::STATE_OPTION
+        ), ARRAY_A);
+        if (is_array($row)) {
+            $written = $wpdb->update(
+                $wpdb->options,
+                array('option_value' => $serialized),
+                array('option_name' => self::STATE_OPTION),
+                array('%s'),
+                array('%s')
+            );
+        } else {
+            $written = $wpdb->insert(
+                $wpdb->options,
+                array(
+                    'option_name' => self::STATE_OPTION,
+                    'option_value' => $serialized,
+                    'autoload' => 'no',
+                ),
+                array('%s', '%s', '%s')
+            );
+        }
+        if (false === $written || 0 === $written) {
+            $wpdb->query('ROLLBACK');
+            $this->invalidate_state_cache();
+
+            return $this->error('digitalogic_product_sync_storage_failed', 'The receiver state could not be stored.', 500);
+        }
+
+        $read_row = $wpdb->get_row($wpdb->prepare(
+            "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
+            self::STATE_OPTION
+        ), ARRAY_A);
+        $read_back = is_array($read_row) && array_key_exists('option_value', $read_row)
+            ? maybe_unserialize($read_row['option_value'])
+            : null;
+        if (!is_array($read_back) || !hash_equals($this->state_digest($state), $this->state_digest($read_back))) {
+            $wpdb->query('ROLLBACK');
+            $this->invalidate_state_cache();
+
+            return $this->error('digitalogic_product_sync_readback_failed', 'Stored receiver state did not pass readback verification.', 500);
+        }
+        if (false === $wpdb->query('COMMIT')) {
+            $wpdb->query('ROLLBACK');
+            $this->invalidate_state_cache();
+
+            return $this->error('digitalogic_product_sync_commit_failed', 'The receiver state transaction could not be committed.', 500);
+        }
+
+        $this->invalidate_state_cache();
+
+        return $read_back;
+    }
+
+    private function replay_result($envelope, $existing) {
+        return array(
+            'status' => 'replayed',
+            'replayed' => true,
+            'event_id' => $envelope['event_id'],
+            'event_type' => $envelope['event_type'],
+            'source' => $envelope['source'],
+            'stored_products' => count($existing['products'] ?? array()),
+        );
+    }
+
+    private function record_hash($product) {
+        $ordered = array();
+        foreach (self::PRODUCT_FIELDS as $field) {
+            if ('record_hash' !== $field) {
+                $ordered[$field] = $product[$field];
+            }
+        }
+
+        return $this->hash_identity($this->encode_go_json($ordered, array('warehouse_stock')));
+    }
+
+    private function source_revision($products, $quarantined_codes) {
+        $material = array();
+        foreach ($products as $code => $product) {
+            $material[] = $code . '=' . $product['record_hash'];
+        }
+        sort($material, SORT_STRING);
+        foreach ($quarantined_codes as $code) {
+            $material[] = 'quarantined=' . $code;
+        }
+
+        return $this->hash_identity(implode("\n", $material));
+    }
+
+    private function event_id($envelope) {
+        $product_hashes = array();
+        foreach ($envelope['products'] as $product) {
+            $product_hashes[] = $product['product_code'] . '=' . $product['record_hash'];
+        }
+        sort($product_hashes, SORT_STRING);
+        $identity = array(
+            'schema' => $envelope['schema'],
+            'schema_version' => $envelope['schema_version'],
+            'event_type' => $envelope['event_type'],
+            'local_currency' => $envelope['local_currency'],
+            'formula_id' => $envelope['formula_id'],
+            'formula_revision' => $envelope['formula_revision'],
+            'source' => array(
+                'id' => $envelope['source']['id'],
+                'dataset' => $envelope['source']['dataset'],
+                'revision' => $envelope['source']['revision'],
+            ),
+            'products' => $product_hashes,
+        );
+        if (!empty($envelope['deleted_codes'])) {
+            $identity['deleted_codes'] = $envelope['deleted_codes'];
+        }
+        if (!empty($envelope['quarantined_codes'])) {
+            $identity['quarantined_codes'] = $envelope['quarantined_codes'];
+        }
+
+        return $this->hash_identity($this->encode_go_json($identity));
+    }
+
+    /**
+     * Encode the validated subset the same way Go encoding/json does.
+     *
+     * Associative arrays preserve insertion order unless explicitly marked as
+     * maps. The only map in Product v1 is warehouse_stock, whose keys Go sorts.
+     */
+    private function encode_go_json($value, $map_fields = array(), $field = '') {
+        if ($value instanceof Digitalogic_Product_Sync_JSON_Number) {
+            return $value->value;
+        }
+        if (null === $value) {
+            return 'null';
+        }
+        if (true === $value) {
+            return 'true';
+        }
+        if (false === $value) {
+            return 'false';
+        }
+        if (is_int($value) || is_float($value)) {
+            return json_encode($value, JSON_THROW_ON_ERROR);
+        }
+        if (is_string($value)) {
+            $encoded = json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+            return str_replace(
+                array('<', '>', '&', "\u{2028}", "\u{2029}"),
+                array('\\u003c', '\\u003e', '\\u0026', '\\u2028', '\\u2029'),
+                $encoded
+            );
+        }
+        if (!is_array($value)) {
+            throw new RuntimeException('Unsupported canonical JSON value.');
+        }
+        if (in_array($field, $map_fields, true)) {
+            $object = $value;
+            ksort($object, SORT_STRING);
+            $items = array();
+            foreach ($object as $key => $item) {
+                $items[] = $this->encode_go_json((string) $key) . ':' . $this->encode_go_json($item, $map_fields, (string) $key);
+            }
+
+            return '{' . implode(',', $items) . '}';
+        }
+        if (array_is_list($value)) {
+            $items = array();
+            foreach ($value as $item) {
+                $items[] = $this->encode_go_json($item, $map_fields, $field);
+            }
+
+            return '[' . implode(',', $items) . ']';
+        }
+
+        $object = $value;
+        $items = array();
+        foreach ($object as $key => $item) {
+            $items[] = $this->encode_go_json((string) $key) . ':' . $this->encode_go_json($item, $map_fields, (string) $key);
+        }
+
+        return '{' . implode(',', $items) . '}';
+    }
+
+    private function hash_identity($material) {
+        return 'sha256:' . hash('sha256', $material);
+    }
+
+    private function state_digest($state) {
+        return hash('sha256', maybe_serialize($state));
+    }
+
+    private function find_forbidden_raw_key($value, $path = '$') {
+        if (!is_array($value)) {
+            return null;
+        }
+        foreach ($value as $key => $child) {
+            $child_path = is_int($key) ? $path . '[' . $key . ']' : $path . '.' . $key;
+            if (is_string($key)) {
+                $normalized = strtolower(preg_replace('/[^a-z0-9]/i', '', $key));
+                if (in_array($normalized, self::FORBIDDEN_RAW_KEYS, true) || str_starts_with($normalized, 'anbar')) {
+                    return $child_path;
+                }
+            }
+            $found = $this->find_forbidden_raw_key($child, $child_path);
+            if (null !== $found) {
+                return $found;
+            }
+        }
+
+        return null;
+    }
+
+    private function is_supported_major_version($version) {
+        return is_string($version) && 1 === preg_match('/^1(?:\.[0-9]+){1,2}$/', $version);
+    }
+
+    private function is_hash($value) {
+        return is_string($value) && 1 === preg_match('/^sha256:[a-f0-9]{64}$/', $value);
+    }
+
+    private function is_json_number($value) {
+        return $value instanceof Digitalogic_Product_Sync_JSON_Number
+            || is_int($value)
+            || (is_float($value) && is_finite($value));
+    }
+
+    private function is_nonnegative_integer($value) {
+        if ($value instanceof Digitalogic_Product_Sync_JSON_Number) {
+            return 1 === preg_match('/^(?:0|[1-9][0-9]*)$/', $value->value)
+                && false !== filter_var($value->value, FILTER_VALIDATE_INT);
+        }
+
+        return is_int($value) && $value >= 0;
+    }
+
+    private function number_compare_zero($value) {
+        $text = $value instanceof Digitalogic_Product_Sync_JSON_Number ? $value->value : (string) $value;
+        $text = ltrim($text, '+');
+        $negative = str_starts_with($text, '-');
+        $text = ltrim($text, '-');
+        $parts = preg_split('/[eE]/', $text, 2);
+        $digits = str_replace('.', '', $parts[0]);
+        $nonzero = '' !== trim($digits, '0');
+
+        return !$nonzero ? 0 : ($negative ? -1 : 1);
+    }
+
+    private function number_to_storage($value) {
+        if (!$value instanceof Digitalogic_Product_Sync_JSON_Number) {
+            return $value;
+        }
+        if (1 === preg_match('/^-?(?:0|[1-9][0-9]*)$/', $value->value)) {
+            $integer = filter_var($value->value, FILTER_VALIDATE_INT);
+            if (false !== $integer) {
+                return $integer;
+            }
+        }
+
+        return (float) $value->value;
+    }
+
+    private function decimal_to_storage($value) {
+        if ($value instanceof Digitalogic_Product_Sync_JSON_Number) {
+            return $value->value;
+        }
+
+        return is_int($value) ? (string) $value : json_encode($value, JSON_THROW_ON_ERROR);
+    }
+
+    private function is_plain_decimal($value) {
+        if ($value instanceof Digitalogic_Product_Sync_JSON_Number) {
+            return 1 === preg_match('/^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/', $value->value);
+        }
+
+        return is_int($value) || (is_float($value) && is_finite($value));
+    }
+
+    private function timestamp_order($timestamp) {
+        if (!is_string($timestamp) || !preg_match(
+            '/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?(Z|[+\-]\d{2}:\d{2})$/',
+            $timestamp,
+            $matches
+        )) {
+            return $this->field_error('generated_at', 'must be RFC3339 with up to nanosecond precision');
+        }
+        $zone = 'Z' === $matches[3] ? '+00:00' : $matches[3];
+        $date = DateTimeImmutable::createFromFormat('!Y-m-d\TH:i:sP', $matches[1] . $zone);
+        $errors = DateTimeImmutable::getLastErrors();
+        if (false === $date || (is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))) {
+            return $this->field_error('generated_at', 'must be a valid RFC3339 timestamp');
+        }
+        $fraction = isset($matches[2]) ? str_pad($matches[2], 9, '0') : '000000000';
+
+        return array((int) $date->format('U'), (int) $fraction);
+    }
+
+    private function compare_timestamp_order($left, $right) {
+        if (!is_array($right) || count($right) !== 2) {
+            return 1;
+        }
+        if ((int) $left[0] !== (int) $right[0]) {
+            return (int) $left[0] <=> (int) $right[0];
+        }
+
+        return (int) $left[1] <=> (int) $right[1];
+    }
+
+    private function source_key($source_id, $dataset) {
+        return hash('sha256', $source_id . "\n" . $dataset);
+    }
+
+    private function invalidate_state_cache() {
+        wp_cache_delete(self::STATE_OPTION, 'options');
+        wp_cache_delete('notoptions', 'options');
+        wp_cache_delete('alloptions', 'options');
+    }
+
+    private function acquire_lock() {
+        if ($this->lock_depth > 0) {
+            $this->lock_depth++;
+            return true;
+        }
+
+        global $wpdb;
+        if (!is_object($wpdb) || !method_exists($wpdb, 'get_var') || !method_exists($wpdb, 'prepare')) {
+            return $this->error('digitalogic_product_sync_lock_unavailable', 'The database lock service is unavailable.', 503);
+        }
+        $prefix = isset($wpdb->prefix) ? (string) $wpdb->prefix : 'wp_';
+        $lock_name = substr(self::LOCK_NAME . '_' . md5($prefix), 0, 64);
+        $locked = $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, %d)', $lock_name, self::LOCK_TIMEOUT_SECONDS));
+        if ('1' !== (string) $locked) {
+            return $this->error('digitalogic_product_sync_busy', 'Another product-sync event is being applied. Please retry.', 503, array('retryable' => true));
+        }
+        $this->lock_depth = 1;
+
+        return true;
+    }
+
+    private function release_lock() {
+        if ($this->lock_depth <= 0) {
+            return;
+        }
+        $this->lock_depth--;
+        if ($this->lock_depth > 0) {
+            return;
+        }
+
+        global $wpdb;
+        if (!is_object($wpdb) || !method_exists($wpdb, 'get_var') || !method_exists($wpdb, 'prepare')) {
+            return;
+        }
+        $prefix = isset($wpdb->prefix) ? (string) $wpdb->prefix : 'wp_';
+        $lock_name = substr(self::LOCK_NAME . '_' . md5($prefix), 0, 64);
+        $wpdb->get_var($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $lock_name));
+    }
+
+    private function field_error($field, $reason) {
+        return $this->error(
+            'digitalogic_product_sync_field_invalid',
+            'A product-sync field is invalid.',
+            422,
+            array('field' => $field, 'reason' => $reason)
+        );
+    }
+
+    private function error($code, $message, $status, $details = array()) {
+        return new WP_Error($code, __($message, 'digitalogic'), array_merge(array('status' => (int) $status), $details));
+    }
+}

--- a/includes/class-product-sync-receiver.php
+++ b/includes/class-product-sync-receiver.php
@@ -237,7 +237,7 @@ class Digitalogic_Product_Sync_Receiver {
     public const CONTRACT_NAME = 'digitalogic.product-sync';
     public const FORMULA_ID = 'landed_price_v1';
 
-    private const STATE_VERSION = 1;
+    private const STATE_VERSION = 2;
     private const LOCK_NAME = 'digitalogic_product_sync_v1';
     private const LOCK_TIMEOUT_SECONDS = 15;
     private const MAX_BODY_BYTES = 8388608;
@@ -247,6 +247,9 @@ class Digitalogic_Product_Sync_Receiver {
     private const MAX_RECENT_EVENTS = 128;
     private const MAX_RESULT_ERRORS = 100;
     private const MAX_CODE_LENGTH = 191;
+    private const MAX_FORMULA_INTEGER_DIGITS = 15;
+    private const MAX_FORMULA_SCALE = 12;
+    private const MAX_MARKUP_PERCENT = '1000';
 
     private const ENVELOPE_FIELDS = array(
         'schema',
@@ -464,7 +467,11 @@ class Digitalogic_Product_Sync_Receiver {
         }
 
         if (is_array($existing) && isset($existing['recent_events'][$envelope['event_id']])) {
-            return $this->replay_result($envelope, $existing);
+            if (empty($existing['pending_products'])) {
+                return $this->replay_result($envelope, $existing);
+            }
+
+            return $this->retry_pending_locked($state, $source_key, $envelope, $existing);
         }
         if ('update' === $envelope['event_type'] && !is_array($existing)) {
             return $this->error(
@@ -492,18 +499,8 @@ class Digitalogic_Product_Sync_Receiver {
         if (is_wp_error($transition)) {
             return $transition;
         }
-        if (
-            is_array($existing)
-            && $envelope['source']['revision'] === ($existing['source']['revision'] ?? '')
-        ) {
-            return array(
-                'status' => 'already_current',
-                'replayed' => true,
-                'event_id' => $envelope['event_id'],
-                'source' => $envelope['source'],
-                'stored_products' => count($existing['products'] ?? array()),
-            );
-        }
+        $same_revision = is_array($existing)
+            && $envelope['source']['revision'] === ($existing['source']['revision'] ?? '');
 
         $recent_events = is_array($existing['recent_events'] ?? null) ? $existing['recent_events'] : array();
         $recent_events[$envelope['event_id']] = array(
@@ -515,6 +512,7 @@ class Digitalogic_Product_Sync_Receiver {
             array_shift($recent_events);
         }
 
+        $delivery = $this->build_delivery_state($transition['products'], $transition['changed_products'], $envelope, $existing);
         $source_state = array(
             'source' => $envelope['source'],
             'generated_at' => $envelope['generated_at'],
@@ -527,6 +525,8 @@ class Digitalogic_Product_Sync_Receiver {
             'products' => $transition['products'],
             'quarantined_codes' => $envelope['quarantined_codes'],
             'recent_events' => $recent_events,
+            'applied_products' => $delivery['applied_products'],
+            'pending_products' => $delivery['pending_products'],
             'received_at' => current_time('mysql'),
         );
         $state['sources'][$source_key] = $source_state;
@@ -536,9 +536,20 @@ class Digitalogic_Product_Sync_Receiver {
             return $stored;
         }
 
-        $woo = $this->apply_woocommerce_updates($transition['changed_products']);
+        $before_delivery = $this->state_digest($source_state);
+        $woo = $this->drain_pending_products($source_state);
+        $state['sources'][$source_key] = $source_state;
+        if (!hash_equals($before_delivery, $this->state_digest($source_state))) {
+            $delivery_stored = $this->persist_and_read_back($state);
+            if (is_wp_error($delivery_stored)) {
+                return $delivery_stored;
+            }
+        }
+
+        $fully_applied = empty($source_state['pending_products']);
+        $status = $fully_applied ? ($same_revision ? 'already_current' : 'accepted') : 'partially_applied';
         $result = array(
-            'status' => 'accepted',
+            'status' => $status,
             'replayed' => false,
             'event_id' => $envelope['event_id'],
             'event_type' => $envelope['event_type'],
@@ -548,9 +559,46 @@ class Digitalogic_Product_Sync_Receiver {
             'deleted_codes' => $transition['deleted_count'],
             'preserved_quarantined' => $transition['preserved_quarantined'],
             'woocommerce' => $woo,
+            'fully_applied' => $fully_applied,
+            'retryable' => !$fully_applied,
+            'pending_products' => count($source_state['pending_products']),
             'persistence_verified' => true,
         );
 
+        return $this->emit_result($result, $envelope);
+    }
+
+    private function retry_pending_locked($state, $source_key, $envelope, $existing) {
+        $source_state = $existing;
+        $before_delivery = $this->state_digest($source_state);
+        $woo = $this->drain_pending_products($source_state);
+        $state['sources'][$source_key] = $source_state;
+        if (!hash_equals($before_delivery, $this->state_digest($source_state))) {
+            $stored = $this->persist_and_read_back($state);
+            if (is_wp_error($stored)) {
+                return $stored;
+            }
+        }
+
+        $fully_applied = empty($source_state['pending_products']);
+        $result = array(
+            'status' => $fully_applied ? 'recovered' : 'retry_pending',
+            'replayed' => true,
+            'event_id' => $envelope['event_id'],
+            'event_type' => $envelope['event_type'],
+            'source' => $envelope['source'],
+            'stored_products' => count($source_state['products'] ?? array()),
+            'woocommerce' => $woo,
+            'fully_applied' => $fully_applied,
+            'retryable' => !$fully_applied,
+            'pending_products' => count($source_state['pending_products']),
+            'persistence_verified' => true,
+        );
+
+        return $this->emit_result($result, $envelope);
+    }
+
+    private function emit_result($result, $envelope) {
         try {
             do_action('digitalogic_product_sync_v1_applied', $result, array(
                 'schema' => $envelope['schema'],
@@ -840,6 +888,11 @@ class Digitalogic_Product_Sync_Receiver {
             );
         }
 
+        $formula_check = $this->validate_final_price_formula($product, $path);
+        if (is_wp_error($formula_check)) {
+            return $formula_check;
+        }
+
         $stored = array();
         foreach (self::PRODUCT_FIELDS as $field) {
             if ('warehouse_stock' === $field) {
@@ -985,18 +1038,82 @@ class Digitalogic_Product_Sync_Receiver {
         );
     }
 
-    private function apply_woocommerce_updates($products) {
+    private function build_delivery_state($products, $changed_products, $envelope, $existing) {
+        $applied = is_array($existing['applied_products'] ?? null) ? $existing['applied_products'] : array();
+        $pending = is_array($existing['pending_products'] ?? null) ? $existing['pending_products'] : array();
+
+        foreach ($applied as $code => $entry) {
+            if (!isset($products[$code]) || !is_array($entry) || !isset($entry['record_hash'], $entry['woocommerce_id'])) {
+                unset($applied[$code]);
+            }
+        }
+        foreach ($pending as $code => $entry) {
+            if (
+                !isset($products[$code])
+                || !is_array($entry)
+                || !isset($entry['record_hash'])
+                || !hash_equals((string) $products[$code]['record_hash'], (string) $entry['record_hash'])
+            ) {
+                unset($pending[$code]);
+            }
+        }
+
+        foreach ($changed_products as $product) {
+            $code = $product['product_code'];
+            $record_hash = $product['record_hash'];
+            $applied_entry = is_array($applied[$code] ?? null) ? $applied[$code] : array();
+            if (isset($applied_entry['record_hash']) && hash_equals((string) $applied_entry['record_hash'], $record_hash)) {
+                unset($pending[$code]);
+                continue;
+            }
+
+            $pending_entry = is_array($pending[$code] ?? null) ? $pending[$code] : array();
+            if (!isset($pending_entry['record_hash']) || !hash_equals((string) $pending_entry['record_hash'], $record_hash)) {
+                $pending_entry = array(
+                    'record_hash' => $record_hash,
+                    'queued_event_id' => $envelope['event_id'],
+                    'attempts' => 0,
+                );
+            }
+            $pending[$code] = $pending_entry;
+        }
+
+        ksort($applied, SORT_STRING);
+        ksort($pending, SORT_STRING);
+        return array('applied_products' => $applied, 'pending_products' => $pending);
+    }
+
+    private function drain_pending_products(&$source_state) {
         $result = array(
+            'attempted' => 0,
             'updated' => 0,
+            'already_applied' => 0,
             'missing' => 0,
             'ambiguous' => 0,
             'failed' => 0,
             'errors' => array(),
             'errors_truncated' => 0,
         );
-        foreach ($products as $product_data) {
+        $products = is_array($source_state['products'] ?? null) ? $source_state['products'] : array();
+        $pending = is_array($source_state['pending_products'] ?? null) ? $source_state['pending_products'] : array();
+        $applied = is_array($source_state['applied_products'] ?? null) ? $source_state['applied_products'] : array();
+        ksort($pending, SORT_STRING);
+
+        foreach ($pending as $code => &$pending_entry) {
+            if (!isset($products[$code]) || !is_array($pending_entry)) {
+                unset($pending[$code]);
+                continue;
+            }
+            $product_data = $products[$code];
+            $record_hash = (string) ($pending_entry['record_hash'] ?? '');
+            if (!hash_equals((string) $product_data['record_hash'], $record_hash)) {
+                unset($pending[$code]);
+                continue;
+            }
+
+            $result['attempted']++;
             $resolved = Digitalogic_Product_Identifier_Resolver::instance()->resolve(array(
-                'code' => $product_data['product_code'],
+                'code' => $code,
             ));
             if (is_wp_error($resolved)) {
                 if ('digitalogic_product_identifier_not_found' === $resolved->get_error_code()) {
@@ -1006,36 +1123,87 @@ class Digitalogic_Product_Sync_Receiver {
                 } else {
                     $result['failed']++;
                 }
+                $this->mark_pending_failure($pending_entry, $resolved->get_error_code());
                 $this->append_woo_error($result, array(
-                    'product_code' => $product_data['product_code'],
+                    'product_code' => $code,
                     'code' => $resolved->get_error_code(),
+                    'retryable' => true,
                 ));
                 continue;
             }
 
-            $product = wc_get_product((int) $resolved['woocommerce_id']);
+            $woocommerce_id = (int) $resolved['woocommerce_id'];
+            $applied_entry = is_array($applied[$code] ?? null) ? $applied[$code] : array();
+            if (
+                isset($applied_entry['record_hash'], $applied_entry['woocommerce_id'])
+                && hash_equals((string) $applied_entry['record_hash'], $record_hash)
+                && (string) $applied_entry['woocommerce_id'] === (string) $woocommerce_id
+            ) {
+                unset($pending[$code]);
+                $result['already_applied']++;
+                continue;
+            }
+
+            $persisted_hash = (string) get_post_meta($woocommerce_id, '_digitalogic_patris_record_hash', true);
+            if ('' !== $persisted_hash && hash_equals($record_hash, $persisted_hash)) {
+                $applied[$code] = array(
+                    'record_hash' => $record_hash,
+                    'woocommerce_id' => (string) $woocommerce_id,
+                );
+                unset($pending[$code]);
+                $result['already_applied']++;
+                continue;
+            }
+
+            $product = wc_get_product($woocommerce_id);
             if (!$product) {
                 $result['failed']++;
+                $this->mark_pending_failure($pending_entry, 'digitalogic_product_sync_woocommerce_product_unavailable');
                 $this->append_woo_error($result, array(
-                    'product_code' => $product_data['product_code'],
+                    'product_code' => $code,
                     'code' => 'digitalogic_product_sync_woocommerce_product_unavailable',
+                    'retryable' => true,
                 ));
                 continue;
             }
 
             try {
                 Digitalogic_Patris_Feed::instance()->apply_product_feed($product, $product_data);
+                $persisted_hash = (string) get_post_meta($woocommerce_id, '_digitalogic_patris_record_hash', true);
+                if ('' === $persisted_hash || !hash_equals($record_hash, $persisted_hash)) {
+                    throw new RuntimeException('WooCommerce record hash readback failed.');
+                }
+                $applied[$code] = array(
+                    'record_hash' => $record_hash,
+                    'woocommerce_id' => (string) $woocommerce_id,
+                );
+                unset($pending[$code]);
                 $result['updated']++;
             } catch (Throwable $exception) {
                 $result['failed']++;
+                $this->mark_pending_failure($pending_entry, 'digitalogic_product_sync_woocommerce_write_failed');
                 $this->append_woo_error($result, array(
-                    'product_code' => $product_data['product_code'],
+                    'product_code' => $code,
                     'code' => 'digitalogic_product_sync_woocommerce_write_failed',
+                    'retryable' => true,
                 ));
             }
         }
+        unset($pending_entry);
+
+        ksort($pending, SORT_STRING);
+        ksort($applied, SORT_STRING);
+        $source_state['pending_products'] = $pending;
+        $source_state['applied_products'] = $applied;
+        $result['pending'] = count($pending);
 
         return $result;
+    }
+
+    private function mark_pending_failure(&$pending_entry, $code) {
+        $pending_entry['attempts'] = max(0, (int) ($pending_entry['attempts'] ?? 0)) + 1;
+        $pending_entry['last_error'] = (string) $code;
+        $pending_entry['last_attempt_at'] = current_time('mysql');
     }
 
     private function append_woo_error(&$result, $error) {
@@ -1132,7 +1300,217 @@ class Digitalogic_Product_Sync_Receiver {
             'event_type' => $envelope['event_type'],
             'source' => $envelope['source'],
             'stored_products' => count($existing['products'] ?? array()),
+            'fully_applied' => true,
+            'retryable' => false,
+            'pending_products' => 0,
         );
+    }
+
+    /**
+     * Independently evaluate landed_price_v1 using bounded decimal strings.
+     * No binary floating-point operation participates in the calculation and
+     * the only rounding is one half-up step to the final IRT integer.
+     */
+    private function validate_final_price_formula($product, $path) {
+        $required = array('foreign_price', 'weight_grams', 'freight_cny_per_kg', 'markup_percent', 'irt_per_cny');
+        $missing = array();
+        $decimals = array();
+        foreach ($required as $field) {
+            if (null === $product[$field]) {
+                $missing[] = $field;
+                continue;
+            }
+            $parts = $this->formula_decimal_parts($product[$field]);
+            if (isset($parts['error'])) {
+                return $this->field_error($path . '.' . $field, $parts['error']);
+            }
+            $decimals[$field] = $parts;
+        }
+        if ('' === $product['import_freight_method_id']) {
+            $missing[] = 'import_freight_method_id';
+        }
+
+        if (!empty($missing)) {
+            if (null === $product['final_price']) {
+                return true;
+            }
+
+            return $this->error(
+                'digitalogic_product_sync_final_price_mismatch',
+                'final_price must be null when landed_price_v1 inputs are incomplete.',
+                422,
+                array('path' => $path . '.final_price', 'expected' => null, 'missing' => $missing)
+            );
+        }
+
+        if ($this->decimal_compare($decimals['markup_percent'], $this->formula_decimal_parts(self::MAX_MARKUP_PERCENT)) > 0) {
+            return $this->field_error($path . '.markup_percent', 'must not exceed ' . self::MAX_MARKUP_PERCENT);
+        }
+
+        $freight = $this->decimal_multiply($decimals['weight_grams'], $decimals['freight_cny_per_kg']);
+        $freight['scale'] += 3; // grams to kilograms, exactly.
+        $landed_cny = $this->decimal_add($decimals['foreign_price'], $freight);
+        $markup_multiplier = $this->decimal_add(
+            $this->formula_decimal_parts('100'),
+            $decimals['markup_percent']
+        );
+        $marked_up = $this->decimal_multiply($landed_cny, $markup_multiplier);
+        $marked_up['scale'] += 2; // percent to multiplier, exactly.
+        $irt = $this->decimal_multiply($marked_up, $decimals['irt_per_cny']);
+        $rounded = $this->decimal_round_half_up_integer($irt);
+        if ($this->big_integer_compare($rounded, (string) PHP_INT_MAX) > 0) {
+            return $this->field_error($path . '.final_price', 'landed_price_v1 exceeds the supported IRT integer range');
+        }
+
+        $actual = null === $product['final_price'] ? null : $this->number_to_storage($product['final_price']);
+        $expected = (int) $rounded;
+        if (!is_int($actual) || $actual !== $expected) {
+            return $this->error(
+                'digitalogic_product_sync_final_price_mismatch',
+                'final_price does not match independently evaluated landed_price_v1.',
+                422,
+                array('path' => $path . '.final_price', 'expected' => $expected, 'actual' => $actual)
+            );
+        }
+
+        return true;
+    }
+
+    private function formula_decimal_parts($value) {
+        if ($value instanceof Digitalogic_Product_Sync_JSON_Number) {
+            $text = $value->value;
+        } elseif (is_string($value) || is_int($value)) {
+            $text = (string) $value;
+        } elseif (is_float($value) && is_finite($value)) {
+            $text = json_encode($value, JSON_THROW_ON_ERROR);
+        } else {
+            return array('error' => 'must be an exact base-10 decimal');
+        }
+        if (!preg_match('/^(0|[1-9][0-9]*)(?:\.([0-9]+))?$/', $text, $matches)) {
+            return array('error' => 'must be a non-negative base-10 decimal without exponent notation');
+        }
+
+        $integer = $matches[1];
+        $fraction = isset($matches[2]) ? $matches[2] : '';
+        $integer_digits = strlen(ltrim($integer, '0'));
+        if (0 === $integer_digits) {
+            $integer_digits = 1;
+        }
+        if ($integer_digits > self::MAX_FORMULA_INTEGER_DIGITS) {
+            return array('error' => 'has too many integer digits for landed_price_v1');
+        }
+        if (strlen($fraction) > self::MAX_FORMULA_SCALE) {
+            return array('error' => 'has too many fractional digits for landed_price_v1');
+        }
+
+        $scale = strlen($fraction);
+        $digits = ltrim($integer . $fraction, '0');
+        $digits = '' === $digits ? '0' : $digits;
+        while ($scale > 0 && str_ends_with($digits, '0')) {
+            $digits = substr($digits, 0, -1);
+            $scale--;
+        }
+        if ('' === $digits) {
+            $digits = '0';
+            $scale = 0;
+        }
+
+        return array('digits' => $digits, 'scale' => $scale);
+    }
+
+    private function decimal_add($left, $right) {
+        $scale = max((int) $left['scale'], (int) $right['scale']);
+        $left_digits = $left['digits'] . str_repeat('0', $scale - (int) $left['scale']);
+        $right_digits = $right['digits'] . str_repeat('0', $scale - (int) $right['scale']);
+
+        return array('digits' => $this->big_integer_add($left_digits, $right_digits), 'scale' => $scale);
+    }
+
+    private function decimal_multiply($left, $right) {
+        return array(
+            'digits' => $this->big_integer_multiply($left['digits'], $right['digits']),
+            'scale' => (int) $left['scale'] + (int) $right['scale'],
+        );
+    }
+
+    private function decimal_compare($left, $right) {
+        $scale = max((int) $left['scale'], (int) $right['scale']);
+        $left_digits = $left['digits'] . str_repeat('0', $scale - (int) $left['scale']);
+        $right_digits = $right['digits'] . str_repeat('0', $scale - (int) $right['scale']);
+
+        return $this->big_integer_compare($left_digits, $right_digits);
+    }
+
+    private function decimal_round_half_up_integer($decimal) {
+        $digits = $this->normalize_big_integer($decimal['digits']);
+        $scale = (int) $decimal['scale'];
+        if ($scale <= 0) {
+            return $digits . str_repeat('0', -$scale);
+        }
+
+        $padded = str_pad($digits, $scale + 1, '0', STR_PAD_LEFT);
+        $cut = strlen($padded) - $scale;
+        $integer = $this->normalize_big_integer(substr($padded, 0, $cut));
+        if ((int) $padded[$cut] >= 5) {
+            $integer = $this->big_integer_add($integer, '1');
+        }
+
+        return $integer;
+    }
+
+    private function big_integer_add($left, $right) {
+        $left = strrev($this->normalize_big_integer($left));
+        $right = strrev($this->normalize_big_integer($right));
+        $length = max(strlen($left), strlen($right));
+        $carry = 0;
+        $result = '';
+        for ($index = 0; $index < $length; $index++) {
+            $sum = ($index < strlen($left) ? (int) $left[$index] : 0)
+                + ($index < strlen($right) ? (int) $right[$index] : 0)
+                + $carry;
+            $result .= (string) ($sum % 10);
+            $carry = intdiv($sum, 10);
+        }
+        if ($carry > 0) {
+            $result .= (string) $carry;
+        }
+
+        return $this->normalize_big_integer(strrev($result));
+    }
+
+    private function big_integer_multiply($left, $right) {
+        $left = $this->normalize_big_integer($left);
+        $right = $this->normalize_big_integer($right);
+        if ('0' === $left || '0' === $right) {
+            return '0';
+        }
+
+        $result = array_fill(0, strlen($left) + strlen($right), 0);
+        for ($left_index = strlen($left) - 1; $left_index >= 0; $left_index--) {
+            for ($right_index = strlen($right) - 1; $right_index >= 0; $right_index--) {
+                $position = $left_index + $right_index + 1;
+                $sum = $result[$position] + ((int) $left[$left_index] * (int) $right[$right_index]);
+                $result[$position] = $sum % 10;
+                $result[$position - 1] += intdiv($sum, 10);
+            }
+        }
+
+        return $this->normalize_big_integer(implode('', $result));
+    }
+
+    private function big_integer_compare($left, $right) {
+        $left = $this->normalize_big_integer($left);
+        $right = $this->normalize_big_integer($right);
+        if (strlen($left) !== strlen($right)) {
+            return strlen($left) <=> strlen($right);
+        }
+
+        return strcmp($left, $right) <=> 0;
+    }
+
+    private function normalize_big_integer($value) {
+        $value = ltrim((string) $value, '0');
+        return '' === $value ? '0' : $value;
     }
 
     private function record_hash($product) {
@@ -1177,6 +1555,7 @@ class Digitalogic_Product_Sync_Receiver {
                 'dataset' => $envelope['source']['dataset'],
                 'revision' => $envelope['source']['revision'],
             ),
+            'generated_at' => $envelope['generated_at'],
             'products' => $product_hashes,
         );
         if (!empty($envelope['deleted_codes'])) {

--- a/tests/PatrisFeedResolutionTest.php
+++ b/tests/PatrisFeedResolutionTest.php
@@ -62,7 +62,7 @@ final class PatrisFeedResolutionTest extends TestCase {
         $this->assertSame('Upstream-only product', $snapshot['NOT-IN-WOO']['name']);
     }
 
-    public function test_generic_code_prefers_exact_sku_over_a_different_products_patris_code(): void {
+    public function test_cross_namespace_collision_is_ambiguous_and_neither_product_is_written(): void {
         $GLOBALS['digitalogic_test_posts'] = array(
             702 => array(
                 'post_type' => 'product',
@@ -76,16 +76,20 @@ final class PatrisFeedResolutionTest extends TestCase {
 
         $result = $this->feed->import_payload(array('products' => array(array(
             'product_code' => 'COLLISION',
-            'name' => 'SKU wins',
+            'name' => 'Must remain ambiguous',
             'total_stock' => 2,
             'final_price' => 12345,
         ))), 'test');
 
-        $this->assertSame(1, $result['updated']);
-        $this->assertSame(array(702), $GLOBALS['digitalogic_test_wc_product_saves']);
-        $this->assertSame('SKU wins', $GLOBALS['digitalogic_test_posts'][702]['meta']['_digitalogic_patris_name']);
+        $this->assertSame(0, $result['updated']);
+        $this->assertSame(1, $result['failed']);
+        $this->assertSame(array('Skipped product because its exact Code/SKU is ambiguous.'), $result['errors']);
+        $this->assertSame(array(), $GLOBALS['digitalogic_test_wc_product_saves']);
+        $this->assertSame('sku-target', $GLOBALS['digitalogic_test_posts'][702]['meta']['_existing_sentinel']);
+        $this->assertArrayNotHasKey('_digitalogic_patris_name', $GLOBALS['digitalogic_test_posts'][702]['meta']);
         $this->assertSame('patris-nontarget', $GLOBALS['digitalogic_test_posts'][703]['meta']['_existing_sentinel']);
         $this->assertArrayNotHasKey('_digitalogic_patris_name', $GLOBALS['digitalogic_test_posts'][703]['meta']);
+        $this->assertSame('Must remain ambiguous', get_option('digitalogic_patris_feed_products')['COLLISION']['name']);
     }
 
     public function test_ambiguous_and_invalid_identifiers_fail_safely_without_product_writes_but_remain_reportable(): void {

--- a/tests/ProductIdentifierResolverTest.php
+++ b/tests/ProductIdentifierResolverTest.php
@@ -66,14 +66,16 @@ final class ProductIdentifierResolverTest extends TestCase {
         $this->assertSame(1, $GLOBALS['wpdb']->identifier_query_count);
     }
 
-    public function test_generic_code_uses_exact_sku_before_exact_patris_code_without_integer_coercion(): void {
+    public function test_generic_code_rejects_cross_namespace_collision_and_uses_exact_sku_fallback(): void {
         $cross = $this->resolver->resolve(array('code' => 'CROSS'));
         $numeric_looking = $this->resolver->resolve(array('code' => '00123'));
         $wrong_case = $this->resolver->resolve(array('code' => 'sku-601'));
 
-        $this->assertSame('607', $cross['woocommerce_id']);
-        $this->assertSame('sku', $cross['resolved_by']);
+        $this->assertSame('digitalogic_product_identifier_ambiguous', $cross->get_error_code());
+        $this->assertSame('cross_namespace_collision', $cross->get_error_data()['reason']);
+        $this->assertSame(array('607', '608'), $cross->get_error_data()['woocommerce_ids']);
         $this->assertSame('609', $numeric_looking['woocommerce_id']);
+        $this->assertSame('sku_fallback', $numeric_looking['resolved_by']);
         $this->assertSame('00123', $numeric_looking['identifier']);
         $this->assertSame('digitalogic_product_identifier_not_found', $wrong_case->get_error_code());
         $this->assertSame(3, $GLOBALS['wpdb']->identifier_query_count);

--- a/tests/ProductSyncReceiverTest.php
+++ b/tests/ProductSyncReceiverTest.php
@@ -1,0 +1,391 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ProductSyncReceiverTest extends TestCase {
+    private static $golden;
+
+    public static function setUpBeforeClass(): void {
+        $path = __DIR__ . '/fixtures/patris-product-sync-v1-golden.json';
+        self::$golden = json_decode(file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_capabilities'] = array();
+        $GLOBALS['digitalogic_test_filters'] = array();
+        $GLOBALS['digitalogic_test_routes'] = array();
+        $GLOBALS['digitalogic_test_options'] = array();
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_action_callbacks'] = array();
+        $GLOBALS['digitalogic_test_posts'] = array();
+        $GLOBALS['digitalogic_test_post_meta_cache'] = array();
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_transaction_failures'] = array();
+        $GLOBALS['digitalogic_test_cache_deletes'] = array();
+        $GLOBALS['digitalogic_test_wc_products'] = array();
+        $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+        $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
+        $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
+    }
+
+    public function test_accepts_the_go_generated_synthetic_fixture_with_exact_hashes(): void {
+        $path = __DIR__ . '/fixtures/patris-product-sync-v1-golden.json';
+        $this->assertSame(
+            '409f065af9c8b4adde8410e052a6ca2b11c4c2e6358f73c07db3165f20ba64ec',
+            hash_file('sha256', $path)
+        );
+
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive_json(file_get_contents($path));
+
+        $this->assertNotInstanceOf(WP_Error::class, $result, $result instanceof WP_Error ? $result->get_error_message() : '');
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame('sha256:b659a592853f5709fd3ee0d52f7e58738cf3d109fe58d538257738a6dd157dff', $result['event_id']);
+        $this->assertSame(2, $result['stored_products']);
+        $this->assertSame(2, $result['woocommerce']['missing']);
+        $this->assertCount(2, $result['woocommerce']['errors']);
+        $this->assertSame(0, $result['woocommerce']['errors_truncated']);
+        $source = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('synthetic-fixture', 'synthetic-kala.db');
+        $this->assertSame('sha256:eec5251e15aa8d8d29736650afdc0edfa9d2576fe60427af22afe5d7119f7294', $source['source']['revision']);
+        $this->assertSame(
+            'sha256:fb1fc9e10312f7aaa4659550525a0f9b4536f375e4d005ee1f2e1658a90e4976',
+            $source['products']['SYNTH-PRICED-001']['record_hash']
+        );
+        $this->assertSame('24.5', $source['products']['SYNTH-PRICED-001']['foreign_price']);
+        $this->assertSame('240', $source['products']['SYNTH-PRICED-001']['weight_grams']);
+        $this->assertSame(2009410, $source['products']['SYNTH-PRICED-001']['final_price']);
+    }
+
+    public function test_snapshot_persists_before_event_and_uses_shared_exact_woo_writer(): void {
+        $product = $this->product(1);
+        $code = $product['product_code'];
+        $GLOBALS['digitalogic_test_posts'][700] = array(
+            'post_type' => 'product',
+            'post_status' => 'draft',
+            'meta' => array('_sku' => $code),
+        );
+        $persisted_before_event = false;
+        add_action('digitalogic_product_sync_v1_applied', function() use (&$persisted_before_event) {
+            $persisted_before_event = !empty(get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array()));
+        }, 10, 2);
+
+        $envelope = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00.123456789Z');
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertTrue($persisted_before_event);
+        $this->assertSame(1, $result['woocommerce']['updated'], wp_json_encode($result['woocommerce']));
+        $this->assertSame(array(700), $GLOBALS['digitalogic_test_wc_product_saves']);
+        $woo = $GLOBALS['digitalogic_test_wc_products'][700];
+        $this->assertSame($product['record_hash'], $woo->meta['_digitalogic_patris_record_hash']);
+        if (null === $product['final_price']) {
+            $this->assertNull($woo->price);
+        } else {
+            $this->assertSame((string) $product['final_price'], $woo->price);
+        }
+        $this->assertArrayNotHasKey('_digitalogic_patris_last_feed', $woo->meta);
+        $this->assertSame(1, $GLOBALS['wpdb']->acquire_count);
+        $this->assertSame(1, $GLOBALS['wpdb']->release_count);
+        $this->assertContains(array(Digitalogic_Product_Sync_Receiver::STATE_OPTION, 'options'), $GLOBALS['digitalogic_test_cache_deletes']);
+        $this->assertContains(array('notoptions', 'options'), $GLOBALS['digitalogic_test_cache_deletes']);
+        $this->assertContains(array('alloptions', 'options'), $GLOBALS['digitalogic_test_cache_deletes']);
+    }
+
+    public function test_exact_replay_causes_no_second_write_woo_save_or_domain_event(): void {
+        $product = $this->product(0);
+        $envelope = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
+
+        $first = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+        $option_events = count($GLOBALS['digitalogic_test_actions']['update_option_' . Digitalogic_Product_Sync_Receiver::STATE_OPTION] ?? array());
+        $domain_events = count($GLOBALS['digitalogic_test_actions']['digitalogic_product_sync_v1_applied'] ?? array());
+        $transaction_queries = count($GLOBALS['wpdb']->queries);
+        $second = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+
+        $this->assertSame('accepted', $first['status']);
+        $this->assertSame('replayed', $second['status']);
+        $this->assertTrue($second['replayed']);
+        $this->assertSame($option_events, count($GLOBALS['digitalogic_test_actions']['update_option_' . Digitalogic_Product_Sync_Receiver::STATE_OPTION] ?? array()));
+        $this->assertSame($domain_events, count($GLOBALS['digitalogic_test_actions']['digitalogic_product_sync_v1_applied'] ?? array()));
+        $this->assertSame($transaction_queries, count($GLOBALS['wpdb']->queries));
+        $this->assertSame(array(), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_throwing_domain_listener_does_not_turn_committed_event_into_failure(): void {
+        $product = $this->product(0);
+        $envelope = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
+        add_action('digitalogic_product_sync_v1_applied', static function() {
+            throw new RuntimeException('injected listener failure');
+        }, 10, 2);
+
+        $first = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+        $second = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+
+        $this->assertSame('accepted', $first['status']);
+        $this->assertSame('digitalogic_product_sync_listener_failed', $first['delivery_warnings'][0]['code']);
+        $this->assertSame('replayed', $second['status']);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_actions']['digitalogic_product_sync_v1_applied']);
+    }
+
+    public function test_update_merges_instead_of_replacing_snapshot(): void {
+        $first = $this->product(0);
+        $second = $this->product(1);
+        $snapshot = $this->envelope('snapshot', array($first), array($first), '2026-07-16T10:00:00Z');
+        $this->assertSame('accepted', Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot)['status']);
+
+        $update = $this->envelope('update', array($second), array($first, $second), '2026-07-16T10:01:00Z');
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive($update);
+        $state = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertCount(2, $state['products']);
+        $this->assertArrayHasKey($first['product_code'], $state['products']);
+        $this->assertArrayHasKey($second['product_code'], $state['products']);
+    }
+
+    public function test_deletion_only_update_removes_receiver_entry_but_never_woo_product(): void {
+        $first = $this->product(0);
+        $second = $this->product(1);
+        $GLOBALS['digitalogic_test_posts'][801] = array('post_type' => 'product', 'post_status' => 'publish', 'meta' => array('_sku' => $first['product_code']));
+        $snapshot = $this->envelope('snapshot', array($first, $second), array($first, $second), '2026-07-16T10:00:00Z');
+        Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot);
+        $saves_before_delete = count($GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $delete = $this->envelope(
+            'update',
+            array(),
+            array($second),
+            '2026-07-16T10:02:00Z',
+            array(array('product_code' => $first['product_code'], 'deleted' => true))
+        );
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive($delete);
+        $state = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame(0, $result['received_products']);
+        $this->assertSame(1, $result['deleted_codes']);
+        $this->assertArrayNotHasKey($first['product_code'], $state['products']);
+        $this->assertArrayHasKey($second['product_code'], $state['products']);
+        $this->assertArrayHasKey(801, $GLOBALS['digitalogic_test_posts']);
+        $this->assertSame($saves_before_delete, count($GLOBALS['digitalogic_test_wc_product_saves']));
+    }
+
+    public function test_snapshot_preserves_quarantined_code_then_replaces_other_entries(): void {
+        $first = $this->product(0);
+        $second = $this->product(1);
+        $snapshot = $this->envelope('snapshot', array($first, $second), array($first, $second), '2026-07-16T10:00:00Z');
+        Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot);
+
+        $replacement = $this->envelope(
+            'snapshot',
+            array(),
+            array(),
+            '2026-07-16T10:03:00Z',
+            array(),
+            array($first['product_code'])
+        );
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive($replacement);
+        $state = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
+
+        $this->assertSame(1, $result['preserved_quarantined']);
+        $this->assertCount(1, $state['products']);
+        $this->assertArrayHasKey($first['product_code'], $state['products']);
+        $this->assertArrayNotHasKey($second['product_code'], $state['products']);
+    }
+
+    public function test_rejects_recursive_raw_keys_and_numeric_product_codes(): void {
+        $product = $this->product(0);
+        $envelope = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
+        $envelope['products'][0]['metadata'] = array('sHaRh-2' => 'raw');
+        $raw = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+        $this->assertSame('digitalogic_product_sync_raw_key_forbidden', $raw->get_error_code());
+
+        $numeric = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:01Z');
+        $numeric['products'][0]['product_code'] = 123;
+        $invalid_code = Digitalogic_Product_Sync_Receiver::instance()->receive($numeric);
+        $this->assertSame('digitalogic_product_sync_field_invalid', $invalid_code->get_error_code());
+
+        $padded = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:02Z');
+        $padded['products'][0]['product_code'] = ' ' . $product['product_code'];
+        $invalid_padding = Digitalogic_Product_Sync_Receiver::instance()->receive($padded);
+        $this->assertSame('digitalogic_product_sync_field_invalid', $invalid_padding->get_error_code());
+    }
+
+    public function test_rejects_record_event_and_source_hash_tampering(): void {
+        $product = $this->product(0);
+        $record = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
+        $record['products'][0]['name'] .= ' changed';
+        $record_error = Digitalogic_Product_Sync_Receiver::instance()->receive($record);
+        $this->assertSame('digitalogic_product_sync_record_hash_mismatch', $record_error->get_error_code());
+
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
+        $event['event_id'] = 'sha256:' . str_repeat('0', 64);
+        $event_error = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('digitalogic_product_sync_event_hash_mismatch', $event_error->get_error_code());
+
+        $source = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
+        $source['source']['revision'] = 'sha256:' . str_repeat('1', 64);
+        $source['event_id'] = $this->eventId($source);
+        $source_error = Digitalogic_Product_Sync_Receiver::instance()->receive($source);
+        $this->assertSame('digitalogic_product_sync_source_revision_mismatch', $source_error->get_error_code());
+    }
+
+    public function test_rejects_unsupported_contract_currency_formula_and_types(): void {
+        $product = $this->product(0);
+        $base = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
+        $cases = array(
+            array('schema_version', '2.0', 'digitalogic_product_sync_version_unsupported'),
+            array('local_currency', 'IRR', 'digitalogic_product_sync_currency_unsupported'),
+            array('formula_id', 'other_v1', 'digitalogic_product_sync_formula_unsupported'),
+            array('formula_revision', '2.0.0', 'digitalogic_product_sync_formula_revision_unsupported'),
+        );
+        foreach ($cases as $case) {
+            $payload = $base;
+            $payload[$case[0]] = $case[1];
+            $error = Digitalogic_Product_Sync_Receiver::instance()->receive($payload);
+            $this->assertSame($case[2], $error->get_error_code());
+        }
+
+        $GLOBALS['digitalogic_test_wc_currency'] = 'IRR';
+        $currency_error = Digitalogic_Product_Sync_Receiver::instance()->receive($base);
+        $this->assertSame('digitalogic_product_sync_store_currency_mismatch', $currency_error->get_error_code());
+        $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
+
+        $typed = $base;
+        $typed['products'][0]['warehouse_stock'] = array('1' => '5');
+        $error = Digitalogic_Product_Sync_Receiver::instance()->receive($typed);
+        $this->assertSame('digitalogic_product_sync_field_invalid', $error->get_error_code());
+    }
+
+    public function test_rejects_update_without_baseline_and_stale_or_conflicting_events(): void {
+        $first = $this->product(0);
+        $second = $this->product(1);
+        $update = $this->envelope('update', array($first), array($first), '2026-07-16T10:00:00Z');
+        $missing = Digitalogic_Product_Sync_Receiver::instance()->receive($update);
+        $this->assertSame('digitalogic_product_sync_baseline_required', $missing->get_error_code());
+
+        $snapshot = $this->envelope('snapshot', array($first), array($first), '2026-07-16T10:05:00Z');
+        Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot);
+        $stale = $this->envelope('update', array($second), array($first, $second), '2026-07-16T10:04:59.999999999Z');
+        $stale_error = Digitalogic_Product_Sync_Receiver::instance()->receive($stale);
+        $this->assertSame('digitalogic_product_sync_stale_event', $stale_error->get_error_code());
+
+        $conflict = $this->envelope('update', array($second), array($first, $second), '2026-07-16T10:05:00Z');
+        $conflict_error = Digitalogic_Product_Sync_Receiver::instance()->receive($conflict);
+        $this->assertSame('digitalogic_product_sync_order_conflict', $conflict_error->get_error_code());
+    }
+
+    public function test_lock_and_storage_failures_are_reported_without_domain_event(): void {
+        $product = $this->product(0);
+        $envelope = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
+        $GLOBALS['wpdb']->acquire_result = 0;
+        $busy = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+        $this->assertSame('digitalogic_product_sync_busy', $busy->get_error_code());
+
+        $GLOBALS['wpdb']->acquire_result = 1;
+        $GLOBALS['digitalogic_test_update_failures'][] = Digitalogic_Product_Sync_Receiver::STATE_OPTION;
+        $failed = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+        $this->assertSame('digitalogic_product_sync_storage_failed', $failed->get_error_code());
+        $this->assertFalse(get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, false));
+        $this->assertContains('ROLLBACK', $GLOBALS['wpdb']->queries);
+        $this->assertEmpty($GLOBALS['digitalogic_test_actions']['digitalogic_product_sync_v1_applied'] ?? array());
+
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_transaction_failures'] = array('START TRANSACTION');
+        $unavailable = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+        $this->assertSame('digitalogic_product_sync_transaction_unavailable', $unavailable->get_error_code());
+
+        $GLOBALS['digitalogic_test_transaction_failures'] = array('COMMIT');
+        $commit = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
+        $this->assertSame('digitalogic_product_sync_commit_failed', $commit->get_error_code());
+        $this->assertFalse(get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, false));
+    }
+
+    private function product($index) {
+        return self::$golden['products'][$index];
+    }
+
+    private function envelope($type, $event_products, $full_products, $generated_at, $deleted = array(), $quarantined = array()) {
+        usort($event_products, static function($left, $right) {
+            return strcmp($left['product_code'], $right['product_code']);
+        });
+        usort($deleted, static function($left, $right) {
+            return strcmp($left['product_code'], $right['product_code']);
+        });
+        sort($quarantined, SORT_STRING);
+        $source = array(
+            'id' => 'receiver-tests',
+            'dataset' => 'kala.db',
+            'revision' => $this->sourceRevision($full_products, $quarantined),
+        );
+        $envelope = array(
+            'schema' => 'digitalogic.product-sync',
+            'schema_version' => '1.0',
+            'event' => 'digitalogic.product-sync',
+            'event_type' => $type,
+            'event_id' => '',
+            'local_currency' => 'IRT',
+            'formula_id' => 'landed_price_v1',
+            'formula_revision' => '1.0.0',
+            'formula_version' => 'landed_price_v1',
+            'source' => $source,
+            'generated_at' => $generated_at,
+            'products' => array_values($event_products),
+        );
+        if (!empty($deleted)) {
+            $envelope['deleted_codes'] = $deleted;
+        }
+        if (!empty($quarantined)) {
+            $envelope['quarantined_codes'] = $quarantined;
+        }
+        $envelope['event_id'] = $this->eventId($envelope);
+
+        return $envelope;
+    }
+
+    private function sourceRevision($products, $quarantined) {
+        $lines = array();
+        foreach ($products as $product) {
+            if (in_array($product['product_code'], $quarantined, true)) {
+                continue;
+            }
+            $lines[] = $product['product_code'] . '=' . $product['record_hash'];
+        }
+        sort($lines, SORT_STRING);
+        sort($quarantined, SORT_STRING);
+        foreach ($quarantined as $code) {
+            $lines[] = 'quarantined=' . $code;
+        }
+
+        return 'sha256:' . hash('sha256', implode("\n", $lines));
+    }
+
+    private function eventId($envelope) {
+        $hashes = array();
+        foreach ($envelope['products'] as $product) {
+            $hashes[] = $product['product_code'] . '=' . $product['record_hash'];
+        }
+        sort($hashes, SORT_STRING);
+        $identity = array(
+            'schema' => $envelope['schema'],
+            'schema_version' => $envelope['schema_version'],
+            'event_type' => $envelope['event_type'],
+            'local_currency' => $envelope['local_currency'],
+            'formula_id' => $envelope['formula_id'],
+            'formula_revision' => $envelope['formula_revision'],
+            'source' => array(
+                'id' => $envelope['source']['id'],
+                'dataset' => $envelope['source']['dataset'],
+                'revision' => $envelope['source']['revision'],
+            ),
+            'products' => $hashes,
+        );
+        if (!empty($envelope['deleted_codes'])) {
+            $identity['deleted_codes'] = $envelope['deleted_codes'];
+        }
+        if (!empty($envelope['quarantined_codes'])) {
+            $identity['quarantined_codes'] = $envelope['quarantined_codes'];
+        }
+
+        return 'sha256:' . hash('sha256', json_encode($identity, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+}

--- a/tests/ProductSyncReceiverTest.php
+++ b/tests/ProductSyncReceiverTest.php
@@ -25,6 +25,7 @@ final class ProductSyncReceiverTest extends TestCase {
         $GLOBALS['digitalogic_test_cache_deletes'] = array();
         $GLOBALS['digitalogic_test_wc_products'] = array();
         $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array();
         $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
         $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
     }
@@ -32,15 +33,18 @@ final class ProductSyncReceiverTest extends TestCase {
     public function test_accepts_the_go_generated_synthetic_fixture_with_exact_hashes(): void {
         $path = __DIR__ . '/fixtures/patris-product-sync-v1-golden.json';
         $this->assertSame(
-            '409f065af9c8b4adde8410e052a6ca2b11c4c2e6358f73c07db3165f20ba64ec',
+            '810bdf4d8fd5e3c2a87750a02f241363f6403736c899a625f615967fea259da5',
             hash_file('sha256', $path)
         );
 
         $result = Digitalogic_Product_Sync_Receiver::instance()->receive_json(file_get_contents($path));
 
         $this->assertNotInstanceOf(WP_Error::class, $result, $result instanceof WP_Error ? $result->get_error_message() : '');
-        $this->assertSame('accepted', $result['status']);
-        $this->assertSame('sha256:b659a592853f5709fd3ee0d52f7e58738cf3d109fe58d538257738a6dd157dff', $result['event_id']);
+        $this->assertSame('partially_applied', $result['status']);
+        $this->assertSame('sha256:25d5afce95dfdcf598c28f9c9639cbd54ed7f2e838a6c285844eee75d972ef06', $result['event_id']);
+        $this->assertFalse($result['fully_applied']);
+        $this->assertTrue($result['retryable']);
+        $this->assertSame(2, $result['pending_products']);
         $this->assertSame(2, $result['stored_products']);
         $this->assertSame(2, $result['woocommerce']['missing']);
         $this->assertCount(2, $result['woocommerce']['errors']);
@@ -93,6 +97,11 @@ final class ProductSyncReceiverTest extends TestCase {
 
     public function test_exact_replay_causes_no_second_write_woo_save_or_domain_event(): void {
         $product = $this->product(0);
+        $GLOBALS['digitalogic_test_posts'][701] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $product['product_code']),
+        );
         $envelope = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
 
         $first = Digitalogic_Product_Sync_Receiver::instance()->receive($envelope);
@@ -107,11 +116,16 @@ final class ProductSyncReceiverTest extends TestCase {
         $this->assertSame($option_events, count($GLOBALS['digitalogic_test_actions']['update_option_' . Digitalogic_Product_Sync_Receiver::STATE_OPTION] ?? array()));
         $this->assertSame($domain_events, count($GLOBALS['digitalogic_test_actions']['digitalogic_product_sync_v1_applied'] ?? array()));
         $this->assertSame($transaction_queries, count($GLOBALS['wpdb']->queries));
-        $this->assertSame(array(), $GLOBALS['digitalogic_test_wc_product_saves']);
+        $this->assertSame(array(701), $GLOBALS['digitalogic_test_wc_product_saves']);
     }
 
     public function test_throwing_domain_listener_does_not_turn_committed_event_into_failure(): void {
         $product = $this->product(0);
+        $GLOBALS['digitalogic_test_posts'][702] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $product['product_code']),
+        );
         $envelope = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
         add_action('digitalogic_product_sync_v1_applied', static function() {
             throw new RuntimeException('injected listener failure');
@@ -130,13 +144,13 @@ final class ProductSyncReceiverTest extends TestCase {
         $first = $this->product(0);
         $second = $this->product(1);
         $snapshot = $this->envelope('snapshot', array($first), array($first), '2026-07-16T10:00:00Z');
-        $this->assertSame('accepted', Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot)['status']);
+        $this->assertSame('partially_applied', Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot)['status']);
 
         $update = $this->envelope('update', array($second), array($first, $second), '2026-07-16T10:01:00Z');
         $result = Digitalogic_Product_Sync_Receiver::instance()->receive($update);
         $state = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
 
-        $this->assertSame('accepted', $result['status']);
+        $this->assertSame('partially_applied', $result['status']);
         $this->assertCount(2, $state['products']);
         $this->assertArrayHasKey($first['product_code'], $state['products']);
         $this->assertArrayHasKey($second['product_code'], $state['products']);
@@ -160,7 +174,7 @@ final class ProductSyncReceiverTest extends TestCase {
         $result = Digitalogic_Product_Sync_Receiver::instance()->receive($delete);
         $state = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
 
-        $this->assertSame('accepted', $result['status']);
+        $this->assertSame('partially_applied', $result['status']);
         $this->assertSame(0, $result['received_products']);
         $this->assertSame(1, $result['deleted_codes']);
         $this->assertArrayNotHasKey($first['product_code'], $state['products']);
@@ -274,6 +288,217 @@ final class ProductSyncReceiverTest extends TestCase {
         $this->assertSame('digitalogic_product_sync_order_conflict', $conflict_error->get_error_code());
     }
 
+    public function test_independently_recomputes_landed_price_and_requires_null_when_inputs_are_incomplete(): void {
+        $priced = $this->product(1);
+        $priced['final_price']++;
+        $priced = $this->rehashProduct($priced);
+        $wrong = $this->envelope('snapshot', array($priced), array($priced), '2026-07-16T11:00:00Z');
+        $wrong_result = Digitalogic_Product_Sync_Receiver::instance()->receive($wrong);
+        $this->assertSame('digitalogic_product_sync_final_price_mismatch', $wrong_result->get_error_code());
+        $this->assertSame(2009410, $wrong_result->get_error_data()['expected']);
+
+        $incomplete = $this->product(0);
+        $incomplete['final_price'] = 1;
+        $incomplete = $this->rehashProduct($incomplete);
+        $nonnull = $this->envelope('snapshot', array($incomplete), array($incomplete), '2026-07-16T11:01:00Z');
+        $nonnull_result = Digitalogic_Product_Sync_Receiver::instance()->receive($nonnull);
+        $this->assertSame('digitalogic_product_sync_final_price_mismatch', $nonnull_result->get_error_code());
+        $this->assertNull($nonnull_result->get_error_data()['expected']);
+        $this->assertContains('foreign_price', $nonnull_result->get_error_data()['missing']);
+    }
+
+    public function test_decimal_formula_uses_one_exact_half_up_integer_round_and_enforces_bounds(): void {
+        $product = $this->product(1);
+        $product['foreign_price'] = 1;
+        $product['weight_grams'] = 1;
+        $product['freight_cny_per_kg'] = 1;
+        $product['markup_percent'] = 0;
+        $product['irt_per_cny'] = 500;
+        $product['final_price'] = 501; // (1 + 1/1000) * 500 = 500.5.
+        $product = $this->rehashProduct($product);
+        $GLOBALS['digitalogic_test_posts'][703] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $product['product_code']),
+        );
+        $accepted = Digitalogic_Product_Sync_Receiver::instance()->receive(
+            $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:02:00Z')
+        );
+        $this->assertSame('accepted', $accepted['status']);
+        $this->assertSame('501', $GLOBALS['digitalogic_test_wc_products'][703]->price);
+
+        $product['markup_percent'] = 1000.1;
+        $product['final_price'] = 5506;
+        $product = $this->rehashProduct($product);
+        $bounded = Digitalogic_Product_Sync_Receiver::instance()->receive(
+            $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:03:00Z')
+        );
+        $this->assertSame('digitalogic_product_sync_field_invalid', $bounded->get_error_code());
+        $this->assertSame('products[0].markup_percent', $bounded->get_error_data()['field']);
+
+        $product['markup_percent'] = 0.1234567890123;
+        $product = $this->rehashProduct($product);
+        $scale = Digitalogic_Product_Sync_Receiver::instance()->receive(
+            $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:04:00Z')
+        );
+        $this->assertSame('digitalogic_product_sync_field_invalid', $scale->get_error_code());
+        $this->assertStringContainsString('fractional digits', $scale->get_error_data()['reason']);
+    }
+
+    public function test_failed_woo_save_stays_pending_and_identical_replay_recovers(): void {
+        $product = $this->product(1);
+        $GLOBALS['digitalogic_test_posts'][710] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $product['product_code']),
+        );
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array(710);
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:10:00Z');
+
+        $first = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('partially_applied', $first['status']);
+        $this->assertSame(1, $first['woocommerce']['failed']);
+        $this->assertSame(1, $first['pending_products']);
+        $this->assertEmpty($GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array();
+        $second = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('recovered', $second['status']);
+        $this->assertTrue($second['replayed']);
+        $this->assertTrue($second['fully_applied']);
+        $this->assertSame(0, $second['pending_products']);
+        $this->assertSame(array(710), $GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $third = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('replayed', $third['status']);
+        $this->assertSame(array(710), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_partial_batch_retries_only_the_unapplied_product(): void {
+        $first_product = $this->product(0);
+        $second_product = $this->product(1);
+        $GLOBALS['digitalogic_test_posts'][711] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $first_product['product_code']),
+        );
+        $GLOBALS['digitalogic_test_posts'][712] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $second_product['product_code']),
+        );
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array(712);
+        $event = $this->envelope(
+            'snapshot',
+            array($first_product, $second_product),
+            array($first_product, $second_product),
+            '2026-07-16T11:11:00Z'
+        );
+
+        $first = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('partially_applied', $first['status']);
+        $this->assertSame(1, $first['woocommerce']['updated']);
+        $this->assertSame(1, $first['woocommerce']['failed']);
+        $this->assertSame(array(711), $GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array();
+        $second = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('recovered', $second['status']);
+        $this->assertSame(1, $second['woocommerce']['updated']);
+        $this->assertSame(array(711, 712), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_missing_product_added_later_is_recovered_by_identical_replay(): void {
+        $product = $this->product(0);
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:12:00Z');
+        $first = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('partially_applied', $first['status']);
+        $this->assertSame(1, $first['woocommerce']['missing']);
+
+        $GLOBALS['digitalogic_test_posts'][713] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_sku' => $product['product_code']),
+        );
+        $recovered = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('recovered', $recovered['status']);
+        $this->assertSame(1, $recovered['woocommerce']['updated']);
+        $this->assertSame(array(713), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_persisted_record_hash_cas_acks_without_a_duplicate_woo_save(): void {
+        $product = $this->product(0);
+        $GLOBALS['digitalogic_test_posts'][714] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $product['product_code']),
+        );
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:13:00Z');
+        $this->assertSame('accepted', Digitalogic_Product_Sync_Receiver::instance()->receive($event)['status']);
+        $this->assertSame(array(714), $GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $state = Digitalogic_Product_Sync_Receiver::instance()->get_state();
+        $source_key = array_key_first($state['sources']);
+        unset($state['sources'][$source_key]['applied_products'][$product['product_code']]);
+        $state['sources'][$source_key]['pending_products'][$product['product_code']] = array(
+            'record_hash' => $product['record_hash'],
+            'queued_event_id' => $event['event_id'],
+            'attempts' => 0,
+        );
+        update_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, $state, false);
+
+        $recovered = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('recovered', $recovered['status']);
+        $this->assertSame(1, $recovered['woocommerce']['already_applied']);
+        $this->assertSame(array(714), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_patris_code_is_canonical_and_cross_namespace_collision_remains_pending(): void {
+        $product = $this->product(0);
+        $code = $product['product_code'];
+        $GLOBALS['digitalogic_test_posts'][720] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_sku' => $code),
+        );
+        $GLOBALS['digitalogic_test_posts'][721] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $code),
+        );
+        $resolved = Digitalogic_Product_Identifier_Resolver::instance()->resolve(array('code' => $code));
+        $this->assertSame('digitalogic_product_identifier_ambiguous', $resolved->get_error_code());
+        $this->assertSame('cross_namespace_collision', $resolved->get_error_data()['reason']);
+
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:14:00Z');
+        $first = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('partially_applied', $first['status']);
+        $this->assertSame(1, $first['woocommerce']['ambiguous']);
+        $this->assertEmpty($GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $GLOBALS['digitalogic_test_posts'][720]['meta']['_sku'] = 'OTHER-SKU';
+        $recovered = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('recovered', $recovered['status']);
+        $this->assertSame(array(721), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_newer_same_content_occurrence_advances_watermark_before_older_change(): void {
+        $first = $this->product(0);
+        $second = $this->product(1);
+        $jan2 = $this->envelope('snapshot', array($first), array($first), '2026-01-02T00:00:00Z');
+        $jan4 = $this->envelope('snapshot', array($first), array($first), '2026-01-04T00:00:00Z');
+        $this->assertNotSame($jan2['event_id'], $jan4['event_id']);
+        Digitalogic_Product_Sync_Receiver::instance()->receive($jan2);
+        $same_content = Digitalogic_Product_Sync_Receiver::instance()->receive($jan4);
+        $this->assertFalse($same_content['replayed']);
+
+        $jan3 = $this->envelope('update', array($second), array($first, $second), '2026-01-03T00:00:00Z');
+        $stale = Digitalogic_Product_Sync_Receiver::instance()->receive($jan3);
+        $this->assertSame('digitalogic_product_sync_stale_event', $stale->get_error_code());
+        $source = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
+        $this->assertSame('2026-01-04T00:00:00Z', $source['generated_at']);
+    }
+
     public function test_lock_and_storage_failures_are_reported_without_domain_event(): void {
         $product = $this->product(0);
         $envelope = $this->envelope('snapshot', array($product), array($product), '2026-07-16T10:00:00Z');
@@ -302,6 +527,17 @@ final class ProductSyncReceiverTest extends TestCase {
 
     private function product($index) {
         return self::$golden['products'][$index];
+    }
+
+    private function rehashProduct($product) {
+        unset($product['record_hash']);
+        ksort($product['warehouse_stock'], SORT_STRING);
+        $product['record_hash'] = 'sha256:' . hash(
+            'sha256',
+            json_encode($product, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+        );
+
+        return $product;
     }
 
     private function envelope($type, $event_products, $full_products, $generated_at, $deleted = array(), $quarantined = array()) {
@@ -377,6 +613,7 @@ final class ProductSyncReceiverTest extends TestCase {
                 'dataset' => $envelope['source']['dataset'],
                 'revision' => $envelope['source']['revision'],
             ),
+            'generated_at' => $envelope['generated_at'],
             'products' => $hashes,
         );
         if (!empty($envelope['deleted_codes'])) {

--- a/tests/ProductSyncRestTest.php
+++ b/tests/ProductSyncRestTest.php
@@ -8,7 +8,8 @@ final class ProductSyncRestTest extends TestCase {
         $GLOBALS['digitalogic_test_filters'] = array();
         $GLOBALS['digitalogic_test_routes'] = array();
         $GLOBALS['digitalogic_test_options'] = array(
-            'digitalogic_patris_feed_push_token' => 'receiver-secret',
+            'digitalogic_patris_feed_push_token' => 'legacy-secret',
+            Digitalogic_Patris_Feed::PRODUCT_SYNC_SECRET_OPTION => 'receiver-secret',
         );
         $GLOBALS['digitalogic_test_option_cache'] = array();
         $GLOBALS['digitalogic_test_actions'] = array();
@@ -37,13 +38,34 @@ final class ProductSyncRestTest extends TestCase {
         $this->assertNotSame($routes['/patris/product-sync']['callback'], $routes['/patris/push']['callback']);
     }
 
-    public function test_v1_token_is_header_only_and_write_scope_remains_supported(): void {
+    public function test_v1_secret_is_separate_header_only_scoped_and_write_scope_remains_supported(): void {
         $api = Digitalogic_REST_API::instance();
         $query_token = new WP_REST_Request(array('token' => 'receiver-secret'));
-        $header_token = new WP_REST_Request(array(), array(), array('X-Digitalogic-Token' => 'receiver-secret'));
+        $legacy_token = new WP_REST_Request(array(), array(), array('X-Digitalogic-Token' => 'legacy-secret'));
+        $header_token = new WP_REST_Request(array(), array(), array('X-Digitalogic-Product-Sync-Secret' => 'receiver-secret'));
 
         $this->assertFalse($api->check_patris_product_sync_permission($query_token));
+        $this->assertFalse($api->check_patris_product_sync_permission($legacy_token));
         $this->assertTrue($api->check_patris_product_sync_permission($header_token));
+
+        $GLOBALS['digitalogic_test_options'][Digitalogic_Patris_Feed::PRODUCT_SYNC_SCOPES_OPTION] = array(
+            array('id' => 'rest-tests', 'dataset' => 'kala.db'),
+        );
+        $matching = new WP_REST_Request(
+            array(),
+            array('source' => array('id' => 'rest-tests', 'dataset' => 'kala.db')),
+            array('X-Digitalogic-Product-Sync-Secret' => 'receiver-secret')
+        );
+        $wrong_source = new WP_REST_Request(
+            array(),
+            array('source' => array('id' => 'other', 'dataset' => 'kala.db')),
+            array('X-Digitalogic-Product-Sync-Secret' => 'receiver-secret')
+        );
+        $this->assertTrue($api->check_patris_product_sync_permission($matching));
+        $this->assertFalse($api->check_patris_product_sync_permission($wrong_source));
+
+        $GLOBALS['digitalogic_test_options'][Digitalogic_Patris_Feed::PRODUCT_SYNC_SCOPES_OPTION] = array('malformed');
+        $this->assertFalse($api->check_patris_product_sync_permission($matching));
 
         $GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
         $this->assertTrue($api->check_patris_product_sync_permission(new WP_REST_Request()));
@@ -53,7 +75,7 @@ final class ProductSyncRestTest extends TestCase {
         $payload = $this->emptySnapshot();
         $body = json_encode($payload, JSON_UNESCAPED_SLASHES);
         $headers = array(
-            'X-Digitalogic-Token' => 'receiver-secret',
+            'X-Digitalogic-Product-Sync-Secret' => 'receiver-secret',
             'X-Patris-Contract' => $payload['schema'],
             'X-Patris-Contract-Version' => $payload['schema_version'],
             'X-Patris-Event-ID' => $payload['event_id'],
@@ -79,7 +101,7 @@ final class ProductSyncRestTest extends TestCase {
         $request = new WP_REST_Request(
             array(),
             $payload,
-            array('X-Digitalogic-Token' => 'receiver-secret'),
+            array('X-Digitalogic-Product-Sync-Secret' => 'receiver-secret'),
             json_encode($payload)
         );
         $response = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
@@ -100,6 +122,7 @@ final class ProductSyncRestTest extends TestCase {
             'formula_id' => 'landed_price_v1',
             'formula_revision' => '1.0.0',
             'source' => $source,
+            'generated_at' => '2026-07-16T10:00:00Z',
             'products' => array(),
         );
 

--- a/tests/ProductSyncRestTest.php
+++ b/tests/ProductSyncRestTest.php
@@ -40,10 +40,12 @@ final class ProductSyncRestTest extends TestCase {
 
     public function test_v1_secret_is_separate_header_only_scoped_and_write_scope_remains_supported(): void {
         $api = Digitalogic_REST_API::instance();
-        $query_token = new WP_REST_Request(array('token' => 'receiver-secret'));
+        $query_token = new WP_REST_Request(array('token' => 'legacy-secret'));
         $legacy_token = new WP_REST_Request(array(), array(), array('X-Digitalogic-Token' => 'legacy-secret'));
         $header_token = new WP_REST_Request(array(), array(), array('X-Digitalogic-Product-Sync-Secret' => 'receiver-secret'));
 
+        $this->assertTrue($api->check_patris_push_permission($query_token));
+        $this->assertTrue($api->check_patris_push_permission($legacy_token));
         $this->assertFalse($api->check_patris_product_sync_permission($query_token));
         $this->assertFalse($api->check_patris_product_sync_permission($legacy_token));
         $this->assertTrue($api->check_patris_product_sync_permission($header_token));
@@ -109,6 +111,24 @@ final class ProductSyncRestTest extends TestCase {
         $this->assertSame(422, $response->get_status());
         $this->assertFalse($response->get_data()['success']);
         $this->assertSame('digitalogic_product_sync_currency_unsupported', $response->get_data()['code']);
+    }
+
+    public function test_partial_and_identical_retry_responses_are_intentionally_http_200(): void {
+        $body = file_get_contents(__DIR__ . '/fixtures/patris-product-sync-v1-golden.json');
+        $payload = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        $headers = array('X-Digitalogic-Product-Sync-Secret' => 'receiver-secret');
+        $request = new WP_REST_Request(array(), $payload, $headers, $body);
+
+        $partial = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
+        $this->assertSame(200, $partial->get_status());
+        $this->assertSame('partially_applied', $partial->get_data()['data']['status']);
+        $this->assertTrue($partial->get_data()['data']['retryable']);
+
+        $retry = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
+        $this->assertSame(200, $retry->get_status());
+        $this->assertSame('retry_pending', $retry->get_data()['data']['status']);
+        $this->assertTrue($retry->get_data()['data']['replayed']);
+        $this->assertTrue($retry->get_data()['data']['retryable']);
     }
 
     private function emptySnapshot() {

--- a/tests/ProductSyncRestTest.php
+++ b/tests/ProductSyncRestTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ProductSyncRestTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_capabilities'] = array();
+        $GLOBALS['digitalogic_test_filters'] = array();
+        $GLOBALS['digitalogic_test_routes'] = array();
+        $GLOBALS['digitalogic_test_options'] = array(
+            'digitalogic_patris_feed_push_token' => 'receiver-secret',
+        );
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_transaction_failures'] = array();
+        $GLOBALS['digitalogic_test_cache_deletes'] = array();
+        $GLOBALS['digitalogic_test_posts'] = array();
+        $GLOBALS['digitalogic_test_wc_products'] = array();
+        $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+        $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
+        $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
+    }
+
+    public function test_registers_dedicated_route_without_changing_legacy_callback(): void {
+        $api = Digitalogic_REST_API::instance();
+        $api->register_routes();
+        $routes = array();
+        foreach ($GLOBALS['digitalogic_test_routes'] as $route) {
+            $routes[$route['route']] = $route['args'];
+        }
+
+        $this->assertArrayHasKey('/patris/product-sync', $routes);
+        $this->assertArrayHasKey('/patris/push', $routes);
+        $this->assertSame('receive_patris_product_sync', $routes['/patris/product-sync']['callback'][1]);
+        $this->assertSame('push_patris', $routes['/patris/push']['callback'][1]);
+        $this->assertNotSame($routes['/patris/product-sync']['callback'], $routes['/patris/push']['callback']);
+    }
+
+    public function test_v1_token_is_header_only_and_write_scope_remains_supported(): void {
+        $api = Digitalogic_REST_API::instance();
+        $query_token = new WP_REST_Request(array('token' => 'receiver-secret'));
+        $header_token = new WP_REST_Request(array(), array(), array('X-Digitalogic-Token' => 'receiver-secret'));
+
+        $this->assertFalse($api->check_patris_product_sync_permission($query_token));
+        $this->assertTrue($api->check_patris_product_sync_permission($header_token));
+
+        $GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
+        $this->assertTrue($api->check_patris_product_sync_permission(new WP_REST_Request()));
+    }
+
+    public function test_rest_callback_accepts_empty_snapshot_and_checks_headers(): void {
+        $payload = $this->emptySnapshot();
+        $body = json_encode($payload, JSON_UNESCAPED_SLASHES);
+        $headers = array(
+            'X-Digitalogic-Token' => 'receiver-secret',
+            'X-Patris-Contract' => $payload['schema'],
+            'X-Patris-Contract-Version' => $payload['schema_version'],
+            'X-Patris-Event-ID' => $payload['event_id'],
+        );
+        $request = new WP_REST_Request(array(), $payload, $headers, $body);
+
+        $response = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
+        $this->assertSame(200, $response->get_status());
+        $this->assertTrue($response->get_data()['success']);
+        $this->assertSame('accepted', $response->get_data()['data']['status']);
+
+        $headers['X-Patris-Event-ID'] = 'sha256:' . str_repeat('f', 64);
+        $mismatch = Digitalogic_REST_API::instance()->receive_patris_product_sync(
+            new WP_REST_Request(array(), $payload, $headers, $body)
+        );
+        $this->assertSame(400, $mismatch->get_status());
+        $this->assertSame('digitalogic_product_sync_header_mismatch', $mismatch->get_data()['code']);
+    }
+
+    public function test_rest_callback_returns_validation_status_and_code(): void {
+        $payload = $this->emptySnapshot();
+        $payload['local_currency'] = 'IRR';
+        $request = new WP_REST_Request(
+            array(),
+            $payload,
+            array('X-Digitalogic-Token' => 'receiver-secret'),
+            json_encode($payload)
+        );
+        $response = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
+
+        $this->assertSame(422, $response->get_status());
+        $this->assertFalse($response->get_data()['success']);
+        $this->assertSame('digitalogic_product_sync_currency_unsupported', $response->get_data()['code']);
+    }
+
+    private function emptySnapshot() {
+        $revision = 'sha256:' . hash('sha256', '');
+        $source = array('id' => 'rest-tests', 'dataset' => 'kala.db', 'revision' => $revision);
+        $identity = array(
+            'schema' => 'digitalogic.product-sync',
+            'schema_version' => '1.0',
+            'event_type' => 'snapshot',
+            'local_currency' => 'IRT',
+            'formula_id' => 'landed_price_v1',
+            'formula_revision' => '1.0.0',
+            'source' => $source,
+            'products' => array(),
+        );
+
+        return array(
+            'schema' => 'digitalogic.product-sync',
+            'schema_version' => '1.0',
+            'event' => 'digitalogic.product-sync',
+            'event_type' => 'snapshot',
+            'event_id' => 'sha256:' . hash('sha256', json_encode($identity, JSON_UNESCAPED_SLASHES)),
+            'local_currency' => 'IRT',
+            'formula_id' => 'landed_price_v1',
+            'formula_revision' => '1.0.0',
+            'formula_version' => 'landed_price_v1',
+            'source' => $source,
+            'generated_at' => '2026-07-16T10:00:00Z',
+            'products' => array(),
+        );
+    }
+}

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -250,6 +250,7 @@ final class RestApiPermissionsTest extends TestCase {
             'GET /reports' => 'check_diagnostic_permission',
             'POST /patris/sync' => 'check_write_permission',
             'POST /patris/push' => 'check_patris_push_permission',
+            'POST /patris/product-sync' => 'check_patris_product_sync_permission',
             'GET /integration/catalog' => 'check_read_permission',
             'GET /import-freight-methods' => 'check_read_permission',
             'POST /import-freight-methods' => 'check_write_permission',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,6 +29,7 @@ $GLOBALS['digitalogic_test_remote_posts'] = array();
 $GLOBALS['digitalogic_test_remote_post_results'] = array();
 $GLOBALS['digitalogic_test_wc_products'] = array();
 $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+$GLOBALS['digitalogic_test_wc_save_failures'] = array();
 $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
 
 class WP_Error {
@@ -346,6 +347,10 @@ function wp_parse_url($url, $component = -1) {
 
 function wp_unslash($value) {
     return $value;
+}
+
+function wp_generate_password($length = 12, $special_chars = true, $extra_special_chars = false) {
+    return substr(str_repeat('test-generated-secret-', 8), 0, (int) $length);
 }
 
 function maybe_serialize($value) {
@@ -924,6 +929,9 @@ class WC_Product {
     }
 
     public function save() {
+        if (in_array($this->id, $GLOBALS['digitalogic_test_wc_save_failures'] ?? array(), true)) {
+            throw new RuntimeException('Injected WooCommerce save failure.');
+        }
         $this->save_count++;
         $GLOBALS['digitalogic_test_posts'][$this->id]['meta'] = $this->meta;
         $GLOBALS['digitalogic_test_wc_product_saves'][] = $this->id;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,6 +29,7 @@ $GLOBALS['digitalogic_test_remote_posts'] = array();
 $GLOBALS['digitalogic_test_remote_post_results'] = array();
 $GLOBALS['digitalogic_test_wc_products'] = array();
 $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+$GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
 
 class WP_Error {
     private $code;
@@ -58,11 +59,13 @@ class WP_REST_Request implements ArrayAccess {
     private $params;
     private $json;
     private $headers;
+    private $body;
 
-    public function __construct($params = array(), $json = array(), $headers = array()) {
+    public function __construct($params = array(), $json = array(), $headers = array(), $body = null) {
         $this->params = is_array($params) ? $params : array();
         $this->json = is_array($json) ? $json : array();
         $this->headers = array_change_key_case(is_array($headers) ? $headers : array(), CASE_LOWER);
+        $this->body = is_string($body) ? $body : json_encode($this->json);
     }
 
     public function get_params() {
@@ -81,6 +84,10 @@ class WP_REST_Request implements ArrayAccess {
     public function get_header($key) {
         $key = strtolower((string) $key);
         return isset($this->headers[$key]) ? $this->headers[$key] : '';
+    }
+
+    public function get_body() {
+        return $this->body;
     }
 
     public function offsetExists($offset): bool {
@@ -941,7 +948,9 @@ function wc_get_product($product_id) {
 }
 
 function get_woocommerce_currency() {
-    return 'IRT';
+    return isset($GLOBALS['digitalogic_test_wc_currency'])
+        ? (string) $GLOBALS['digitalogic_test_wc_currency']
+        : 'IRT';
 }
 
 function wc_get_weight($weight, $to_unit, $from_unit = '') {
@@ -1043,6 +1052,7 @@ $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
 require_once dirname(__DIR__) . '/includes/class-unit-converter.php';
 require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';
 require_once dirname(__DIR__) . '/includes/class-patris-feed.php';
+require_once dirname(__DIR__) . '/includes/class-product-sync-receiver.php';
 require_once dirname(__DIR__) . '/includes/class-import-freight-service.php';
 require_once dirname(__DIR__) . '/includes/class-command-dispatcher.php';
 require_once dirname(__DIR__) . '/includes/api/class-rest-api.php';

--- a/tests/fixtures/patris-product-sync-v1-golden.json
+++ b/tests/fixtures/patris-product-sync-v1-golden.json
@@ -1,0 +1,86 @@
+{
+  "schema": "digitalogic.product-sync",
+  "schema_version": "1.0",
+  "event": "digitalogic.product-sync",
+  "event_type": "snapshot",
+  "event_id": "sha256:b659a592853f5709fd3ee0d52f7e58738cf3d109fe58d538257738a6dd157dff",
+  "local_currency": "IRT",
+  "formula_id": "landed_price_v1",
+  "formula_revision": "1.0.0",
+  "formula_version": "landed_price_v1",
+  "source": {
+    "id": "synthetic-fixture",
+    "dataset": "synthetic-kala.db",
+    "revision": "sha256:eec5251e15aa8d8d29736650afdc0edfa9d2576fe60427af22afe5d7119f7294"
+  },
+  "generated_at": "2026-01-02T03:04:05Z",
+  "products": [
+    {
+      "product_code": "SYNTH-NULL-002",
+      "name": "Synthetic incomplete product",
+      "serial": "SYNTH-PN-002",
+      "unit": "unit",
+      "sale_price_source": null,
+      "purchase_price_source": null,
+      "warehouse_stock": {
+        "1": 0,
+        "2": 0
+      },
+      "total_stock": 0,
+      "minimum_stock": null,
+      "foreign_currency": "CNY",
+      "foreign_price": null,
+      "weight_grams": null,
+      "location": "weight unavailable",
+      "import_freight_method_id": "",
+      "freight_cny_per_kg": null,
+      "markup_percent": null,
+      "irt_per_cny": 29000,
+      "pricing_catalog_revision": "synthetic-catalog-v1",
+      "pricing_catalog_status": "static",
+      "currency_effective_date": "2026-01-01",
+      "final_price": null,
+      "formula_version": "landed_price_v1",
+      "source_updated_at": "",
+      "warnings": [
+        "final_price_unavailable",
+        "foreign_price_missing",
+        "freight_rate_missing",
+        "import_freight_method_missing",
+        "markup_percent_missing",
+        "weight_missing"
+      ],
+      "record_hash": "sha256:d031b2316e7963976b994301033f1fe4c4ba29a744c221ec0117cd6170344ca8"
+    },
+    {
+      "product_code": "SYNTH-PRICED-001",
+      "name": "Synthetic priced product",
+      "serial": "SYNTH-PN-001",
+      "unit": "unit",
+      "sale_price_source": 100000,
+      "purchase_price_source": 90000,
+      "warehouse_stock": {
+        "1": 3,
+        "2": 2
+      },
+      "total_stock": 5,
+      "minimum_stock": 1,
+      "foreign_currency": "CNY",
+      "foreign_price": 24.5,
+      "weight_grams": 240,
+      "location": "TEST-A",
+      "import_freight_method_id": "synthetic-air",
+      "freight_cny_per_kg": 120,
+      "markup_percent": 30,
+      "irt_per_cny": 29000,
+      "pricing_catalog_revision": "synthetic-catalog-v1",
+      "pricing_catalog_status": "static",
+      "currency_effective_date": "2026-01-01",
+      "final_price": 2009410,
+      "formula_version": "landed_price_v1",
+      "source_updated_at": "2026-01-01T00:00:00Z",
+      "warnings": [],
+      "record_hash": "sha256:fb1fc9e10312f7aaa4659550525a0f9b4536f375e4d005ee1f2e1658a90e4976"
+    }
+  ]
+}

--- a/tests/fixtures/patris-product-sync-v1-golden.json
+++ b/tests/fixtures/patris-product-sync-v1-golden.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0",
   "event": "digitalogic.product-sync",
   "event_type": "snapshot",
-  "event_id": "sha256:b659a592853f5709fd3ee0d52f7e58738cf3d109fe58d538257738a6dd157dff",
+  "event_id": "sha256:25d5afce95dfdcf598c28f9c9639cbd54ed7f2e838a6c285844eee75d972ef06",
   "local_currency": "IRT",
   "formula_id": "landed_price_v1",
   "formula_revision": "1.0.0",


### PR DESCRIPTION
## Summary
- add a dedicated authenticated product-sync receiver that accepts only the current `patris.product-sync` shape and does not support the retired `/patris/push` shape
- validate the transformed-only `patris.product-sync` shape, IRT output, typed products, recursive raw-field boundary, and exact Go-equivalent record/source/occurrence hashes
- independently recompute `landed_price` with bounded exact-decimal arithmetic and a single half-up final IRT integer round; require a complete producer value to match exactly, omit it when source/reference inputs are unavailable, and preserve `null` only when explicitly supplied upstream
- commit source state and a durable per-product delivery outbox before WooCommerce writes; retry pending work on identical replay and acknowledge crash-window saves by persisted record-hash CAS
- make Patris Code canonical, reject distinct exact SKU/Patris-Code namespace collisions as ambiguous, and use exact SKU only when no Patris Code exists
- bind exact `generated_at` into `event_id` and persist newer same-content occurrences so the per-source ordering watermark advances
- authenticate machine delivery with the neutral `X-Patris-Product-Sync-Secret` header, optional exact source ID/dataset scopes, and fail-closed malformed scope configuration
- document staged rollout and bump the plugin feature version to 1.2.0

## Cross-project contract proof
- Go-generated synthetic fixture only (no live catalog data): 2 fake products, 2,760 bytes, SHA-256 `810bdf4d8fd5e3c2a87750a02f241363f6403736c899a625f615967fea259da5`
- receiver and producer agree on occurrence `sha256:25d5afce95dfdcf598c28f9c9639cbd54ed7f2e838a6c285844eee75d972ef06`
- exact event hash material uses the current `patris.product-sync` fields only, including `schema`, `event_type`, `local_currency`, `source{id,dataset,revision}`, `generated_at`, products, categories, exclusions, quarantine, warnings, and tombstones
- receiver independently verifies the source revision, both record hashes, and the reference `2,009,410 IRT` landed price

## Delivery outcomes
- `accepted` / `already_current`: occurrence committed and no Woo work remains
- `partially_applied`: occurrence committed, one or more products remain durably pending, `retryable: true`
- `retry_pending`: identical replay retried pending products but work remains
- `recovered`: identical replay cleared the pending outbox
- `replayed`: fully applied event replay; no state write, Woo save, log, or domain event

## Verification
- PHPUnit: 112 tests, 667 assertions
- focused receiver + REST regressions: 25 tests, 157 assertions
- PHP syntax: 49 plugin/test files
- JavaScript syntax: 9 first-party files
- Composer manifest strict validation: pass
- Composer locked install dry-run: pass with only the PHP platform check ignored because this host CLI is PHP 8.5 while PhpSpreadsheet 1.x declares `<8.5`; CI runs PHP 8.3
- public backup-artifact guard: pass
- `git diff --check`: pass

`composer audit --locked` reports the pre-existing locked dependency advisories tracked separately in #52; this receiver PR does not mix dependency remediation into the contract change.

## Deployment safety
- do not connect Patris delivery or deploy this branch before review and merge
- provision the dedicated `X-Patris-Product-Sync-Secret` value and exact source scopes, then stage a snapshot and exact-Code canaries before enabling production delivery
- retired receiver state remains isolated; the current receiver uses its plugin-owned product-sync state option

Closes #48


