### PR TITLE
Add the current global default markup setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Canonical nullable global default percentage markup with exact decimal storage, REST/command/admin controls, catalog revisioning, and result-aware delivery events.
 - **WordPress Admin Bar integration** with quicklinks menu
   - Parent menu item with WooCommerce-focused cart icon (dashicons-cart)
   - Quicklinks to Dashboard, Products, Currency, Import/Export, Logs, and Status pages

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ curl -X POST https://yoursite.com/wp-json/digitalogic/v1/products/batch \
 
 #### Pricing
 - `POST /wp-json/digitalogic/v1/pricing/recalculate` - Recalculate all prices
+- `GET|PUT /wp-json/digitalogic/v1/pricing/default-markup` - Read, set, or explicitly clear the canonical default percentage markup
 
 #### Import Freight Integration
 - `GET /wp-json/digitalogic/v1/integration/catalog` - Read the versioned pricing/freight catalog
@@ -167,6 +168,9 @@ curl -X POST https://yoursite.com/wp-json/digitalogic/v1/products/batch \
 - `GET|PUT|DELETE /wp-json/digitalogic/v1/import-freight-methods/{id}` - Manage an immutable method ID
 - `GET|PUT /wp-json/digitalogic/v1/products/by-code/{code}/import-pricing` - Read or assign by exact Patris Code/SKU
 - `POST /wp-json/digitalogic/v1/products/import-pricing/batch` - Preflight and apply Code-based assignments
+
+The default markup is nullable, exact-decimal, and used only when product
+markup is absent. Saving it does not write WooCommerce prices.
 
 Import freight is distinct from customer delivery and WooCommerce checkout
 shipping. See [Import Freight Integration Contract](docs/IMPORT-FREIGHT-API.md).

--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ curl -X POST https://yoursite.com/wp-json/digitalogic/v1/products/batch \
 - `GET|PUT /wp-json/digitalogic/v1/products/by-code/{code}/import-pricing` - Read or assign by exact Patris Code/SKU
 - `POST /wp-json/digitalogic/v1/products/import-pricing/batch` - Preflight and apply Code-based assignments
 
-The default markup is nullable, exact-decimal, and used only when product
-markup is absent. Saving it does not write WooCommerce prices.
+The default markup is nullable, exact-decimal, and used only when both product
+markup metadata rows are absent or both rows are stored empty. Saving it does
+not write WooCommerce prices.
 
 Import freight is distinct from customer delivery and WooCommerce checkout
 shipping. See [Import Freight Integration Contract](docs/IMPORT-FREIGHT-API.md).

--- a/docs/IMPORT-FREIGHT-API.md
+++ b/docs/IMPORT-FREIGHT-API.md
@@ -37,6 +37,7 @@ integration permission (normally `manage_woocommerce`). WooCommerce REST API
 keys may provide that identity.
 
 - `GET /wp-json/digitalogic/v1/integration/catalog`
+- `GET|PUT /wp-json/digitalogic/v1/pricing/default-markup`
 - `GET|POST /wp-json/digitalogic/v1/import-freight-methods`
 - `GET|PUT|DELETE /wp-json/digitalogic/v1/import-freight-methods/{id}`
 - `GET|PUT /wp-json/digitalogic/v1/products/by-code/{code}/import-pricing`
@@ -48,13 +49,15 @@ readable. Disabled methods cannot be assigned to new products, while replaying
 the same disabled assignment is an allowed idempotent no-op. Custom IDs cannot
 use the legacy ACF values `express`, `aerial`, or `marine`.
 
-Product assignment uses the shared exact identifier resolver. Its deterministic
-precedence is an explicitly supplied WooCommerce product/variation ID, exact
-`_sku`, then exact `_digitalogic_patris_product_code`; the legacy `{code}` route
-uses exact SKU before exact Patris Code. Identifiers remain strings, so a code
-such as `00123` is never coerced to an integer. Missing and same-source duplicate
-identifiers fail without a write; names are never used for automatic matching.
-Trash and auto-draft records are excluded.
+Product assignment uses the shared exact identifier resolver. Explicit
+WooCommerce ID, SKU, and Patris Code inputs retain their named namespaces. The
+generic `{code}` route treats exact `_digitalogic_patris_product_code` as
+canonical and uses exact `_sku` only when no Patris Code exists; if the same
+text names distinct SKU and Patris Code targets, resolution is ambiguous and
+no write occurs. Identifiers remain strings, so a code such as `00123` is never
+coerced to an integer. Missing and same-source duplicate identifiers fail
+without a write; names are never used for automatic matching. Trash and
+auto-draft records are excluded.
 
 Example assignment:
 
@@ -108,6 +111,10 @@ channels run. A committed mutation remains successful, while no-op retries do
 not emit another event. An empty webhook destination list is an intentionally
 disabled, confirmed-success channel.
 
+The same delivery contract applies to `import_freight.default_markup.updated`.
+Updating or clearing the default changes only the canonical catalog option; it
+does not recalculate or write any WooCommerce product price.
+
 ## Catalog and formula
 
 The read-only integration catalog contains the CNY-to-local (currently IRT)
@@ -126,6 +133,45 @@ is retained as `source_effective_date` with format `ymd`.
   * cny_to_irt
 ```
 
+The reference values `24.5 CNY`, `240 g`, `120 CNY/kg`, `30%`, and
+`29,000 IRT/CNY` produce exactly `2,009,410 IRT` after one final half-up round.
+
+The catalog exposes the nullable default at
+`pricing.default_percentage_markup`:
+
+```json
+{
+  "schema": "digitalogic.default-percentage-markup",
+  "schema_version": "1.0.0",
+  "configured": true,
+  "type": "percentage",
+  "profit_percent": "30",
+  "source": "global_default",
+  "revision": "sha256:...",
+  "bounds": {
+    "minimum": "0",
+    "maximum": "1000",
+    "maximum_fraction_digits": 12
+  },
+  "warnings": []
+}
+```
+
+The stored percentage is a canonical base-10 string: no exponent or grouping
+notation, no redundant leading/trailing zeroes, and at most 12 fractional
+digits. JSON clients should send a string to preserve every decimal digit:
+
+```json
+{"profit_percent": "30.125"}
+```
+
+Use `{"profit_percent": null}` to clear it. The absence of the option is the
+only unset state; there is no hard-coded fallback. The workbook's current 30%
+is a proposed reviewed production action, not an automatic migration or seed.
+The setting revision covers its configured state and exact decimal. The parent
+integration-catalog revision includes the full setting metadata, so Patris can
+invalidate caches deterministically.
+
 The method schema reserves validated fields for minimum charge, actual versus
 volumetric billable weight, volumetric divisor, transit-day bounds, metadata,
 and tiered rates. Version 1 exposes these fields but does not silently apply a
@@ -138,12 +184,13 @@ WooCommerce product, Digitalogic converts that positive finite gram value with
 The original gram value remains available in Patris metadata for formula input.
 
 Feed ingestion uses the same shared generic Code/SKU resolver as freight
-assignment. A Patris-Code-only product can therefore be updated, while an exact
-SKU wins over a different product carrying the same Patris Code. Not-found rows
-are counted as `missing_in_woocommerce`; ambiguous or invalid identifiers are
-counted as failed with non-sensitive errors and never write a product. Every
-valid normalized upstream row is still retained in the feed snapshot for
-reporting and later reconciliation, including missing or ambiguous rows.
+assignment. A Patris-Code-only product can therefore be updated, SKU is a
+compatibility fallback only when that Code is absent, and cross-namespace
+collisions fail as ambiguous. Not-found rows are counted as
+`missing_in_woocommerce`; ambiguous or invalid identifiers are counted as
+failed with non-sensitive errors and never write a product. Every valid
+normalized upstream row is still retained in the feed snapshot for reporting
+and later reconciliation, including missing or ambiguous rows.
 
 Product assignment reads expose the markup mapping used by the formula:
 
@@ -153,18 +200,27 @@ Product assignment reads expose the markup mapping used by the formula:
     "type": "percentage",
     "value": 12.5,
     "profit_percent": 12.5,
+    "source": "product_override",
+    "default_revision": null,
     "warning": null
   },
   "profit_percent": 12.5,
+  "profit_percent_source": "product_override",
   "pricing_warnings": []
 }
 ```
 
-Only a numeric `percentage` markup maps to `profit_percent`. A `fixed`, missing,
-or unsupported markup returns `profit_percent: null` and a machine-readable
-warning; `landed_price_v1` never silently treats a fixed amount as a percent.
+Only a valid product `percentage` maps directly to `profit_percent`, with
+`source: product_override`. When both product markup fields are truly absent,
+the configured default is returned as an exact decimal string with
+`source: global_default` and its setting revision. A fixed, malformed,
+explicitly incomplete percentage, or unsupported product markup returns
+`profit_percent: null` and a machine-readable warning; these explicit product
+states never silently fall back or treat a fixed amount as a percent. If both
+the product and global default are absent, the existing `markup_missing`
+warning remains.
 
