### PR TITLE
Remediate Composer advisories and harden spreadsheet I/O

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -30,7 +30,7 @@ jobs:
         
     - name: Get Composer cache directory
       id: composer-cache
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
       
     - name: Cache Composer dependencies
       uses: actions/cache@v4
@@ -102,7 +102,7 @@ jobs:
       run: composer install --prefer-dist --no-progress
       
     - name: Check for known security vulnerabilities
-      run: composer audit || true
+      run: composer audit --locked
       
   build:
     name: Build Plugin

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 # Test
 phpunit.xml
 /.phpunit.result.cache
+/.phpunit.cache/
 
 # Temporary files
 *.tmp

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 
 ## Requirements
 
-- PHP 8.0 or higher
+- PHP 8.3 or higher
 - WordPress 6.0 or higher
 - WooCommerce 7.0 or higher (8.2+ recommended for HPOS)
 - MySQL 5.7 or higher

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
   ],
   "require": {
     "php": ">=8.3",
-    "phpoffice/phpspreadsheet": "^1.29"
+    "phpoffice/phpspreadsheet": "^5.9"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^12.5",
     "wp-coding-standards/wpcs": "^3.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
@@ -40,6 +40,9 @@
     ]
   },
   "config": {
+    "platform": {
+      "php": "8.3.0"
+    },
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,33 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1368f17fa08f6de9fe44707ceddb8f9",
+    "content-hash": "0c4232ab4752a31a5259b810118dc450",
     "packages": [
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -67,7 +68,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -77,87 +78,22 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
-        },
-        {
-            "name": "ezyang/htmlpurifier",
-            "version": "v4.19.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/b287d2a16aceffbf6e0295559b39662612b77fcf",
-                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
-            },
-            "require-dev": {
-                "cerdic/css-tidy": "^1.7 || ^2.0",
-                "simpletest/simpletest": "dev-master"
-            },
-            "suggest": {
-                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
-                "ext-bcmath": "Used for unit conversion and imagecrash protection",
-                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
-                "ext-tidy": "Used for pretty-printing HTML"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "library/HTMLPurifier.composer.php"
-                ],
-                "psr-0": {
-                    "HTMLPurifier": "library/"
-                },
-                "exclude-from-classmap": [
-                    "/library/HTMLPurifier/Language/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-2.1-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Edward Z. Yang",
-                    "email": "admin@htmlpurifier.org",
-                    "homepage": "http://ezyang.com"
-                }
-            ],
-            "description": "Standards compliant HTML filter written in PHP",
-            "homepage": "http://htmlpurifier.org/",
-            "keywords": [
-                "html"
-            ],
-            "support": {
-                "issues": "https://github.com/ezyang/htmlpurifier/issues",
-                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.19.0"
-            },
-            "time": "2025-10-17T16:34:55+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "3.2.0",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "9712d8fa4cdf9240380b01eb4be55ad8dcf71416"
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/9712d8fa4cdf9240380b01eb4be55ad8dcf71416",
-                "reference": "9712d8fa4cdf9240380b01eb4be55ad8dcf71416",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
                 "shasum": ""
             },
             "require": {
@@ -168,7 +104,7 @@
             "require-dev": {
                 "brianium/paratest": "^7.7",
                 "ext-zip": "*",
-                "friendsofphp/php-cs-fixer": "^3.16",
+                "friendsofphp/php-cs-fixer": "^3.86",
                 "guzzlehttp/guzzle": "^7.5",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.5",
@@ -214,7 +150,7 @@
             ],
             "support": {
                 "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
-                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.0"
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.2"
             },
             "funding": [
                 {
@@ -222,7 +158,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-17T11:15:13+00:00"
+            "time": "2026-04-11T18:38:28+00:00"
         },
         {
             "name": "markbaker/complex",
@@ -333,16 +269,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.30.1",
+            "version": "5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "fa8257a579ec623473eabfe49731de5967306c4c"
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/fa8257a579ec623473eabfe49731de5967306c4c",
-                "reference": "fa8257a579ec623473eabfe49731de5967306c4c",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/05e99ebf61238a70227b4d9cc02d0030d34f6339",
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339",
                 "shasum": ""
             },
             "require": {
@@ -350,6 +286,7 @@
                 "ext-ctype": "*",
                 "ext-dom": "*",
                 "ext-fileinfo": "*",
+                "ext-filter": "*",
                 "ext-gd": "*",
                 "ext-iconv": "*",
                 "ext-libxml": "*",
@@ -360,31 +297,30 @@
                 "ext-xmlwriter": "*",
                 "ext-zip": "*",
                 "ext-zlib": "*",
-                "ezyang/htmlpurifier": "^4.15",
                 "maennchen/zipstream-php": "^2.1 || ^3.0",
                 "markbaker/complex": "^3.0",
                 "markbaker/matrix": "^3.0",
-                "php": ">=7.4.0 <8.5.0",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0",
+                "php": "^8.2",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
-                "dompdf/dompdf": "^1.0 || ^2.0 || ^3.0",
+                "dompdf/dompdf": "^2.0 || ^3.0",
+                "ext-intl": "*",
                 "friendsofphp/php-cs-fixer": "^3.2",
-                "mitoteam/jpgraph": "^10.3",
+                "mitoteam/jpgraph": "^10.5",
                 "mpdf/mpdf": "^8.1.1",
                 "phpcompatibility/php-compatibility": "^9.3",
-                "phpstan/phpstan": "^1.1",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^8.5 || ^9.0",
+                "phpstan/phpstan": "^1.1 || ^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
+                "phpunit/phpunit": "^10.5 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.7",
                 "tecnickcom/tcpdf": "^6.5"
             },
             "suggest": {
                 "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
-                "ext-intl": "PHP Internationalization Functions",
+                "ext-intl": "PHP Internationalization Functions, required for NumberFormat Wizard and StringHelper::setLocale()",
                 "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
                 "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
                 "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
@@ -417,6 +353,9 @@
                 },
                 {
                     "name": "Adrien Crivelli"
+                },
+                {
+                    "name": "Owen Leibman"
                 }
             ],
             "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
@@ -433,169 +372,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.30.1"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.9.0"
             },