-Administrators can manage methods and assign products by exact Patris Code/SKU
+Administrators can manage the nullable default, methods, and assignments by exact Patris Code/SKU
 on the existing Patris Reports screen. This UI and all integration routes are
 for supplier import freight only and do not read or mutate WooCommerce customer
 delivery methods.

--- a/docs/IMPORT-FREIGHT-API.md
+++ b/docs/IMPORT-FREIGHT-API.md
@@ -165,8 +165,10 @@ digits. JSON clients should send a string to preserve every decimal digit:
 {"profit_percent": "30.125"}
 ```
 
-Use `{"profit_percent": null}` to clear it. The absence of the option is the
-only unset state; there is no hard-coded fallback. The workbook's current 30%
+Use `{"profit_percent": null}` to clear it. JSON `null` is the only destructive
+API/command value: a blank or whitespace-only value is invalid with HTTP 400,
+and the administrator UI provides a separate clear action. The absence of the
+option is the only unset state; there is no hard-coded fallback. The workbook's current 30%
 is a proposed reviewed production action, not an automatic migration or seed.
 The setting revision covers its configured state and exact decimal. The parent
 integration-catalog revision includes the full setting metadata, so Patris can
@@ -211,14 +213,19 @@ Product assignment reads expose the markup mapping used by the formula:
 ```
 
 Only a valid product `percentage` maps directly to `profit_percent`, with
-`source: product_override`. When both product markup fields are truly absent,
-the configured default is returned as an exact decimal string with
-`source: global_default` and its setting revision. A fixed, malformed,
-explicitly incomplete percentage, or unsupported product markup returns
-`profit_percent: null` and a machine-readable warning; these explicit product
-states never silently fall back or treat a fixed amount as a percent. If both
-the product and global default are absent, the existing `markup_missing`
-warning remains.
+`source: product_override`. Product markup is semantically unconfigured when
+both metadata rows are absent, or when both rows exist and both values are
+empty. In either state, the configured default is returned as an exact decimal
+string with `source: global_default` and its setting revision. Treating paired
+stored-empty rows this way preserves the current live product data contract.
+
+One-sided metadata rows never fall back. Empty one-sided rows report
+`markup_metadata_value_absent` or `markup_metadata_type_absent`; malformed raw
+types report `markup_type_malformed`. Fixed, unsupported, nonempty malformed,
+or incomplete percentage states likewise return `profit_percent: null` and a
+machine-readable warning instead of treating a fixed amount as a percent. If
+the product is semantically unconfigured and the global default is absent, the
+existing `markup_missing` warning remains.
 
 Administrators can manage the nullable default, methods, and assignments by exact Patris Code/SKU
 on the existing Patris Reports screen. This UI and all integration routes are

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -538,6 +538,24 @@ class Digitalogic_Admin {
                     }
                     break;
 
+                case 'update_default_markup':
+                    $result = $freight_service->update_default_percentage_markup(
+                        $posted_value('default_profit_percent')
+                    );
+                    $notice = is_wp_error($result)
+                        ? $result->get_error_message()
+                        : __('The global default percentage markup was saved. WooCommerce prices were not changed.', 'digitalogic');
+                    $notice_type = is_wp_error($result) ? 'error' : 'success';
+                    break;
+
+                case 'clear_default_markup':
+                    $result = $freight_service->update_default_percentage_markup(null);
+                    $notice = is_wp_error($result)
+                        ? $result->get_error_message()
+                        : __('The global default percentage markup was cleared. WooCommerce prices were not changed.', 'digitalogic');
+                    $notice_type = is_wp_error($result) ? 'error' : 'success';
+                    break;
+
                 default:
                     $notice = __('Unknown import freight action.', 'digitalogic');
                     $notice_type = 'error';
@@ -571,6 +589,18 @@ class Digitalogic_Admin {
             $notice = $freight_methods->get_error_message();
             $notice_type = 'error';
             $freight_methods = array();
+        }
+        $default_markup = $freight_service->get_default_percentage_markup();
+        if (is_wp_error($default_markup)) {
+            $notice = $default_markup->get_error_message();
+            $notice_type = 'error';
+            $default_markup = array(
+                'configured' => false,
+                'profit_percent' => null,
+                'revision' => '',
+                'source' => 'unavailable',
+                'bounds' => array('minimum' => '0', 'maximum' => '1000', 'maximum_fraction_digits' => 12),
+            );
         }
 
         include DIGITALOGIC_PLUGIN_DIR . 'includes/admin/views/patris-reports.php';

--- a/includes/admin/views/patris-reports.php
+++ b/includes/admin/views/patris-reports.php
@@ -8,6 +8,7 @@
  * @var string $notice
  * @var string $notice_type
  * @var array  $freight_methods
+ * @var array  $default_markup
  * @var array|null $freight_assignment
  */
 