-            "time": "2025-10-26T16:01:04+00:00"
-        },
-        {
-            "name": "psr/http-client",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP clients",
-            "homepage": "https://github.com/php-fig/http-client",
-            "keywords": [
-                "http",
-                "http-client",
-                "psr",
-                "psr-18"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-client"
-            },
-            "time": "2023-09-23T14:17:50+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory"
-            },
-            "time": "2024-04-15T12:06:14+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/2.0"
-            },
-            "time": "2023-04-04T09:54:51+00:00"
+            "time": "2026-07-12T19:17:39+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -652,16 +431,16 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -744,77 +523,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -878,20 +587,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -930,9 +638,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1442,35 +1150,33 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "12.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "186dab580576598076de6818596d12b61801880e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/186dab580576598076de6818596d12b61801880e",
+                "reference": "186dab580576598076de6818596d12b61801880e",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
-                "theseer/tokenizer": "^1.2.3"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/lines-of-code": "^4.0.1",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^12.5.28"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -1479,7 +1185,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "12.5.x-dev"
                 }
             },
             "autoload": {
@@ -1508,40 +1214,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.7"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2026-06-01T13:24:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1568,36 +1286,49 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2026-02-02T14:04:18+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -1605,7 +1336,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1631,7 +1362,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1639,32 +1371,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2025-02-07T04:58:58+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1690,7 +1422,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
             },
             "funding": [
                 {
@@ -1698,32 +1431,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2025-02-07T04:59:16+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -1749,7 +1482,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
             },
             "funding": [
                 {
@@ -1757,54 +1491,49 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2025-02-07T04:59:38+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.31",
+            "version": "12.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5"
+                "reference": "0608d157a284f15cc73b99a3327eff06b66a176d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/945d0b7f346a084ce5549e95289962972c4272e5",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0608d157a284f15cc73b99a3327eff06b66a176d",
+                "reference": "0608d157a284f15cc73b99a3327eff06b66a176d",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.8",
-                "sebastian/global-state": "^5.0.8",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.5.7",
+                "phpunit/php-file-iterator": "^6.0.1",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.1",
+                "sebastian/comparator": "^7.1.8",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/exporter": "^7.0.3",
+                "sebastian/global-state": "^8.0.3",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
+                "sebastian/type": "^6.0.4",
+                "sebastian/version": "^6.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "bin": [
                 "phpunit"
@@ -1812,7 +1541,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "12.5-dev"
                 }
             },
             "autoload": {
@@ -1844,56 +1573,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.31"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.31"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2025-12-06T07:45:52+00:00"
+            "time": "2026-07-06T14:54:16+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/7d05781b13f7dec9043a629a21d086ed74582a15",
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1916,153 +1629,60 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2024-03-02T06:27:43+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:08:54+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2026-05-17T05:29:34+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "7.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "7c65c1e79836812819705b473a90c12399542485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/7c65c1e79836812819705b473a90c12399542485",
+                "reference": "7c65c1e79836812819705b473a90c12399542485",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.1-dev"
                 }
             },
             "autoload": {
@@ -2101,7 +1721,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.8"
             },
             "funding": [
                 {
@@ -2121,33 +1742,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-05-21T04:45:25+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2170,7 +1791,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2178,33 +1800,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2025-02-07T04:55:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2236,7 +1858,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
             },
             "funding": [
                 {
@@ -2244,27 +1867,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "8.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.5.26"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2272,7 +1895,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -2291,7 +1914,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -2299,42 +1922,55 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2026-05-25T13:40:20+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.8",
+            "version": "7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
-                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2376,7 +2012,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.3"
             },
             "funding": [
                 {
@@ -2396,38 +2033,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:03:27+00:00"
+            "time": "2026-05-20T04:37:17+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.8",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
-                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^12.5.28"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -2446,13 +2080,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.3"
             },
             "funding": [
                 {
@@ -2472,33 +2107,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T07:10:35+00:00"
+            "time": "2026-06-01T15:10:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2521,42 +2156,55 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2026-05-19T16:22:07+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2578,7 +2226,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -2586,32 +2235,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2025-02-07T04:57:48+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2633,7 +2282,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2641,32 +2291,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2025-02-07T04:58:17+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.6",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
-                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2696,7 +2346,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
             },
             "funding": [
                 {
@@ -2716,86 +2367,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:57:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2025-08-13T04:44:59+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "6.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/82ff822c2edc46724be9f7411d3163021f602773",
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2818,37 +2415,50 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.4"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2026-05-20T06:45:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2871,7 +2481,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2879,7 +2490,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2025-02-07T05:00:38+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -2961,24 +2572,76 @@
             "time": "2025-11-04T16:30:35+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.3.1",
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.1"
             },
             "type": "library",
             "autoload": {
@@ -3000,7 +2663,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
             },
             "funding": [
                 {
@@ -3008,7 +2671,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-17T20:03:58+00:00"
+            "time": "2025-12-08T11:19:18+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -3086,5 +2749,8 @@
         "php": ">=8.3"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3.0"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -9,7 +9,7 @@
  * Text Domain: digitalogic
  * Domain Path: /languages
  * Requires at least: 6.0
- * Requires PHP: 8.2
+ * Requires PHP: 8.3
  * WC requires at least: 7.0
  * WC tested up to: 8.5
  * License: GPL v2 or later
@@ -23,7 +23,7 @@ if (!defined('ABSPATH')) {
 
 // Define plugin constants
 define('DIGITALOGIC_VERSION', '1.2.0');
-define('DIGITALOGIC_MIN_PHP_VERSION', '8.2');
+define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('DIGITALOGIC_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('DIGITALOGIC_PLUGIN_BASENAME', plugin_basename(__FILE__));

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing to the Digitalogic WordPress plugin!
 
 ### Prerequisites
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - Composer
 - WordPress development environment
 - WooCommerce plugin

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - WordPress 6.0 or higher
 - WooCommerce 7.0 or higher
 - MySQL 5.7 or higher

--- a/docs/PROJECT_SUMMARY.md
+++ b/docs/PROJECT_SUMMARY.md
@@ -135,7 +135,7 @@ wp digitalogic logs --limit=50 --action=update_product
 ```
 
 ## System Requirements
-- PHP 8.2+
+- PHP 8.3+
 - WordPress 6.0+
 - WooCommerce 7.0+
 - MySQL 5.7+
@@ -145,7 +145,7 @@ wp digitalogic logs --limit=50 --action=update_product
 ### GitHub Actions Workflows
 1. **CI/CD Pipeline** (ci-cd.yml)
    - Code quality checks (PHPCS)
-   - PHP 8.2, 8.3, 8.4, 8.5 testing
+   - PHP 8.3 compatibility testing
    - Security checks
    - Build artifact creation
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -6,7 +6,7 @@ This guide helps you test the plugin installation and verify all features are wo
 
 - WordPress 6.0 or higher
 - WooCommerce 7.0 or higher (8.2+ recommended)
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - WP-CLI installed (optional, for CLI testing)
 
 ## Installation Testing

--- a/includes/class-import-export.php
+++ b/includes/class-import-export.php
@@ -10,6 +10,25 @@ if (!defined('ABSPATH')) {
 }
 
 class Digitalogic_Import_Export {
+
+    /** Maximum spreadsheet size accepted by default (20 MiB). */
+    private const DEFAULT_MAX_SPREADSHEET_BYTES = 20 * 1024 * 1024;
+
+    /** Maximum populated worksheet dimensions accepted by default. */
+    private const DEFAULT_MAX_SPREADSHEET_ROWS = 100000;
+    private const DEFAULT_MAX_SPREADSHEET_COLUMNS = 128;
+
+    /** XLSX archive limits applied before any XML member is loaded. */
+    private const DEFAULT_MAX_XLSX_ARCHIVE_ENTRIES = 2048;
+    private const DEFAULT_MAX_XLSX_ENTRY_BYTES = 32 * 1024 * 1024;
+    private const DEFAULT_MAX_XLSX_TOTAL_UNCOMPRESSED_BYTES = 64 * 1024 * 1024;
+    private const DEFAULT_MAX_XLSX_COMPRESSION_RATIO = 200;
+
+    /** @var array<string, string> */
+    private const SPREADSHEET_READERS = array(
+        'xlsx' => 'Xlsx',
+        'xls' => 'Xls',
+    );
     
     private static $instance = null;
     
@@ -22,6 +41,232 @@ class Digitalogic_Import_Export {
     
     private function __construct() {
         // Constructor
+    }
+
+    /**
+     * Return the canonical product import/export columns.
+     *
+     * @return string[]
+     */
+    private static function get_product_headers() {
+        return array(
+            'ID',
+            'Name',
+            'SKU',
+            'Type',
+            'Regular Price',
+            'Sale Price',
+            'Stock Quantity',
+            'Stock Status',
+            'Weight',
+            'Length',
+            'Width',
+            'Height',
+            'Dynamic Pricing',
+            'Currency Type',
+            'Base Price',
+            'Markup',
+            'Markup Type',
+        );
+    }
+
+    /**
+     * Write a spreadsheet value without allowing text to be inferred as a formula.
+     *
+     * @param \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet Worksheet.
+     * @param string $coordinate Cell coordinate.
+     * @param mixed $value Cell value.
+     * @param bool $numeric Whether a numeric value should remain numeric.
+     * @return void
+     */
+    private static function set_spreadsheet_value($sheet, $coordinate, $value, $numeric = false) {
+        if ($numeric && is_numeric($value)) {
+            $number = str_contains((string) $value, '.') ? (float) $value : (int) $value;
+            $sheet->setCellValueExplicit(
+                $coordinate,
+                $number,
+                \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_NUMERIC
+            );
+            return;
+        }
+
+        $sheet->setCellValueExplicit(
+            $coordinate,
+            (string) $value,
+            \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING
+        );
+    }
+
+    /**
+     * Neutralize text that spreadsheet applications may otherwise interpret as a formula.
+     *
+     * @param mixed $value CSV field value.
+     * @return string
+     */
+    private static function get_safe_csv_text($value) {
+        $value = (string) $value;
+        if (preg_match('/^[=+\-@\t\r]/u', $value)) {
+            return "'" . $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Validate XLSX central-directory metadata before the reader expands XML members.
+     *
+     * @param string $filepath Canonical local XLSX path.
+     * @return true|WP_Error
+     */
+    private function validate_xlsx_archive($filepath) {
+        $max_entries = (int) apply_filters(
+            'digitalogic_max_xlsx_archive_entries',
+            self::DEFAULT_MAX_XLSX_ARCHIVE_ENTRIES
+        );
+        $max_entry_bytes = (int) apply_filters(
+            'digitalogic_max_xlsx_entry_bytes',
+            self::DEFAULT_MAX_XLSX_ENTRY_BYTES
+        );
+        $max_total_bytes = (int) apply_filters(
+            'digitalogic_max_xlsx_total_uncompressed_bytes',
+            self::DEFAULT_MAX_XLSX_TOTAL_UNCOMPRESSED_BYTES
+        );
+        $max_ratio = (float) apply_filters(
+            'digitalogic_max_xlsx_compression_ratio',
+            self::DEFAULT_MAX_XLSX_COMPRESSION_RATIO
+        );
+
+        if ($max_entries < 1 || $max_entry_bytes < 1 || $max_total_bytes < 1 || $max_ratio < 1) {
+            return new WP_Error(
+                'xlsx_archive_limits_exceeded',
+                __('Excel archive exceeds the import safety limits', 'digitalogic')
+            );
+        }
+
+        $archive = new \ZipArchive();
+        if (true !== $archive->open($filepath, \ZipArchive::RDONLY)) {
+            return new WP_Error('read_error', __('Unable to read Excel file', 'digitalogic'));
+        }
+
+        try {
+            if ($archive->numFiles < 1 || $archive->numFiles > $max_entries) {
+                return new WP_Error(
+                    'xlsx_archive_limits_exceeded',
+                    __('Excel archive exceeds the import safety limits', 'digitalogic')
+                );
+            }
+
+            $total_bytes = 0;
+            $total_compressed_bytes = 0;
+            for ($index = 0; $index < $archive->numFiles; $index++) {
+                $entry = $archive->statIndex($index, \ZipArchive::FL_UNCHANGED);
+                if (false === $entry) {
+                    return new WP_Error('read_error', __('Unable to read Excel file', 'digitalogic'));
+                }
+
+                $name = str_replace('\\', '/', (string) $entry['name']);
+                if (
+                    '' === $name
+                    || str_starts_with($name, '/')
+                    || str_contains($name, "\0")
+                    || preg_match('#(?:^|/)\.\.(?:/|$)#', $name)
+                ) {
+                    return new WP_Error('invalid_xlsx_archive', __('Invalid Excel archive', 'digitalogic'));
+                }
+
+                $entry_bytes = isset($entry['size']) ? (int) $entry['size'] : -1;
+                $compressed_bytes = isset($entry['comp_size']) ? (int) $entry['comp_size'] : -1;
+                if ($entry_bytes < 0 || $compressed_bytes < 0 || $entry_bytes > $max_entry_bytes) {
+                    return new WP_Error(
+                        'xlsx_archive_limits_exceeded',
+                        __('Excel archive exceeds the import safety limits', 'digitalogic')
+                    );
+                }
+
+                $total_bytes += $entry_bytes;
+                $total_compressed_bytes += $compressed_bytes;
+                if ($total_bytes > $max_total_bytes) {
+                    return new WP_Error(
+                        'xlsx_archive_limits_exceeded',
+                        __('Excel archive exceeds the import safety limits', 'digitalogic')
+                    );
+                }
+
+                if ($entry_bytes > 1024 * 1024 && $entry_bytes / max(1, $compressed_bytes) > $max_ratio) {
+                    return new WP_Error(
+                        'xlsx_archive_limits_exceeded',
+                        __('Excel archive exceeds the import safety limits', 'digitalogic')
+                    );
+                }
+            }
+
+            if ($total_bytes > 1024 * 1024 && $total_bytes / max(1, $total_compressed_bytes) > $max_ratio) {
+                return new WP_Error(
+                    'xlsx_archive_limits_exceeded',
+                    __('Excel archive exceeds the import safety limits', 'digitalogic')
+                );
+            }
+        } finally {
+            $archive->close();
+        }
+
+        return true;
+    }
+
+    /**
+     * Load a local Excel workbook with an explicit reader.
+     *
+     * @param string $filepath Workbook path.
+     * @return \PhpOffice\PhpSpreadsheet\Spreadsheet|WP_Error
+     */
+    private function load_spreadsheet($filepath) {
+        if (!is_string($filepath) || '' === trim($filepath)) {
+            return new WP_Error('file_not_found', __('File not found', 'digitalogic'));
+        }
+
+        // Spreadsheet imports are local files only; never resolve stream wrappers.
+        if (preg_match('#^[a-z][a-z0-9+.-]*://#i', $filepath)) {
+            return new WP_Error('invalid_source', __('Excel imports must use a local file', 'digitalogic'));
+        }
+
+        if (!file_exists($filepath)) {
+            return new WP_Error('file_not_found', __('File not found', 'digitalogic'));
+        }
+
+        $realpath = realpath($filepath);
+        if (false === $realpath || !is_file($realpath) || !is_readable($realpath)) {
+            return new WP_Error('unreadable_file', __('Excel file is not readable', 'digitalogic'));
+        }
+
+        $extension = strtolower(pathinfo($realpath, PATHINFO_EXTENSION));
+        if (!isset(self::SPREADSHEET_READERS[$extension])) {
+            return new WP_Error('invalid_file_type', __('Unsupported Excel file type', 'digitalogic'));
+        }
+
+        $max_bytes = (int) apply_filters(
+            'digitalogic_max_spreadsheet_import_bytes',
+            self::DEFAULT_MAX_SPREADSHEET_BYTES
+        );
+        $filesize = filesize($realpath);
+        if (false === $filesize || $max_bytes < 1 || $filesize > $max_bytes) {
+            return new WP_Error('file_too_large', __('Excel file exceeds the import size limit', 'digitalogic'));
+        }
+
+        if ('xlsx' === $extension) {
+            $archive_validation = $this->validate_xlsx_archive($realpath);
+            if (is_wp_error($archive_validation)) {
+                return $archive_validation;
+            }
+        }
+
+        try {
+            $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader(self::SPREADSHEET_READERS[$extension]);
+            $reader->setReadDataOnly(true);
+
+            return $reader->load($realpath);
+        } catch (\Throwable $e) {
+            return new WP_Error('read_error', __('Unable to read Excel file', 'digitalogic'));
+        }
     }
     
     /**
@@ -109,27 +354,9 @@ class Digitalogic_Import_Export {
         $file = fopen($filepath, 'w');
         
         // Headers
-        $headers = array(
-            'ID',
-            'Name',
-            'SKU',
-            'Type',
-            'Regular Price',
-            'Sale Price',
-            'Stock Quantity',
-            'Stock Status',
-            'Weight',
-            'Length',
-            'Width',
-            'Height',
-            'Dynamic Pricing',
-            'Currency Type',
-            'Base Price',
-            'Markup',
-            'Markup Type'
-        );
+        $headers = self::get_product_headers();
         
-        fputcsv($file, $headers);
+        fputcsv($file, $headers, ',', '"', '');
         
         // Get products
         $manager = Digitalogic_Product_Manager::instance();
@@ -155,25 +382,25 @@ class Digitalogic_Import_Export {
             
             $row = array(
                 $product_data['id'],
-                $product_data['name'],
-                $product_data['sku'],
-                $product_data['type'],
+                self::get_safe_csv_text($product_data['name']),
+                self::get_safe_csv_text($product_data['sku']),
+                self::get_safe_csv_text($product_data['type']),
                 $product_data['regular_price'],
                 $product_data['sale_price'],
                 $product_data['stock_quantity'],
-                $product_data['stock_status'],
+                self::get_safe_csv_text($product_data['stock_status']),
                 $product_data['weight'],
                 $product_data['length'],
                 $product_data['width'],
                 $product_data['height'],
-                $product->get_meta('_digitalogic_dynamic_pricing', true),
-                $product->get_meta('_digitalogic_currency_type', true),
+                self::get_safe_csv_text($product->get_meta('_digitalogic_dynamic_pricing', true)),
+                self::get_safe_csv_text($product->get_meta('_digitalogic_currency_type', true)),
                 $product->get_meta('_digitalogic_base_price', true),
                 $product->get_meta('_digitalogic_markup', true),
-                $product->get_meta('_digitalogic_markup_type', true),
+                self::get_safe_csv_text($product->get_meta('_digitalogic_markup_type', true)),
             );
             
-            fputcsv($file, $row);
+            fputcsv($file, $row, ',', '"', '');
         }
         
         fclose($file);
@@ -244,7 +471,7 @@ class Digitalogic_Import_Export {
         }
         
         $file = fopen($filepath, 'r');
-        $headers = fgetcsv($file);
+        $headers = fgetcsv($file, null, ',', '"', '');
         
         $results = array(
             'success' => 0,
@@ -254,7 +481,7 @@ class Digitalogic_Import_Export {
         
         $manager = Digitalogic_Product_Manager::instance();
         
-        while (($row = fgetcsv($file)) !== false) {
+        while (($row = fgetcsv($file, null, ',', '"', '')) !== false) {
             $data = array_combine($headers, $row);
             
             if (empty($data['ID'])) {
@@ -389,36 +616,15 @@ class Digitalogic_Import_Export {
         $sheet->setTitle('Products');
         
         // Headers with custom styling
-        $headers = array(
-            'ID',
-            'Name',
-            'SKU',
-            'Type',
-            'Regular Price',
-            'Sale Price',
-            'Stock Quantity',
-            'Stock Status',
-            'Weight',
-            'Length',
-            'Width',
-            'Height',
-            'Dynamic Pricing',
-            'Currency Type',
-            'Base Price',
-            'Markup',
-            'Markup Type'
-        );
+        $headers = self::get_product_headers();
         
         $num_columns = count($headers);
-        // Note: This calculation works for up to 26 columns (A-Z).
-        // For more columns, PhpSpreadsheet's Coordinate::stringFromColumnIndex() should be used.
-        $last_column = chr(64 + $num_columns); // A=65, so 64+1=A, 64+17=Q
+        $last_column = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($num_columns);
         
         // Set headers
-        $col = 'A';
-        foreach ($headers as $header) {
-            $sheet->setCellValue($col . '1', $header);
-            $col++;
+        foreach ($headers as $index => $header) {
+            $column = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($index + 1);
+            $sheet->setCellValue($column . '1', $header);
         }
         
         // Style header row
@@ -472,23 +678,23 @@ class Digitalogic_Import_Export {
                 continue;
             }
             
-            $sheet->setCellValue('A' . $row, $product_data['id']);
-            $sheet->setCellValue('B' . $row, $product_data['name']);
-            $sheet->setCellValue('C' . $row, $product_data['sku']);
-            $sheet->setCellValue('D' . $row, $product_data['type']);
-            $sheet->setCellValue('E' . $row, $product_data['regular_price']);
-            $sheet->setCellValue('F' . $row, $product_data['sale_price']);
-            $sheet->setCellValue('G' . $row, $product_data['stock_quantity']);
-            $sheet->setCellValue('H' . $row, $product_data['stock_status']);
-            $sheet->setCellValue('I' . $row, $product_data['weight']);
-            $sheet->setCellValue('J' . $row, $product_data['length']);
-            $sheet->setCellValue('K' . $row, $product_data['width']);
-            $sheet->setCellValue('L' . $row, $product_data['height']);
-            $sheet->setCellValue('M' . $row, $product->get_meta('_digitalogic_dynamic_pricing', true));
-            $sheet->setCellValue('N' . $row, $product->get_meta('_digitalogic_currency_type', true));
-            $sheet->setCellValue('O' . $row, $product->get_meta('_digitalogic_base_price', true));
-            $sheet->setCellValue('P' . $row, $product->get_meta('_digitalogic_markup', true));
-            $sheet->setCellValue('Q' . $row, $product->get_meta('_digitalogic_markup_type', true));
+            self::set_spreadsheet_value($sheet, 'A' . $row, $product_data['id'], true);
+            self::set_spreadsheet_value($sheet, 'B' . $row, $product_data['name']);
+            self::set_spreadsheet_value($sheet, 'C' . $row, $product_data['sku']);
+            self::set_spreadsheet_value($sheet, 'D' . $row, $product_data['type']);
+            self::set_spreadsheet_value($sheet, 'E' . $row, $product_data['regular_price'], true);
+            self::set_spreadsheet_value($sheet, 'F' . $row, $product_data['sale_price'], true);
+            self::set_spreadsheet_value($sheet, 'G' . $row, $product_data['stock_quantity'], true);
+            self::set_spreadsheet_value($sheet, 'H' . $row, $product_data['stock_status']);
+            self::set_spreadsheet_value($sheet, 'I' . $row, $product_data['weight'], true);
+            self::set_spreadsheet_value($sheet, 'J' . $row, $product_data['length'], true);
+            self::set_spreadsheet_value($sheet, 'K' . $row, $product_data['width'], true);
+            self::set_spreadsheet_value($sheet, 'L' . $row, $product_data['height'], true);
+            self::set_spreadsheet_value($sheet, 'M' . $row, $product->get_meta('_digitalogic_dynamic_pricing', true));
+            self::set_spreadsheet_value($sheet, 'N' . $row, $product->get_meta('_digitalogic_currency_type', true));
+            self::set_spreadsheet_value($sheet, 'O' . $row, $product->get_meta('_digitalogic_base_price', true), true);
+            self::set_spreadsheet_value($sheet, 'P' . $row, $product->get_meta('_digitalogic_markup', true), true);
+            self::set_spreadsheet_value($sheet, 'Q' . $row, $product->get_meta('_digitalogic_markup_type', true));
             
             // Apply alternating row colors
             if ($row % 2 == 0) {
@@ -512,9 +718,13 @@ class Digitalogic_Import_Export {
         // Add filters to header row
         $sheet->setAutoFilter('A1:' . $last_column . '1');
         
-        // Write file
-        $writer = new \PhpOffice\PhpSpreadsheet\Writer\Xlsx($spreadsheet);
-        $writer->save($filepath);
+        // Write file and release workbook resources even when the writer fails.
+        try {
+            $writer = new \PhpOffice\PhpSpreadsheet\Writer\Xlsx($spreadsheet);
+            $writer->save($filepath);
+        } finally {
+            $spreadsheet->disconnectWorksheets();
+        }
         
         return $filepath;
     }
@@ -526,18 +736,43 @@ class Digitalogic_Import_Export {
      * @return array Results
      */
     public function import_excel($filepath) {
-        if (!file_exists($filepath)) {
-            return new WP_Error('file_not_found', __('File not found', 'digitalogic'));
-        }
-        
         if (!class_exists('\PhpOffice\PhpSpreadsheet\IOFactory')) {
             return new WP_Error('library_missing', __('PhpSpreadsheet library not found', 'digitalogic'));
         }
-        
+
+        $spreadsheet = $this->load_spreadsheet($filepath);
+        if (is_wp_error($spreadsheet)) {
+            return $spreadsheet;
+        }
+
         try {
-            $spreadsheet = \PhpOffice\PhpSpreadsheet\IOFactory::load($filepath);
             $sheet = $spreadsheet->getActiveSheet();
-            $data = $sheet->toArray();
+            $max_rows = (int) apply_filters(
+                'digitalogic_max_spreadsheet_import_rows',
+                self::DEFAULT_MAX_SPREADSHEET_ROWS
+            );
+            $max_columns = (int) apply_filters(
+                'digitalogic_max_spreadsheet_import_columns',
+                self::DEFAULT_MAX_SPREADSHEET_COLUMNS
+            );
+            $highest_row = $sheet->getHighestDataRow();
+            $highest_column = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::columnIndexFromString(
+                $sheet->getHighestDataColumn()
+            );
+            if (
+                $max_rows < 1
+                || $max_columns < 1
+                || $highest_row > $max_rows
+                || $highest_column > $max_columns
+            ) {
+                return new WP_Error(
+                    'spreadsheet_dimensions_exceeded',
+                    __('Excel worksheet exceeds the import dimension limit', 'digitalogic')
+                );
+            }
+
+            // Return raw values so untrusted formulas are never evaluated during import.
+            $data = $sheet->toArray(null, false, false);
             
             $results = array(
                 'success' => 0,
@@ -550,7 +785,16 @@ class Digitalogic_Import_Export {
             }
             
             // First row is headers
-            $headers = array_shift($data);
+            $headers = array_map(
+                static function($header) {
+                    return trim((string) $header);
+                },
+                array_shift($data)
+            );
+            $missing_headers = array_diff(self::get_product_headers(), $headers);
+            if (!empty($missing_headers) || count($headers) !== count(array_unique($headers))) {
+                return new WP_Error('invalid_headers', __('Excel file does not match the product import template', 'digitalogic'));
+            }
             
             $manager = Digitalogic_Product_Manager::instance();
             
@@ -565,6 +809,20 @@ class Digitalogic_Import_Export {
                 if (count($headers) !== count($row)) {
                     $results['failed']++;
                     $results['errors'][] = sprintf('Row %d has %d columns but expected %d', $current_row_num, count($row), count($headers));
+                    $current_row_num++;
+                    continue;
+                }
+
+                $has_formula = false;
+                foreach ($row as $value) {
+                    if (is_string($value) && str_starts_with(ltrim($value), '=')) {
+                        $has_formula = true;
+                        break;
+                    }
+                }
+                if ($has_formula) {
+                    $results['failed']++;
+                    $results['errors'][] = sprintf('Row %d: Formula cells are not supported', $current_row_num);
                     $current_row_num++;
                     continue;
                 }
@@ -623,10 +881,10 @@ class Digitalogic_Import_Export {
             
             return $results;
             
-        } catch (\PhpOffice\PhpSpreadsheet\Reader\Exception $e) {
-            return new WP_Error('read_error', sprintf(__('Error reading Excel file: %s', 'digitalogic'), $e->getMessage()));
-        } catch (Exception $e) {
-            return new WP_Error('import_error', sprintf(__('Error importing Excel file: %s', 'digitalogic'), $e->getMessage()));
+        } catch (\Throwable $e) {
+            return new WP_Error('import_error', __('Unable to import Excel file', 'digitalogic'));
+        } finally {
+            $spreadsheet->disconnectWorksheets();
         }
     }
 }

--- a/includes/websocket/class-websocket-server.php
+++ b/includes/websocket/class-websocket-server.php
@@ -16,7 +16,7 @@ class Digitalogic_WebSocket_Server {
     private $redis_channel = 'digitalogic_panel_events';
 
     public function run($host = '127.0.0.1', $port = 8090) {
-        $server = stream_socket_server('tcp://' . $host . ':' . $port, $errno, $errstr);
+        $server = @stream_socket_server('tcp://' . $host . ':' . $port, $errno, $errstr);
         if (!$server) {
             throw new RuntimeException($errstr, $errno);
         }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,18 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
     bootstrap="tests/bootstrap.php"
     backupGlobals="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true">
+    cacheDirectory=".phpunit.cache"
+    colors="true">
     <testsuites>
         <testsuite name="Digitalogic Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">includes</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/tests/ImportExportCompatibilityTest.php
+++ b/tests/ImportExportCompatibilityTest.php
@@ -1,0 +1,272 @@
+<?php
+
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xls;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('wp_upload_dir')) {
+    function wp_upload_dir() {
+        return array(
+            'basedir' => $GLOBALS['digitalogic_test_upload_dir'],
+            'baseurl' => 'https://digitalogic.test/uploads',
+        );
+    }
+}
+
+if (!function_exists('wp_mkdir_p')) {
+    function wp_mkdir_p($target) {
+        return is_dir($target) || mkdir($target, 0777, true);
+    }
+}
+
+require_once dirname(__DIR__) . '/includes/class-import-export.php';
+
+final class Digitalogic_Test_Import_Export_Manager extends Digitalogic_Product_Manager {
+    public $products = array();
+    public $updates = array();
+
+    public function get_products($args = array()) {
+        return array_values($this->products);
+    }
+
+    public function get_product($product_id) {
+        return isset($this->products[$product_id]) ? $this->products[$product_id] : null;
+    }
+
+    public function update_product($product_id, $data) {
+        $this->updates[(int) $product_id] = $data;
+        return true;
+    }
+}
+
+final class Digitalogic_Test_Import_Export_Product {
+    private $meta;
+
+    public function __construct($meta) {
+        $this->meta = $meta;
+    }
+
+    public function get_meta($key, $single = true) {
+        return isset($this->meta[$key]) ? $this->meta[$key] : '';
+    }
+
+    public function update_meta_data($key, $value) {
+        $this->meta[$key] = $value;
+    }
+
+    public function save() {
+        return true;
+    }
+}
+
+final class ImportExportCompatibilityTest extends TestCase {
+    private $exporter;
+    private $manager;
+    private $temp_dir;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->temp_dir = sys_get_temp_dir() . '/digitalogic-import-export-' . bin2hex(random_bytes(8));
+        mkdir($this->temp_dir, 0777, true);
+        $GLOBALS['digitalogic_test_upload_dir'] = $this->temp_dir;
+        $GLOBALS['digitalogic_test_filters'] = array();
+        $GLOBALS['digitalogic_test_posts'] = array(
+            42 => array('post_type' => 'product', 'meta' => array()),
+        );
+        $GLOBALS['digitalogic_test_wc_products'] = array(
+            42 => new Digitalogic_Test_Import_Export_Product(array(
+                '_digitalogic_dynamic_pricing' => 'yes',
+                '_digitalogic_currency_type' => 'CNY',
+                '_digitalogic_base_price' => '125.50',
+                '_digitalogic_markup' => '12',
+                '_digitalogic_markup_type' => 'percentage',
+            )),
+        );
+
+        $this->manager = new Digitalogic_Test_Import_Export_Manager();
+        $this->manager->products[42] = array(
+            'id' => 42,
+            'name' => 'Round-trip product',
+            'sku' => 'DG-42',
+            'type' => 'simple',
+            'regular_price' => '150000',
+            'sale_price' => '145000',
+            'stock_quantity' => 9,
+            'stock_status' => 'instock',
+            'weight' => '0.24',
+            'length' => '10',
+            'width' => '5',
+            'height' => '2',
+        );
+
+        $manager_instance = new ReflectionProperty(Digitalogic_Product_Manager::class, 'instance');
+        $manager_instance->setValue(null, $this->manager);
+
+        $exporter_instance = new ReflectionProperty(Digitalogic_Import_Export::class, 'instance');
+        $exporter_instance->setValue(null, null);
+        $this->exporter = Digitalogic_Import_Export::instance();
+    }
+
+    protected function tearDown(): void {
+        $manager_instance = new ReflectionProperty(Digitalogic_Product_Manager::class, 'instance');
+        $manager_instance->setValue(null, null);
+        $exporter_instance = new ReflectionProperty(Digitalogic_Import_Export::class, 'instance');
+        $exporter_instance->setValue(null, null);
+        $this->remove_tree($this->temp_dir);
+        unset($GLOBALS['digitalogic_test_upload_dir']);
+        parent::tearDown();
+    }
+
+    public function test_xlsx_template_exports_and_imports_round_trip(): void {
+        $filepath = $this->exporter->export_excel(array(42));
+
+        $this->assertFileExists($filepath);
+        $workbook = IOFactory::load($filepath);
+        $sheet = $workbook->getActiveSheet();
+        $this->assertSame('Products', $sheet->getTitle());
+        $this->assertSame('Product Export', $workbook->getProperties()->getTitle());
+        $this->assertSame('Name', $sheet->getCell('B1')->getValue());
+        $this->assertSame('Round-trip product', $sheet->getCell('B2')->getValue());
+        $this->assertSame('A2', $sheet->getFreezePane());
+        $this->assertSame('A1:Q1', $sheet->getAutoFilter()->getRange());
+        $workbook->disconnectWorksheets();
+
+        $result = $this->exporter->import_excel($filepath);
+
+        $this->assertSame(1, $result['success']);
+        $this->assertSame(0, $result['failed']);
+        $this->assertSame('Round-trip product', $this->manager->updates[42]['name']);
+        $this->assertSame('DG-42', $this->manager->updates[42]['sku']);
+        $this->assertEquals('150000', $this->manager->updates[42]['regular_price']);
+    }
+
+    public function test_xlsx_import_rejects_non_local_and_malformed_sources(): void {
+        $remote = $this->exporter->import_excel('https://digitalogic.test/products.xlsx');
+        $this->assertSame('invalid_source', $remote->get_error_code());
+
+        $wrong_extension = $this->temp_dir . '/products.txt';
+        file_put_contents($wrong_extension, 'not a workbook');
+        $wrong_type = $this->exporter->import_excel($wrong_extension);
+        $this->assertSame('invalid_file_type', $wrong_type->get_error_code());
+
+        $malformed = $this->temp_dir . '/malformed.xlsx';
+        file_put_contents($malformed, 'not a workbook');
+        $read_error = $this->exporter->import_excel($malformed);
+        $this->assertSame('read_error', $read_error->get_error_code());
+
+        $invalid_template = $this->temp_dir . '/invalid-template.xlsx';
+        $workbook = new Spreadsheet();
+        $workbook->getActiveSheet()->fromArray(array(array('Unexpected', 'Headers')));
+        (new Xlsx($workbook))->save($invalid_template);
+        $workbook->disconnectWorksheets();
+
+        $invalid_headers = $this->exporter->import_excel($invalid_template);
+        $this->assertSame('invalid_headers', $invalid_headers->get_error_code());
+        $this->assertSame(array(), $this->manager->updates);
+    }
+
+    public function test_spreadsheet_import_rejects_formulas_and_excessive_dimensions_without_writes(): void {
+        $filepath = $this->exporter->export_excel(array(42));
+        $workbook = IOFactory::load($filepath);
+        $workbook->getActiveSheet()->setCellValue('B2', '=1+1');
+        (new Xlsx($workbook))->save($filepath);
+        $workbook->disconnectWorksheets();
+
+        $formula_result = $this->exporter->import_excel($filepath);
+        $this->assertSame(0, $formula_result['success']);
+        $this->assertSame(1, $formula_result['failed']);
+        $this->assertSame(array(), $this->manager->updates);
+
+        $GLOBALS['digitalogic_test_filters']['digitalogic_max_spreadsheet_import_rows'] = static function() {
+            return 1;
+        };
+        $dimension_result = $this->exporter->import_excel($filepath);
+        $this->assertSame('spreadsheet_dimensions_exceeded', $dimension_result->get_error_code());
+        $this->assertSame(array(), $this->manager->updates);
+
+        unset($GLOBALS['digitalogic_test_filters']['digitalogic_max_spreadsheet_import_rows']);
+        $GLOBALS['digitalogic_test_filters']['digitalogic_max_xlsx_total_uncompressed_bytes'] = static function() {
+            return 1;
+        };
+        $archive_result = $this->exporter->import_excel($filepath);
+        $this->assertSame('xlsx_archive_limits_exceeded', $archive_result->get_error_code());
+        $this->assertSame(array(), $this->manager->updates);
+    }
+
+    public function test_legacy_xls_template_import_remains_supported(): void {
+        $xlsx = $this->exporter->export_excel(array(42));
+        $workbook = IOFactory::load($xlsx);
+        $xls = $this->temp_dir . '/products.xls';
+        (new Xls($workbook))->save($xls);
+        $workbook->disconnectWorksheets();
+
+        $result = $this->exporter->import_excel($xls);
+
+        $this->assertSame(1, $result['success']);
+        $this->assertSame(0, $result['failed']);
+        $this->assertSame('DG-42', $this->manager->updates[42]['sku']);
+    }
+
+    public function test_formula_like_export_text_remains_literal_in_xlsx_and_is_neutralized_in_csv(): void {
+        $this->manager->products[42]['name'] = '=literal product name';
+
+        $xlsx = $this->exporter->export_excel(array(42));
+        $workbook = IOFactory::load($xlsx);
+        $name_cell = $workbook->getActiveSheet()->getCell('B2');
+        $this->assertSame(DataType::TYPE_STRING, $name_cell->getDataType());
+        $this->assertSame('=literal product name', $name_cell->getValue());
+        $workbook->disconnectWorksheets();
+
+        $csv = $this->exporter->export_csv(array(42));
+        $file = fopen($csv, 'r');
+        fgetcsv($file, null, ',', '"', '');
+        $row = fgetcsv($file, null, ',', '"', '');
+        fclose($file);
+        $this->assertSame("'=literal product name", $row[1]);
+    }
+
+    public function test_csv_and_json_fallbacks_remain_compatible(): void {
+        $csv = $this->exporter->export_csv(array(42));
+        $json = $this->exporter->export_json(array(42));
+
+        $this->assertFileExists($csv);
+        $this->assertFileExists($json);
+        $this->assertStringContainsString('Round-trip product', file_get_contents($csv));
+        $decoded = json_decode(file_get_contents($json), true);
+        $this->assertSame('DG-42', $decoded[0]['sku']);
+        $this->assertSame('CNY', $decoded[0]['dynamic_pricing']['currency_type']);
+
+        $csv_result = $this->exporter->import_csv($csv);
+        $this->assertSame(1, $csv_result['success']);
+        $this->assertSame(0, $csv_result['failed']);
+
+        $this->manager->updates = array();
+        $json_result = $this->exporter->import_json($json);
+        $this->assertSame(1, $json_result['success']);
+        $this->assertSame(0, $json_result['failed']);
+        $this->assertSame('Round-trip product', $this->manager->updates[42]['name']);
+    }
+
+    private function remove_tree($path) {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tests/ImportFreightServiceTest.php
+++ b/tests/ImportFreightServiceTest.php
@@ -270,7 +270,6 @@ final class ImportFreightServiceTest extends TestCase {
 
     public function test_lock_is_released_when_a_mutation_callback_throws() {
         $lock = new ReflectionMethod(Digitalogic_Import_Freight_Service::class, 'with_catalog_lock');
-        $lock->setAccessible(true);
 
         $result = $lock->invoke($this->service, function() {
             throw new RuntimeException('injected callback failure');
@@ -1014,7 +1013,6 @@ final class ImportFreightServiceTest extends TestCase {
 
     private function resetSingleton($class_name) {
         $property = new ReflectionProperty($class_name, 'instance');
-        $property->setAccessible(true);
         $property->setValue(null, null);
     }
 }

--- a/tests/PatrisFeedResolutionTest.php
+++ b/tests/PatrisFeedResolutionTest.php
@@ -132,7 +132,6 @@ final class PatrisFeedResolutionTest extends TestCase {
 
     private function resetSingleton($class) {
         $property = new ReflectionProperty($class, 'instance');
-        $property->setAccessible(true);
         $property->setValue(null, null);
     }
 }

--- a/tests/ProductIdentifierResolverTest.php
+++ b/tests/ProductIdentifierResolverTest.php
@@ -37,7 +37,6 @@ final class ProductIdentifierResolverTest extends TestCase {
         $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
 
         $instance = new ReflectionProperty(Digitalogic_Product_Identifier_Resolver::class, 'instance');
-        $instance->setAccessible(true);
         $instance->setValue(null, null);
         $this->resolver = Digitalogic_Product_Identifier_Resolver::instance();
     }

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class RestApiPermissionsTest extends TestCase {
@@ -25,7 +26,6 @@ final class RestApiPermissionsTest extends TestCase {
         remove_all_filters('woocommerce_rest_is_request_to_rest_api');
 
         $instance = new ReflectionProperty(Digitalogic_REST_API::class, 'instance');
-        $instance->setAccessible(true);
         $instance->setValue(null, null);
         $this->api = Digitalogic_REST_API::instance();
     }
@@ -43,9 +43,7 @@ final class RestApiPermissionsTest extends TestCase {
         $this->assertSame(0, $GLOBALS['digitalogic_test_current_user_can_calls']);
     }
 
-    /**
-     * @dataProvider rolePolicyProvider
-     */
+    #[DataProvider('rolePolicyProvider')]
     public function test_role_capability_policy($role, $capabilities, $expected) {
         $GLOBALS['digitalogic_test_capabilities'] = $capabilities;
         $request = new WP_REST_Request();
@@ -64,9 +62,7 @@ final class RestApiPermissionsTest extends TestCase {
         );
     }
 
-    /**
-     * @dataProvider restRequestProvider
-     */
+    #[DataProvider('restRequestProvider')]
     public function test_woocommerce_authentication_recognizes_only_digitalogic_routes($request_uri, $already_recognized, $expected) {
         $_SERVER['REQUEST_URI'] = $request_uri;
 

--- a/tests/WebSocketLifecycleTest.php
+++ b/tests/WebSocketLifecycleTest.php
@@ -424,19 +424,16 @@ final class WebSocketLifecycleTest extends TestCase {
 
     private function invoke_private($object, $method, array $arguments = array()) {
         $reflection = new ReflectionMethod($object, $method);
-        $reflection->setAccessible(true);
         return $reflection->invokeArgs($object, $arguments);
     }
 
     private function read_private($object, $property) {
         $reflection = new ReflectionProperty($object, $property);
-        $reflection->setAccessible(true);
         return $reflection->getValue($object);
     }
 
     private function write_private($object, $property, $value): void {
         $reflection = new ReflectionProperty($object, $property);
-        $reflection->setAccessible(true);
         $reflection->setValue($object, $value);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -372,6 +372,26 @@ function get_post_type($post_id) {
         : null;
 }
 
+function get_post($post_id) {
+    $post_id = (int) $post_id;
+    if (!isset($GLOBALS['digitalogic_test_posts'][$post_id])) {
+        return null;
+    }
+
+    return (object) array_merge(
+        array(
+            'ID' => $post_id,
+            'post_content' => '',
+            'post_excerpt' => '',
+        ),
+        $GLOBALS['digitalogic_test_posts'][$post_id]
+    );
+}
+
+function get_post_thumbnail_id($post_id) {
+    return 0;
+}
+
 function get_post_meta($post_id, $key = '', $single = false) {
     if (!isset($GLOBALS['digitalogic_test_posts'][$post_id])) {
         return $single ? '' : array();


### PR DESCRIPTION
## Summary

- move the spreadsheet runtime and PHPUnit test stack to maintained releases while resolving the lock file for PHP 8.3
- make the locked Composer audit a real CI gate and align the plugin runtime guard and documentation with PHP 8.3
- bound local spreadsheet imports before parsing, avoid formula evaluation, and release workbook/archive resources deterministically
- keep untrusted XLSX export text literal and neutralize formula-like CSV text while preserving numeric spreadsheet cells
- migrate the PHPUnit configuration and add XLSX/XLS template, import/export round-trip, malformed-input, archive-limit, and CSV/JSON compatibility coverage

## Validation

- `composer validate --strict`
- `composer audit --locked` (no advisories)
- `composer check-platform-reqs`
- PHPUnit: 118 tests, 707 assertions
- spreadsheet compatibility subset: 6 tests, 40 assertions
- all 50 non-vendor PHP files linted
- all 11 JavaScript files passed `node --check`
- CI workflow actionlint and public-tree guard
- production-only install, locked audit, platform check, source/package autoload, ZIP integrity, and package smoke
- `git diff --check`

## Sequencing

This branch is rebased on `main` after PR #53. PR #51 remains a separate release-packaging change; its deployment-workflow modernization is intentionally not duplicated here and it should be rebased after this dependency PR lands.

Closes #52