@@ -98,6 +99,54 @@ $notice_type = in_array($notice_type, array('success', 'error', 'warning', 'info
         <p class="description">
             <?php echo esc_html__('Manage freight used to import products from Patris. These records do not change WooCommerce customer delivery methods.', 'digitalogic'); ?>
         </p>
+
+        <h3><?php echo esc_html__('Default percentage markup', 'digitalogic'); ?></h3>
+        <p class="description">
+            <?php echo esc_html__('Used only when a product has no markup configuration. A product percentage overrides it; fixed or unsupported product markup never falls back. Saving or clearing this value does not update WooCommerce prices.', 'digitalogic'); ?>
+        </p>
+        <div class="digitalogic-report-table-wrap">
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row"><label for="digitalogic-default-profit-percent"><?php echo esc_html__('Global profit percent', 'digitalogic'); ?></label></th>
+                    <td>
+                        <form method="post" class="digitalogic-inline-form">
+                            <?php wp_nonce_field('digitalogic_import_freight_admin'); ?>
+                            <input type="hidden" name="digitalogic_import_freight_action" value="update_default_markup">
+                            <input
+                                id="digitalogic-default-profit-percent"
+                                class="small-text code"
+                                name="default_profit_percent"
+                                value="<?php echo esc_attr(!empty($default_markup['configured']) ? $default_markup['profit_percent'] : ''); ?>"
+                                inputmode="decimal"
+                                pattern="[0-9۰-۹٠-٩]+(?:[.٫][0-9۰-۹٠-٩]{1,12})?"
+                                required
+                                dir="ltr"
+                            >
+                            <span>%</span>
+                            <button type="submit" class="button button-primary"><?php echo esc_html__('Save default', 'digitalogic'); ?></button>
+                        </form>
+                        <?php if (!empty($default_markup['configured'])) : ?>
+                            <form method="post" class="digitalogic-inline-form">
+                                <?php wp_nonce_field('digitalogic_import_freight_admin'); ?>
+                                <input type="hidden" name="digitalogic_import_freight_action" value="clear_default_markup">
+                                <button type="submit" class="button button-secondary"><?php echo esc_html__('Clear default', 'digitalogic'); ?></button>
+                            </form>
+                        <?php endif; ?>
+                        <p class="description">
+                            <?php
+                            printf(
+                                esc_html__('Allowed range: %1$s–%2$s%%, up to %3$d fractional digits. The recovered workbook value 30%% is proposed for a reviewed production action and is not seeded automatically.', 'digitalogic'),
+                                esc_html($default_markup['bounds']['minimum']),
+                                esc_html($default_markup['bounds']['maximum']),
+                                absint($default_markup['bounds']['maximum_fraction_digits'])
+                            );
+                            ?>
+                        </p>
+                        <p class="description"><code><?php echo esc_html($default_markup['revision']); ?></code></p>
+                    </td>
+                </tr>
+            </table>
+        </div>
 
         <h3><?php echo esc_html__('Freight methods', 'digitalogic'); ?></h3>
         <div class="digitalogic-report-table-wrap">

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -268,6 +268,19 @@ class Digitalogic_REST_API {
             'permission_callback' => array($this, 'check_read_permission'),
         ));
 
+        register_rest_route('digitalogic/v1', '/pricing/default-markup', array(
+            array(
+                'methods' => 'GET',
+                'callback' => array($this, 'get_default_percentage_markup'),
+                'permission_callback' => array($this, 'check_read_permission'),
+            ),
+            array(
+                'methods' => 'PUT',
+                'callback' => array($this, 'update_default_percentage_markup'),
+                'permission_callback' => array($this, 'check_write_permission'),
+            ),
+        ));
+
         register_rest_route('digitalogic/v1', '/import-freight-methods', array(
             array(
                 'methods' => 'GET',
@@ -677,6 +690,18 @@ class Digitalogic_REST_API {
     public function get_integration_catalog(WP_REST_Request $request) {
         return $this->import_freight_response(
             Digitalogic_Command_Dispatcher::instance()->get_integration_catalog($request->get_params())
+        );
+    }
+
+    public function get_default_percentage_markup(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->get_default_percentage_markup($request->get_params())
+        );
+    }
+
+    public function update_default_percentage_markup(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->update_default_percentage_markup($this->request_payload($request))
         );
     }
 

--- a/includes/api/class-webhooks.php
+++ b/includes/api/class-webhooks.php
@@ -323,6 +323,18 @@ class Digitalogic_Webhooks {
      */
     public function deliver_import_freight_event($hook, $args) {
         $args = is_array($args) ? $args : array();
+        if ('digitalogic_import_freight_default_markup_updated' === $hook) {
+            $markup = isset($args[0]) && is_array($args[0]) ? $args[0] : array();
+            return $this->trigger_webhook('import_freight.default_markup.updated', array(
+                'configured' => !empty($markup['configured']),
+                'profit_percent' => isset($markup['profit_percent']) ? (string) $markup['profit_percent'] : null,
+                'source' => isset($markup['source']) ? sanitize_key($markup['source']) : '',
+                'revision' => isset($markup['revision']) ? sanitize_text_field($markup['revision']) : '',
+                'previous_revision' => isset($markup['previous_revision']) ? sanitize_text_field($markup['previous_revision']) : '',
+                'updated_at' => isset($markup['updated_at']) ? sanitize_text_field($markup['updated_at']) : '',
+                'updated_by' => isset($markup['updated_by']) ? absint($markup['updated_by']) : 0,
+            ), true);
+        }
         if ('digitalogic_product_import_freight_method_updated' === $hook) {
             return $this->trigger_webhook('import_freight.assignment.updated', array(
                 'product_id' => absint(isset($args[0]) ? $args[0] : 0),

--- a/includes/class-command-dispatcher.php
+++ b/includes/class-command-dispatcher.php
@@ -85,6 +85,8 @@ class Digitalogic_Command_Dispatcher {
             'digitalogic_import_patris_payload' => array($this, 'import_patris_payload'),
             'digitalogic_update_patris_settings' => array($this, 'update_patris_settings'),
             'digitalogic_get_integration_catalog' => array($this, 'get_integration_catalog'),
+            'digitalogic_get_default_percentage_markup' => array($this, 'get_default_percentage_markup'),
+            'digitalogic_update_default_percentage_markup' => array($this, 'update_default_percentage_markup'),
             'digitalogic_list_import_freight_methods' => array($this, 'list_import_freight_methods'),
             'digitalogic_create_import_freight_method' => array($this, 'create_import_freight_method'),
             'digitalogic_get_import_freight_method' => array($this, 'get_import_freight_method'),
@@ -261,6 +263,24 @@ class Digitalogic_Command_Dispatcher {
 
     public function get_integration_catalog($payload = array()) {
         return Digitalogic_Import_Freight_Service::instance()->get_integration_catalog();
+    }
+
+    public function get_default_percentage_markup($payload = array()) {
+        return Digitalogic_Import_Freight_Service::instance()->get_default_percentage_markup();
+    }
+
+    public function update_default_percentage_markup($payload) {
+        if (!is_array($payload) || !array_key_exists('profit_percent', $payload)) {
+            return new WP_Error(
+                'digitalogic_import_freight_default_markup_required',
+                __('The profit_percent field is required; use null to clear the default explicitly.', 'digitalogic'),
+                array('status' => 400)
+            );
+        }
+
+        return Digitalogic_Import_Freight_Service::instance()->update_default_percentage_markup(
+            $payload['profit_percent']
+        );
     }
 
     public function list_import_freight_methods($payload = array()) {

--- a/includes/class-import-freight-service.php
+++ b/includes/class-import-freight-service.php
@@ -17,6 +17,7 @@ if (!class_exists('Digitalogic_Product_Identifier_Resolver')) {
 final class Digitalogic_Import_Freight_Service {
 
     public const METHODS_OPTION = 'digitalogic_import_freight_methods_v1';
+    public const DEFAULT_MARKUP_OPTION = 'digitalogic_import_freight_default_markup_v1';
     public const MIGRATION_OPTION = 'digitalogic_import_freight_migration_v1';
     public const PRODUCT_METHOD_META = '_digitalogic_import_freight_method_id';
     public const LEGACY_PRODUCT_METHOD_META = 'shipping_method';
@@ -26,11 +27,15 @@ final class Digitalogic_Import_Freight_Service {
     public const CATALOG_SCHEMA_VERSION = '1.0.0';
     public const FORMULA_ID = 'landed_price_v1';
     public const FORMULA_REVISION = '1.0.0';
+    public const DEFAULT_MARKUP_SCHEMA = 'digitalogic.default-percentage-markup';
+    public const DEFAULT_MARKUP_SCHEMA_VERSION = '1.0.0';
 
     private const MIGRATION_VERSION = 1;
     private const MAX_BATCH_SIZE = 500;
     private const CATALOG_LOCK_NAME = 'digitalogic_import_freight_catalog_v1';
     private const CATALOG_LOCK_TIMEOUT_SECONDS = 10;
+    private const DEFAULT_MARKUP_MAX_PERCENT = '1000';
+    private const DEFAULT_MARKUP_MAX_SCALE = 12;
 
     private static $instance = null;
     private $migration_checked = false;
@@ -210,6 +215,97 @@ final class Digitalogic_Import_Freight_Service {
         }
 
         return $result;
+    }
+
+    /**
+     * Return the canonical nullable catalog-wide percentage markup.
+     *
+     * The value is read directly from MySQL so Redis or another object cache
+     * cannot return stale pricing inputs to Patris.
+     *
+     * @return array|WP_Error
+     */
+    public function get_default_percentage_markup() {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+
+        return $this->load_default_percentage_markup();
+    }
+
+    /**
+     * Set or explicitly clear the catalog-wide default percentage markup.
+     *
+     * Null and an empty string remove the option. An equivalent canonical
+     * value is an idempotent no-op and does not publish another domain event.
+     * This mutation never recalculates or writes a WooCommerce product price.
+     *
+     * @param mixed $value Decimal percentage or null to clear.
+     * @return array|WP_Error
+     */
+    public function update_default_percentage_markup($value) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+
+        $clear = is_null($value) || (is_string($value) && '' === trim($value));
+        $canonical = null;
+        if (!$clear) {
+            $canonical = $this->canonical_default_percentage($value);
+            if (is_wp_error($canonical)) {
+                return $canonical;
+            }
+        }
+
+        return $this->with_catalog_lock(function() use ($clear, $canonical) {
+            $previous = $this->load_default_percentage_markup();
+            $same = $clear
+                ? empty($previous['storage_present'])
+                : !empty($previous['configured']) && $previous['profit_percent'] === $canonical;
+            if ($same) {
+                $previous['changed'] = false;
+                return $previous;
+            }
+
+            $state = $clear ? null : $this->new_default_percentage_markup_state($canonical);
+            $stored = $this->run_transaction(function() use ($clear, $state) {
+                return $this->store_option_state_verified(
+                    self::DEFAULT_MARKUP_OPTION,
+                    !$clear,
+                    $state,
+                    'digitalogic_import_freight_default_markup_write_failed'
+                );
+            });
+            if (is_wp_error($stored)) {
+                return $stored;
+            }
+
+            $result = $this->load_default_percentage_markup();
+            if (
+                ($clear && !empty($result['storage_present']))
+                || (!$clear && (empty($result['configured']) || $result['profit_percent'] !== $canonical))
+            ) {
+                return new WP_Error(
+                    'digitalogic_import_freight_default_markup_readback_failed',
+                    __('The default percentage markup did not pass exact database readback.', 'digitalogic'),
+                    array('status' => 500)
+                );
+            }
+
+            $result['changed'] = true;
+            $result['previous_revision'] = $previous['revision'];
+            $delivery_warnings = $this->emit_domain_action(
+                'digitalogic_import_freight_default_markup_updated',
+                $result
+            );
+            if (!empty($delivery_warnings)) {
+                $result['delivery_warnings'] = $delivery_warnings;
+            }
+
+            return $result;
+        });
     }
 
     /**
@@ -689,6 +785,7 @@ final class Digitalogic_Import_Freight_Service {
         if (is_wp_error($methods)) {
             return $methods;
         }
+        $default_markup = $this->load_default_percentage_markup();
 
         $local_currency = $this->local_currency();
         $yuan_rate = $this->yuan_rate();
@@ -720,7 +817,11 @@ final class Digitalogic_Import_Freight_Service {
                     'profit_percent_field' => 'markup.profit_percent',
                     'supported_type' => 'percentage',
                     'unsupported_types_return_null_with_warning' => true,
+                    'resolution_order' => array('product_percentage', 'global_default'),
+                    'global_default_field' => 'pricing.default_percentage_markup.profit_percent',
+                    'fixed_or_unsupported_never_uses_global_default' => true,
                 ),
+                'default_percentage_markup' => $default_markup,
                 'rounding' => array(
                     'mode' => 'half_up',
                     'local_currency_decimals' => $this->local_currency_decimals(),
@@ -1221,6 +1322,7 @@ final class Digitalogic_Import_Freight_Service {
             'legacy_shipping_method' => $legacy_row['exists'] ? (string) $legacy_row['value'] : '',
             'markup' => $markup,
             'profit_percent' => $markup['profit_percent'],
+            'profit_percent_source' => $markup['source'],
             'pricing_warnings' => $markup['warning'] ? array($markup['warning']) : array(),
         ));
     }
@@ -1961,18 +2063,34 @@ final class Digitalogic_Import_Freight_Service {
     private function build_markup_contract($product_id) {
         $type = sanitize_key((string) get_post_meta($product_id, '_digitalogic_markup_type', true));
         $raw_value = get_post_meta($product_id, '_digitalogic_markup', true);
+        $value_present = !is_null($raw_value) && !(is_string($raw_value) && '' === trim($raw_value));
         $value = $this->number_or_null($raw_value);
         $profit_percent = null;
+        $source = null;
+        $default_revision = null;
         $warning = null;
 
-        if ($type === 'percentage' && !is_null($value)) {
+        if ($type === 'percentage' && !is_null($value) && $value >= 0 && $value <= (float) self::DEFAULT_MARKUP_MAX_PERCENT) {
             $profit_percent = $value;
+            $source = 'product_override';
         } elseif ($type === 'fixed') {
             $warning = 'fixed_markup_not_supported_by_landed_price_v1';
         } elseif ($type === 'percentage') {
-            $warning = 'percentage_markup_value_missing';
+            $warning = !$value_present ? 'percentage_markup_value_missing' : 'percentage_markup_value_invalid';
         } elseif ($type === '') {
-            $warning = is_null($value) ? 'markup_missing' : 'markup_type_missing';
+            if (!$value_present) {
+                $default = $this->load_default_percentage_markup();
+                if (!empty($default['configured'])) {
+                    $profit_percent = $default['profit_percent'];
+                    $source = 'global_default';
+                    $default_revision = $default['revision'];
+                } else {
+                    $source = 'unset';
+                    $warning = 'markup_missing';
+                }
+            } else {
+                $warning = 'markup_type_missing';
+            }
         } else {
             $warning = 'markup_type_unsupported';
         }
@@ -1981,8 +2099,176 @@ final class Digitalogic_Import_Freight_Service {
             'type' => $type === '' ? null : $type,
             'value' => $value,
             'profit_percent' => $profit_percent,
+            'source' => $source,
+            'default_revision' => $default_revision,
             'warning' => $warning,
         );
+    }
+
+    private function load_default_percentage_markup() {
+        $row = $this->read_option_db(self::DEFAULT_MARKUP_OPTION);
+        if (!$row['exists']) {
+            return $this->default_percentage_markup_contract(false, null, 'unset', null, 0, false, array('default_markup_unset'));
+        }
+
+        $state = $row['value'];
+        if (!is_array($state)) {
+            return $this->default_percentage_markup_contract(false, null, 'invalid_storage', null, 0, true, array('default_markup_storage_invalid'));
+        }
+        $canonical = $this->canonical_default_percentage(isset($state['profit_percent']) ? $state['profit_percent'] : null);
+        if (
+            is_wp_error($canonical)
+            || !isset($state['schema'], $state['schema_version'], $state['type'], $state['source'], $state['revision'])
+            || self::DEFAULT_MARKUP_SCHEMA !== $state['schema']
+            || self::DEFAULT_MARKUP_SCHEMA_VERSION !== $state['schema_version']
+            || 'percentage' !== $state['type']
+            || 'global_default' !== $state['source']
+            || !isset($state['configured'])
+            || true !== $state['configured']
+            || !array_key_exists('profit_percent', $state)
+            || !is_string($state['profit_percent'])
+            || $state['profit_percent'] !== $canonical
+        ) {
+            return $this->default_percentage_markup_contract(false, null, 'invalid_storage', null, 0, true, array('default_markup_storage_invalid'));
+        }
+
+        $identity = $this->default_percentage_markup_identity(true, $canonical, 'global_default');
+        $revision = $this->default_percentage_markup_revision($identity);
+        if (!hash_equals($revision, (string) $state['revision'])) {
+            return $this->default_percentage_markup_contract(false, null, 'invalid_storage', null, 0, true, array('default_markup_storage_invalid'));
+        }
+
+        return array_merge($identity, array(
+            'revision' => $revision,
+            'updated_at' => isset($state['updated_at']) ? (string) $state['updated_at'] : '',
+            'updated_by' => isset($state['updated_by']) ? absint($state['updated_by']) : 0,
+            'storage_present' => true,
+            'bounds' => $this->default_percentage_markup_bounds(),
+            'warnings' => array(),
+        ));
+    }
+
+    private function new_default_percentage_markup_state($canonical) {
+        $identity = $this->default_percentage_markup_identity(true, $canonical, 'global_default');
+
+        return array_merge($identity, array(
+            'revision' => $this->default_percentage_markup_revision($identity),
+            'updated_at' => current_time('mysql', true),
+            'updated_by' => function_exists('get_current_user_id') ? absint(get_current_user_id()) : 0,
+        ));
+    }
+
+    private function default_percentage_markup_contract($configured, $value, $source, $updated_at, $updated_by, $storage_present, $warnings) {
+        $identity = $this->default_percentage_markup_identity($configured, $value, $source);
+
+        return array_merge($identity, array(
+            'revision' => $this->default_percentage_markup_revision($identity),
+            'updated_at' => $updated_at,
+            'updated_by' => absint($updated_by),
+            'storage_present' => (bool) $storage_present,
+            'bounds' => $this->default_percentage_markup_bounds(),
+            'warnings' => array_values($warnings),
+        ));
+    }
+
+    private function default_percentage_markup_identity($configured, $value, $source) {
+        return array(
+            'schema' => self::DEFAULT_MARKUP_SCHEMA,
+            'schema_version' => self::DEFAULT_MARKUP_SCHEMA_VERSION,
+            'configured' => (bool) $configured,
+            'type' => 'percentage',
+            'profit_percent' => $value,
+            'source' => $source,
+        );
+    }
+
+    private function default_percentage_markup_revision($identity) {
+        return 'sha256:' . hash(
+            'sha256',
+            wp_json_encode($identity, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    private function default_percentage_markup_bounds() {
+        return array(
+            'minimum' => '0',
+            'maximum' => self::DEFAULT_MARKUP_MAX_PERCENT,
+            'maximum_fraction_digits' => self::DEFAULT_MARKUP_MAX_SCALE,
+        );
+    }
+
+    private function canonical_default_percentage($value) {
+        if (is_bool($value) || is_array($value) || is_object($value) || is_null($value)) {
+            return new WP_Error(
+                'digitalogic_import_freight_default_markup_invalid',
+                __('Default markup must be a finite base-10 percentage.', 'digitalogic'),
+                array('status' => 400)
+            );
+        }
+        if (is_int($value)) {
+            $text = (string) $value;
+        } elseif (is_float($value)) {
+            if (!is_finite($value)) {
+                return new WP_Error(
+                    'digitalogic_import_freight_default_markup_invalid',
+                    __('Default markup must be a finite base-10 percentage.', 'digitalogic'),
+                    array('status' => 400)
+                );
+            }
+            $text = json_encode($value, JSON_PRESERVE_ZERO_FRACTION);
+            if (!is_string($text)) {
+                $text = '';
+            }
+        } elseif (is_string($value)) {
+            $text = trim(wp_unslash($value));
+            $text = strtr($text, array(
+                '۰' => '0', '۱' => '1', '۲' => '2', '۳' => '3', '۴' => '4',
+                '۵' => '5', '۶' => '6', '۷' => '7', '۸' => '8', '۹' => '9',
+                '٠' => '0', '١' => '1', '٢' => '2', '٣' => '3', '٤' => '4',
+                '٥' => '5', '٦' => '6', '٧' => '7', '٨' => '8', '٩' => '9',
+                '٫' => '.',
+            ));
+        } else {
+            $text = '';
+        }
+
+        if (strlen($text) > 64 || !preg_match('/^[+\-]?[0-9]+(?:\.[0-9]+)?$/', $text)) {
+            return new WP_Error(
+                'digitalogic_import_freight_default_markup_invalid',
+                __('Default markup must be a finite base-10 percentage without exponent or grouping notation.', 'digitalogic'),
+                array('status' => 400)
+            );
+        }
+
+        $negative = str_starts_with($text, '-');
+        $text = ltrim($text, '+-');
+        $parts = explode('.', $text, 2);
+        $integer = ltrim($parts[0], '0');
+        $integer = '' === $integer ? '0' : $integer;
+        $fraction = isset($parts[1]) ? rtrim($parts[1], '0') : '';
+        if (strlen($fraction) > self::DEFAULT_MARKUP_MAX_SCALE) {
+            return new WP_Error(
+                'digitalogic_import_freight_default_markup_scale_invalid',
+                sprintf(__('Default markup supports at most %d fractional digits.', 'digitalogic'), self::DEFAULT_MARKUP_MAX_SCALE),
+                array('status' => 400, 'maximum_fraction_digits' => self::DEFAULT_MARKUP_MAX_SCALE)
+            );
+        }
+
+        $is_zero = '0' === $integer && '' === $fraction;
+        if (
+            ($negative && !$is_zero)
+            || strlen($integer) > strlen(self::DEFAULT_MARKUP_MAX_PERCENT)
+            || (strlen($integer) === strlen(self::DEFAULT_MARKUP_MAX_PERCENT) && strcmp($integer, self::DEFAULT_MARKUP_MAX_PERCENT) > 0)
+            || ($integer === self::DEFAULT_MARKUP_MAX_PERCENT && '' !== $fraction)
+        ) {
+            return new WP_Error(
+                'digitalogic_import_freight_default_markup_out_of_range',
+                sprintf(__('Default markup must be between 0 and %s percent.', 'digitalogic'), self::DEFAULT_MARKUP_MAX_PERCENT),
+                array('status' => 400, 'minimum' => '0', 'maximum' => self::DEFAULT_MARKUP_MAX_PERCENT)
+            );
+        }
+
+        return '' === $fraction ? $integer : $integer . '.' . $fraction;
     }
 
     public function filter_acf_method_field($field) {

--- a/includes/class-import-freight-service.php
+++ b/includes/class-import-freight-service.php
@@ -237,8 +237,10 @@ final class Digitalogic_Import_Freight_Service {
     /**
      * Set or explicitly clear the catalog-wide default percentage markup.
      *
-     * Null and an empty string remove the option. An equivalent canonical
-     * value is an idempotent no-op and does not publish another domain event.
+     * Only null removes the option. Blank strings are invalid so an omitted
+     * form value cannot accidentally perform a destructive clear. An
+     * equivalent canonical value is an idempotent no-op and does not publish
+     * another domain event.
      * This mutation never recalculates or writes a WooCommerce product price.
      *
      * @param mixed $value Decimal percentage or null to clear.
@@ -250,7 +252,7 @@ final class Digitalogic_Import_Freight_Service {
             return $migration;
         }
 
-        $clear = is_null($value) || (is_string($value) && '' === trim($value));
+        $clear = is_null($value);
         $canonical = null;
         if (!$clear) {
             $canonical = $this->canonical_default_percentage($value);
@@ -737,6 +739,9 @@ final class Digitalogic_Import_Freight_Service {
             $results = array();
             $updated = 0;
             $delivery_warnings = array();
+            // The catalog lock keeps this exact direct-DB read stable for the
+            // response loop and avoids one option query per batch row.
+            $default_markup = $this->load_default_percentage_markup();
             foreach ($prepared as $index => $row) {
                 if (!empty($writes[$index]['changed'])) {
                     $updated++;
@@ -747,7 +752,7 @@ final class Digitalogic_Import_Freight_Service {
                     ));
                 }
 
-                $response = $this->build_assignment_response($row['resolved']);
+                $response = $this->build_assignment_response($row['resolved'], $default_markup);
                 $response['changed'] = !empty($writes[$index]['changed']);
                 $results[] = $response;
             }
@@ -1309,12 +1314,15 @@ final class Digitalogic_Import_Freight_Service {
         return array('changed' => $changed, 'product_id' => (int) $product_id);
     }
 
-    private function build_assignment_response($resolved) {
+    private function build_assignment_response($resolved, $default_markup = null) {
         $method_row = $this->read_post_meta_db($resolved['product_id'], self::PRODUCT_METHOD_META);
         $legacy_row = $this->read_post_meta_db($resolved['product_id'], self::LEGACY_PRODUCT_METHOD_META);
         $method_id = $method_row['exists'] ? (string) $method_row['value'] : '';
         $methods = $this->load_methods();
-        $markup = $this->build_markup_contract($resolved['product_id']);
+        if (!is_array($default_markup)) {
+            $default_markup = $this->load_default_percentage_markup();
+        }
+        $markup = $this->build_markup_contract($resolved['product_id'], $default_markup);
 
         return array_merge($resolved, array(
             'import_freight_method_id' => $method_id,
@@ -2060,17 +2068,48 @@ final class Digitalogic_Import_Freight_Service {
         });
     }
 
-    private function build_markup_contract($product_id) {
-        $type = sanitize_key((string) get_post_meta($product_id, '_digitalogic_markup_type', true));
+    private function build_markup_contract($product_id, $default_markup) {
+        $type_exists = metadata_exists('post', $product_id, '_digitalogic_markup_type');
+        $value_exists = metadata_exists('post', $product_id, '_digitalogic_markup');
+        $raw_type = get_post_meta($product_id, '_digitalogic_markup_type', true);
         $raw_value = get_post_meta($product_id, '_digitalogic_markup', true);
-        $value_present = !is_null($raw_value) && !(is_string($raw_value) && '' === trim($raw_value));
+        $type_input = is_scalar($raw_type) ? strtolower(trim(wp_unslash((string) $raw_type))) : '';
+        $type = sanitize_key($type_input);
+        $type_malformed = $type_exists && (
+            !is_scalar($raw_type)
+            || ('' !== $type_input && ('' === $type || $type !== $type_input))
+        );
+        $type_empty = !$type_exists || '' === $type_input;
+        $value_empty = !$value_exists
+            || is_null($raw_value)
+            || (is_string($raw_value) && '' === trim($raw_value));
+        $semantically_unconfigured = (
+            (!$type_exists && !$value_exists)
+            || ($type_exists && $value_exists && $type_empty && $value_empty)
+        );
+        $value_present = !$value_empty;
         $value = $this->number_or_null($raw_value);
         $profit_percent = null;
         $source = null;
         $default_revision = null;
         $warning = null;
 
-        if ($type === 'percentage' && !is_null($value) && $value >= 0 && $value <= (float) self::DEFAULT_MARKUP_MAX_PERCENT) {
+        if ($type_malformed) {
+            $warning = 'markup_type_malformed';
+        } elseif ($semantically_unconfigured) {
+            if (!empty($default_markup['configured'])) {
+                $profit_percent = $default_markup['profit_percent'];
+                $source = 'global_default';
+                $default_revision = $default_markup['revision'];
+            } else {
+                $source = 'unset';
+                $warning = 'markup_missing';
+            }
+        } elseif ($type_exists && !$value_exists && $type_empty) {
+            $warning = 'markup_metadata_value_absent';
+        } elseif (!$type_exists && $value_exists && $value_empty) {
+            $warning = 'markup_metadata_type_absent';
+        } elseif ($type === 'percentage' && !is_null($value) && $value >= 0 && $value <= (float) self::DEFAULT_MARKUP_MAX_PERCENT) {
             $profit_percent = $value;
             $source = 'product_override';
         } elseif ($type === 'fixed') {
@@ -2078,19 +2117,7 @@ final class Digitalogic_Import_Freight_Service {
         } elseif ($type === 'percentage') {
             $warning = !$value_present ? 'percentage_markup_value_missing' : 'percentage_markup_value_invalid';
         } elseif ($type === '') {
-            if (!$value_present) {
-                $default = $this->load_default_percentage_markup();
-                if (!empty($default['configured'])) {
-                    $profit_percent = $default['profit_percent'];
-                    $source = 'global_default';
-                    $default_revision = $default['revision'];
-                } else {
-                    $source = 'unset';
-                    $warning = 'markup_missing';
-                }
-            } else {
-                $warning = 'markup_type_missing';
-            }
+            $warning = 'markup_type_missing';
         } else {
             $warning = 'markup_type_unsupported';
         }

--- a/includes/panel/class-panel.php
+++ b/includes/panel/class-panel.php
@@ -628,7 +628,19 @@ class Digitalogic_Panel {
      */
     public function deliver_import_freight_event($hook, $args) {
         $args = is_array($args) ? $args : array();
-        if ('digitalogic_product_import_freight_method_updated' === $hook) {
+        if ('digitalogic_import_freight_default_markup_updated' === $hook) {
+            $event = 'import_freight.default_markup.updated';
+            $markup = isset($args[0]) && is_array($args[0]) ? $args[0] : array();
+            $data = array(
+                'configured' => !empty($markup['configured']),
+                'profit_percent' => isset($markup['profit_percent']) ? (string) $markup['profit_percent'] : null,
+                'source' => isset($markup['source']) ? sanitize_key($markup['source']) : '',
+                'revision' => isset($markup['revision']) ? sanitize_text_field($markup['revision']) : '',
+                'previous_revision' => isset($markup['previous_revision']) ? sanitize_text_field($markup['previous_revision']) : '',
+                'updated_at' => isset($markup['updated_at']) ? sanitize_text_field($markup['updated_at']) : '',
+                'updated_by' => isset($markup['updated_by']) ? absint($markup['updated_by']) : 0,
+            );
+        } elseif ('digitalogic_product_import_freight_method_updated' === $hook) {
             $event = 'import_freight.assignment.updated';
             $data = array(
                 'product_id' => absint(isset($args[0]) ? $args[0] : 0),

--- a/tests/ImportFreightServiceTest.php
+++ b/tests/ImportFreightServiceTest.php
@@ -1033,6 +1033,8 @@ final class ImportFreightServiceTest extends TestCase {
     public function test_default_markup_validation_bounds_and_mysql_string_readback_are_exact() {
         $this->service->get_default_percentage_markup();
         $invalid = array(
+            '' => 'digitalogic_import_freight_default_markup_invalid',
+            '   ' => 'digitalogic_import_freight_default_markup_invalid',
             '1e2' => 'digitalogic_import_freight_default_markup_invalid',
             '-0.1' => 'digitalogic_import_freight_default_markup_out_of_range',
             '1000.0000001' => 'digitalogic_import_freight_default_markup_out_of_range',
@@ -1099,6 +1101,33 @@ final class ImportFreightServiceTest extends TestCase {
         $this->assertSame($default['revision'], $global['markup']['default_revision']);
         $this->assertSame(array(), $global['pricing_warnings']);
 
+        update_post_meta(602, '_digitalogic_markup_type', '');
+        update_post_meta(602, '_digitalogic_markup', '');
+        $paired_empty = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertSame('30', $paired_empty['profit_percent']);
+        $this->assertSame('global_default', $paired_empty['profit_percent_source']);
+        $this->assertSame($default['revision'], $paired_empty['markup']['default_revision']);
+        $this->assertSame(array(), $paired_empty['pricing_warnings']);
+
+        delete_post_meta(602, '_digitalogic_markup');
+        $type_only_empty = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($type_only_empty['profit_percent']);
+        $this->assertNull($type_only_empty['profit_percent_source']);
+        $this->assertSame(array('markup_metadata_value_absent'), $type_only_empty['pricing_warnings']);
+
+        delete_post_meta(602, '_digitalogic_markup_type');
+        update_post_meta(602, '_digitalogic_markup', '');
+        $value_only_empty = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($value_only_empty['profit_percent']);
+        $this->assertNull($value_only_empty['profit_percent_source']);
+        $this->assertSame(array('markup_metadata_type_absent'), $value_only_empty['pricing_warnings']);
+
+        update_post_meta(602, '_digitalogic_markup_type', '***');
+        $malformed_type = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($malformed_type['profit_percent']);
+        $this->assertNull($malformed_type['profit_percent_source']);
+        $this->assertSame(array('markup_type_malformed'), $malformed_type['pricing_warnings']);
+
         update_post_meta(602, '_digitalogic_markup_type', 'percentage');
         update_post_meta(602, '_digitalogic_markup', '12.5');
         $override = $this->service->get_product_assignment_by_code('MARKUP-602');
@@ -1144,6 +1173,41 @@ final class ImportFreightServiceTest extends TestCase {
         $fallback = $this->service->get_product_assignment_by_code('MARKUP-602');
         $this->assertSame('30', $fallback['profit_percent']);
         $this->assertSame('global_default', $fallback['profit_percent_source']);
+    }
+
+    public function test_batch_assignment_reads_default_markup_once_for_all_response_rows() {
+        $assignments = array();
+        for ($index = 0; $index < 12; $index++) {
+            $product_id = 620 + $index;
+            $code = 'BATCH-MARKUP-' . $product_id;
+            $GLOBALS['digitalogic_test_posts'][$product_id] = array(
+                'post_type' => 'product',
+                'post_status' => 'publish',
+                'meta' => array('_sku' => $code),
+            );
+            $assignments[] = array(
+                'code' => $code,
+                'method_id' => 'air_express',
+            );
+        }
+
+        $this->service->migrate_legacy_data();
+        $this->service->update_default_percentage_markup('30');
+        $GLOBALS['wpdb']->option_read_counts = array();
+
+        $result = $this->service->batch_assign_products($assignments);
+
+        $this->assertFalse(is_wp_error($result));
+        $this->assertSame(12, $result['updated']);
+        $this->assertCount(12, $result['assignments']);
+        foreach ($result['assignments'] as $assignment) {
+            $this->assertSame('30', $assignment['profit_percent']);
+            $this->assertSame('global_default', $assignment['profit_percent_source']);
+        }
+        $this->assertSame(
+            1,
+            $GLOBALS['wpdb']->option_read_counts[Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION] ?? 0
+        );
     }
 
     public function test_thirty_percent_global_fixture_produces_2009410_irt() {
@@ -1194,6 +1258,31 @@ final class ImportFreightServiceTest extends TestCase {
         $get = $api->get_default_percentage_markup(new WP_REST_Request());
         $this->assertSame(200, $get->get_status());
         $this->assertSame($put->get_data()['data']['revision'], $get->get_data()['data']['revision']);
+
+        foreach (array('', '   ') as $blank) {
+            $invalid_rest = $api->update_default_percentage_markup(
+                new WP_REST_Request(array(), array('profit_percent' => $blank))
+            );
+            $this->assertSame(400, $invalid_rest->get_status());
+            $this->assertSame(
+                'digitalogic_import_freight_default_markup_invalid',
+                $invalid_rest->get_data()['code']
+            );
+            $this->assertSame('30', $this->service->get_default_percentage_markup()['profit_percent']);
+
+            $invalid_command = $dispatcher->execute(
+                'digitalogic_update_default_percentage_markup',
+                array('profit_percent' => $blank),
+                'websocket'
+            );
+            $this->assertSame(
+                'digitalogic_import_freight_default_markup_invalid',
+                $invalid_command->get_error_code()
+            );
+            $this->assertSame(400, $invalid_command->get_error_data()['status']);
+            $this->assertSame('30', $this->service->get_default_percentage_markup()['profit_percent']);
+        }
+
         $clear = $api->update_default_percentage_markup(new WP_REST_Request(array(), array('profit_percent' => null)));
         $this->assertSame(200, $clear->get_status());
         $this->assertFalse($clear->get_data()['data']['configured']);
@@ -1202,6 +1291,10 @@ final class ImportFreightServiceTest extends TestCase {
         $view = file_get_contents(dirname(__DIR__) . '/includes/admin/views/patris-reports.php');
         $this->assertStringContainsString("case 'update_default_markup'", $admin);
         $this->assertStringContainsString("case 'clear_default_markup'", $admin);
+        $this->assertMatchesRegularExpression(
+            "/case 'update_default_markup'.*posted_value\\('default_profit_percent'\\).*case 'clear_default_markup'.*update_default_percentage_markup\\(null\\)/s",
+            $admin
+        );
         $this->assertStringContainsString('WooCommerce prices were not changed.', $admin);
         $this->assertStringContainsString('digitalogic_import_freight_admin', $view);
         $this->assertStringContainsString('name="default_profit_percent"', $view);

--- a/tests/ImportFreightServiceTest.php
+++ b/tests/ImportFreightServiceTest.php
@@ -36,6 +36,9 @@ final class ImportFreightServiceTest extends TestCase {
         $GLOBALS['digitalogic_test_cache_deletes'] = array();
         $GLOBALS['digitalogic_test_remote_posts'] = array();
         $GLOBALS['digitalogic_test_remote_post_results'] = array();
+        $GLOBALS['digitalogic_test_wc_products'] = array();
+        $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array();
         $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
         $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
         $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
@@ -974,6 +977,313 @@ final class ImportFreightServiceTest extends TestCase {
             ));
             $this->assertSame('digitalogic_import_freight_transit_invalid', $method->get_error_code());
         }
+    }
+
+    public function test_default_markup_lifecycle_is_exact_idempotent_and_catalog_versioned_without_price_writes() {
+        $GLOBALS['digitalogic_test_posts'][601] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_sku' => 'NO-PRICE-WRITE-601', '_price' => '777'),
+        );
+        $before_posts = $GLOBALS['digitalogic_test_posts'];
+
+        $unset = $this->service->get_default_percentage_markup();
+        $catalog_before = $this->service->get_integration_catalog();
+        $this->assertFalse($unset['configured']);
+        $this->assertNull($unset['profit_percent']);
+        $this->assertSame('unset', $unset['source']);
+        $this->assertFalse($unset['storage_present']);
+        $this->assertContains('default_markup_unset', $unset['warnings']);
+        $this->assertFalse(get_option(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION, false));
+
+        $updated = $this->service->update_default_percentage_markup('۰۰۳۰٫۵۰۰۰');
+        $this->assertFalse(is_wp_error($updated));
+        $this->assertTrue($updated['changed']);
+        $this->assertTrue($updated['configured']);
+        $this->assertSame('30.5', $updated['profit_percent']);
+        $this->assertSame('global_default', $updated['source']);
+        $stored = get_option(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION);
+        $this->assertSame('30.5', $stored['profit_percent']);
+        $this->assertSame($updated['revision'], $stored['revision']);
+
+        $catalog_changed = $this->service->get_integration_catalog();
+        $this->assertSame($updated, array_merge($catalog_changed['pricing']['default_percentage_markup'], array(
+            'changed' => true,
+            'previous_revision' => $updated['previous_revision'],
+        )));
+        $this->assertNotSame($catalog_before['revision'], $catalog_changed['revision']);
+        $this->assertSame(array('product_percentage', 'global_default'), $catalog_changed['pricing']['product_markup_contract']['resolution_order']);
+
+        $event_count = count($GLOBALS['digitalogic_test_actions']['digitalogic_import_freight_default_markup_updated'] ?? array());
+        $same = $this->service->update_default_percentage_markup('30.500000');
+        $this->assertFalse($same['changed']);
+        $this->assertSame($event_count, count($GLOBALS['digitalogic_test_actions']['digitalogic_import_freight_default_markup_updated'] ?? array()));
+
+        $cleared = $this->service->update_default_percentage_markup(null);
+        $this->assertTrue($cleared['changed']);
+        $this->assertFalse($cleared['configured']);
+        $this->assertNull($cleared['profit_percent']);
+        $this->assertFalse(get_option(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION, false));
+        $catalog_cleared = $this->service->get_integration_catalog();
+        $this->assertSame($catalog_before['revision'], $catalog_cleared['revision']);
+        $this->assertSame($before_posts, $GLOBALS['digitalogic_test_posts']);
+        $this->assertSame(array(), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_default_markup_validation_bounds_and_mysql_string_readback_are_exact() {
+        $this->service->get_default_percentage_markup();
+        $invalid = array(
+            '1e2' => 'digitalogic_import_freight_default_markup_invalid',
+            '-0.1' => 'digitalogic_import_freight_default_markup_out_of_range',
+            '1000.0000001' => 'digitalogic_import_freight_default_markup_out_of_range',
+            '0.1234567890123' => 'digitalogic_import_freight_default_markup_scale_invalid',
+        );
+        foreach ($invalid as $value => $code) {
+            $result = $this->service->update_default_percentage_markup($value);
+            $this->assertSame($code, $result->get_error_code(), $value);
+            $this->assertFalse(get_option(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION, false));
+        }
+        foreach (array(true, false, array('30'), NAN, INF) as $value) {
+            $result = $this->service->update_default_percentage_markup($value);
+            $this->assertSame('digitalogic_import_freight_default_markup_invalid', $result->get_error_code());
+        }
+        $float_scale = $this->service->update_default_percentage_markup(0.1234567890123);
+        $this->assertSame('digitalogic_import_freight_default_markup_scale_invalid', $float_scale->get_error_code());
+
+        $this->assertSame('0', $this->service->update_default_percentage_markup('0')['profit_percent']);
+        $this->assertSame('1000', $this->service->update_default_percentage_markup(1000)['profit_percent']);
+
+        $GLOBALS['wpdb']->mysql_string_roundtrip = true;
+        $exact = $this->service->update_default_percentage_markup('30.123456789012');
+        $this->assertSame('30.123456789012', $exact['profit_percent']);
+        $GLOBALS['digitalogic_test_option_cache'][Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION] = array(
+            'profit_percent' => '999',
+        );
+        $read_back = $this->service->get_default_percentage_markup();
+        $this->assertSame('30.123456789012', $read_back['profit_percent']);
+        $this->assertContains(
+            array(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION, 'options'),
+            $GLOBALS['digitalogic_test_cache_deletes']
+        );
+
+        $non_string_state = get_option(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION);
+        $non_string_state['profit_percent'] = 30;
+        $GLOBALS['digitalogic_test_options'][Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION] = $non_string_state;
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $invalid_storage = $this->service->get_default_percentage_markup();
+        $this->assertFalse($invalid_storage['configured']);
+        $this->assertSame('invalid_storage', $invalid_storage['source']);
+        $this->assertContains('default_markup_storage_invalid', $invalid_storage['warnings']);
+        $repaired = $this->service->update_default_percentage_markup('30');
+        $this->assertSame('30', $repaired['profit_percent']);
+        $this->assertIsString(get_option(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION)['profit_percent']);
+    }
+
+    public function test_product_percentage_override_precedes_global_and_non_percentage_states_never_fallback() {
+        $GLOBALS['digitalogic_test_posts'][602] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_sku' => 'MARKUP-602'),
+        );
+        $this->service->migrate_legacy_data();
+
+        $unset = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($unset['profit_percent']);
+        $this->assertSame('unset', $unset['profit_percent_source']);
+        $this->assertSame(array('markup_missing'), $unset['pricing_warnings']);
+
+        $default = $this->service->update_default_percentage_markup('30');
+        $global = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertSame('30', $global['profit_percent']);
+        $this->assertSame('global_default', $global['profit_percent_source']);
+        $this->assertSame($default['revision'], $global['markup']['default_revision']);
+        $this->assertSame(array(), $global['pricing_warnings']);
+
+        update_post_meta(602, '_digitalogic_markup_type', 'percentage');
+        update_post_meta(602, '_digitalogic_markup', '12.5');
+        $override = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertSame(12.5, $override['profit_percent']);
+        $this->assertSame('product_override', $override['profit_percent_source']);
+        $this->assertNull($override['markup']['default_revision']);
+
+        update_post_meta(602, '_digitalogic_markup_type', 'fixed');
+        $fixed = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($fixed['profit_percent']);
+        $this->assertNull($fixed['profit_percent_source']);
+        $this->assertSame(array('fixed_markup_not_supported_by_landed_price_v1'), $fixed['pricing_warnings']);
+
+        update_post_meta(602, '_digitalogic_markup_type', 'tiered');
+        $unsupported = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($unsupported['profit_percent']);
+        $this->assertSame(array('markup_type_unsupported'), $unsupported['pricing_warnings']);
+
+        update_post_meta(602, '_digitalogic_markup_type', 'percentage');
+        update_post_meta(602, '_digitalogic_markup', '');
+        $missing_value = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($missing_value['profit_percent']);
+        $this->assertSame(array('percentage_markup_value_missing'), $missing_value['pricing_warnings']);
+
+        update_post_meta(602, '_digitalogic_markup', 'not-a-number');
+        $invalid_value = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($invalid_value['profit_percent']);
+        $this->assertSame(array('percentage_markup_value_invalid'), $invalid_value['pricing_warnings']);
+
+        update_post_meta(602, '_digitalogic_markup', '1000.1');
+        $out_of_range = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($out_of_range['profit_percent']);
+        $this->assertSame(array('percentage_markup_value_invalid'), $out_of_range['pricing_warnings']);
+
+        update_post_meta(602, '_digitalogic_markup_type', '');
+        update_post_meta(602, '_digitalogic_markup', 'not-a-number');
+        $missing_type = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertNull($missing_type['profit_percent']);
+        $this->assertSame(array('markup_type_missing'), $missing_type['pricing_warnings']);
+
+        delete_post_meta(602, '_digitalogic_markup_type');
+        delete_post_meta(602, '_digitalogic_markup');
+        $fallback = $this->service->get_product_assignment_by_code('MARKUP-602');
+        $this->assertSame('30', $fallback['profit_percent']);
+        $this->assertSame('global_default', $fallback['profit_percent_source']);
+    }
+
+    public function test_thirty_percent_global_fixture_produces_2009410_irt() {
+        $GLOBALS['digitalogic_test_posts'][603] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_sku' => 'FIXTURE-603'),
+        );
+        $this->service->migrate_legacy_data();
+        $this->service->update_default_percentage_markup('30');
+
+        $assignment = $this->service->get_product_assignment_by_code('FIXTURE-603');
+        $catalog = $this->service->get_integration_catalog();
+        $final_price = (int) round(
+            ((24.5 + (240 / 1000 * 120)) * (1 + ((float) $assignment['profit_percent'] / 100))) * 29000,
+            0,
+            PHP_ROUND_HALF_UP
+        );
+
+        $this->assertSame('30', $assignment['profit_percent']);
+        $this->assertSame('global_default', $assignment['profit_percent_source']);
+        $this->assertSame('30', $catalog['pricing']['default_percentage_markup']['profit_percent']);
+        $this->assertSame(2009410, $final_price);
+    }
+
+    public function test_default_markup_rest_command_and_admin_surfaces_share_the_service_contract() {
+        $this->service->migrate_legacy_data();
+        $dispatcher = Digitalogic_Command_Dispatcher::instance();
+        $missing = $dispatcher->update_default_percentage_markup(array());
+        $this->assertSame('digitalogic_import_freight_default_markup_required', $missing->get_error_code());
+
+        $GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
+        $command = $dispatcher->execute(
+            'digitalogic_update_default_percentage_markup',
+            array('profit_percent' => '24.5'),
+            'websocket'
+        );
+        $this->assertSame('24.5', $command['profit_percent']);
+        $this->assertSame(
+            $command['revision'],
+            $dispatcher->execute('digitalogic_get_default_percentage_markup', array(), 'websocket')['revision']
+        );
+
+        $api = Digitalogic_REST_API::instance();
+        $put = $api->update_default_percentage_markup(new WP_REST_Request(array(), array('profit_percent' => '30')));
+        $this->assertSame(200, $put->get_status());
+        $this->assertSame('30', $put->get_data()['data']['profit_percent']);
+        $get = $api->get_default_percentage_markup(new WP_REST_Request());
+        $this->assertSame(200, $get->get_status());
+        $this->assertSame($put->get_data()['data']['revision'], $get->get_data()['data']['revision']);
+        $clear = $api->update_default_percentage_markup(new WP_REST_Request(array(), array('profit_percent' => null)));
+        $this->assertSame(200, $clear->get_status());
+        $this->assertFalse($clear->get_data()['data']['configured']);
+
+        $admin = file_get_contents(dirname(__DIR__) . '/includes/admin/class-admin.php');
+        $view = file_get_contents(dirname(__DIR__) . '/includes/admin/views/patris-reports.php');
+        $this->assertStringContainsString("case 'update_default_markup'", $admin);
+        $this->assertStringContainsString("case 'clear_default_markup'", $admin);
+        $this->assertStringContainsString('WooCommerce prices were not changed.', $admin);
+        $this->assertStringContainsString('digitalogic_import_freight_admin', $view);
+        $this->assertStringContainsString('name="default_profit_percent"', $view);
+        $this->assertStringContainsString('value="clear_default_markup"', $view);
+        $this->assertSame(array(), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_default_markup_event_is_result_aware_and_delivered_once_per_change() {
+        $this->service->migrate_legacy_data();
+        $GLOBALS['digitalogic_test_posts'][604] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_sku' => 'EVENT-604', '_price' => '888'),
+        );
+        $before_posts = $GLOBALS['digitalogic_test_posts'];
+        $redis = new Digitalogic_Test_Redis_Client();
+        add_filter('digitalogic_panel_redis_client', static function() use ($redis) {
+            return $redis;
+        });
+        $GLOBALS['digitalogic_test_options']['digitalogic_webhook_urls'] = array('https://n8n.test/webhook/default-markup');
+        $GLOBALS['digitalogic_test_options']['digitalogic_webhook_secret'] = 'test-secret';
+        Digitalogic_Panel::instance();
+        Digitalogic_Webhooks::instance();
+
+        $updated = $this->service->update_default_percentage_markup('30');
+        $this->assertTrue($updated['changed']);
+        $events = get_option('digitalogic_panel_events', array());
+        $this->assertCount(1, $events);
+        $this->assertSame('import_freight.default_markup.updated', $events[0]['name']);
+        $this->assertTrue($events[0]['data']['configured']);
+        $this->assertSame('30', $events[0]['data']['profit_percent']);
+        $this->assertSame($updated['revision'], $events[0]['data']['revision']);
+        $this->assertSame($updated['previous_revision'], $events[0]['data']['previous_revision']);
+        $this->assertSame($updated['updated_at'], $events[0]['data']['updated_at']);
+        $this->assertCount(1, $redis->published);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+        $webhook = json_decode($GLOBALS['digitalogic_test_remote_posts'][0]['args']['body'], true);
+        $this->assertSame('import_freight.default_markup.updated', $webhook['event']);
+        $this->assertSame('30', $webhook['data']['profit_percent']);
+        $this->assertSame($updated['previous_revision'], $webhook['data']['previous_revision']);
+
+        $same = $this->service->update_default_percentage_markup('30.0');
+        $this->assertFalse($same['changed']);
+        $this->assertCount(1, get_option('digitalogic_panel_events', array()));
+        $this->assertCount(1, $redis->published);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+
+        $cleared = $this->service->update_default_percentage_markup(null);
+        $this->assertTrue($cleared['changed']);
+        $events = get_option('digitalogic_panel_events', array());
+        $this->assertCount(2, $events);
+        $this->assertFalse($events[1]['data']['configured']);
+        $this->assertNull($events[1]['data']['profit_percent']);
+        $this->assertCount(2, $redis->published);
+        $this->assertCount(2, $GLOBALS['digitalogic_test_remote_posts']);
+        $this->assertSame($before_posts, $GLOBALS['digitalogic_test_posts']);
+        $this->assertSame(array(), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_default_markup_lock_write_and_commit_failures_are_atomic_and_silent() {
+        $this->service->get_default_percentage_markup();
+        $GLOBALS['digitalogic_test_actions'] = array();
+
+        $GLOBALS['wpdb']->acquire_result = 0;
+        $busy = $this->service->update_default_percentage_markup('30');
+        $this->assertSame('digitalogic_import_freight_catalog_busy', $busy->get_error_code());
+        $this->assertFalse(get_option(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION, false));
+
+        $GLOBALS['wpdb']->acquire_result = 1;
+        $GLOBALS['digitalogic_test_update_failures'][] = Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION;
+        $write = $this->service->update_default_percentage_markup('30');
+        $this->assertSame('digitalogic_import_freight_default_markup_write_failed', $write->get_error_code());
+        $this->assertFalse(get_option(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION, false));
+        $this->assertContains('ROLLBACK', $GLOBALS['wpdb']->queries);
+
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_transaction_failures'] = array('COMMIT');
+        $commit = $this->service->update_default_percentage_markup('30');
+        $this->assertSame('digitalogic_import_freight_commit_failed', $commit->get_error_code());
+        $this->assertFalse(get_option(Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION, false));
+        $this->assertArrayNotHasKey('digitalogic_import_freight_default_markup_updated', $GLOBALS['digitalogic_test_actions']);
+        $this->assertSame(array(), $GLOBALS['digitalogic_test_wc_product_saves']);
     }
 
     public function test_routes_and_implementation_do_not_register_customer_delivery_apis() {

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -248,6 +248,8 @@ final class RestApiPermissionsTest extends TestCase {
             'POST /patris/push' => 'check_patris_push_permission',
             'POST /patris/product-sync' => 'check_patris_product_sync_permission',
             'GET /integration/catalog' => 'check_read_permission',
+            'GET /pricing/default-markup' => 'check_read_permission',
+            'PUT /pricing/default-markup' => 'check_write_permission',
             'GET /import-freight-methods' => 'check_read_permission',
             'POST /import-freight-methods' => 'check_write_permission',
             'GET /import-freight-methods/(?P<id>[a-z][a-z0-9_]{1,63})' => 'check_read_permission',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -588,6 +588,7 @@ class Digitalogic_Test_WPDB {
     public $mysql_string_roundtrip = false;
     public $after_rollback = null;
     public $identifier_query_count = 0;
+    public $option_read_counts = array();
     private $transaction_snapshot = null;
     private $meta_ids = array();
     private $next_meta_id = 1;
@@ -620,6 +621,10 @@ class Digitalogic_Test_WPDB {
 
         if (strpos($query, $this->options) !== false) {
             $name = isset($args[0]) ? (string) $args[0] : '';
+            if (!isset($this->option_read_counts[$name])) {
+                $this->option_read_counts[$name] = 0;
+            }
+            $this->option_read_counts[$name]++;
             return array_key_exists($name, $GLOBALS['digitalogic_test_options'])
                 ? array('option_value' => $this->database_raw_value($GLOBALS['digitalogic_test_options'][$name]))
                 : null;


### PR DESCRIPTION
## Summary
- add the single current sparse catalog-wide percentage markup owned by `Digitalogic_Import_Freight_Service`
- store a canonical base-10 string under the existing catalog lock and verified transaction/readback path, bounded to `0..1000` with at most 12 fractional digits
- include setting state, source, revision, bounds, and audit metadata in `digitalogic.integration-catalog` revision material
- resolve valid product percentage markup first, use `global_default` only when both product markup rows are absent or both are stored empty, and omit `profit_percent` for one-sided, fixed, malformed, or unsupported states and return warnings without synthetic null placeholders
- expose authenticated REST and shared command controls plus nonce/capability-protected admin save and explicit-clear controls with Persian/Arabic decimal input support
- publish result-aware panel queue, Redis/WebSocket, and webhook events only for semantic changes, including current and previous revisions
- keep setting mutations separate from WooCommerce price writes and leave the production default unset

## Contract behavior
- `GET|PUT /wp-json/digitalogic/pricing/default-markup`
- one current setting shape: `digitalogic.default-percentage-markup`; no alternate parser or route negotiation
- JSON clients should send decimal strings; an explicit authenticated clear action is destructive, while blank or whitespace values return HTTP 400
- equivalent canonical writes are idempotent and emit no duplicate event
- product source is `product_override` for a valid percentage and `global_default` only for absent or paired stored-empty product markup rows
- one-sided empty rows expose `markup_metadata_value_absent` / `markup_metadata_type_absent`; malformed raw types expose `markup_type_malformed`
- fixed, unsupported, missing-value, malformed-value, and missing-type states never silently inherit the global percentage
- batch assignment preloads the exact default once after commit under the catalog lock; a 12-row regression proves one default-option read

## Fixture proof
- `24.5 CNY` product price
- `240 g` weight
- product freight pair `shipping_price_per_kg=120`, `shipping_price_per_kg_currency=CNY`; the same path accepts `IRR` and converts it to canonical IRT by dividing by 10
- `30%` global default markup
- `29,000 IRT/CNY`
- one final half-up round produces exactly `2,009,410 IRT`

The workbook's 30% is documented as a proposed reviewed production action. This change does not hard-code, migrate, deploy, or seed that value.

## Verification
- PHPUnit 12.5.31 on PHP 8.5: 128 tests, 902 assertions
- focused import-freight and REST permissions: 66 tests, 541 assertions
- PHP syntax: 50 first-party plugin/test files
- JavaScript syntax: 9 first-party files
- Composer strict manifest validation: pass
- locked Composer install dry-run: pass
- locked Composer audit: no advisories
- public backup-artifact guard: pass
- `git diff --check`: pass

## Deployment safety
- rebased on `origin/main` at `9d3153f`, including merged receiver PR #53, dependency/security PR #55, and optional-header PR #58
- no production deployment or live option mutation was performed
- changing this setting does not recalculate or save WooCommerce product prices

Closes #50

