### PR TITLE
Fix omitted product-sync identity headers

### DIFF
--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -649,7 +649,13 @@ class Digitalogic_REST_API {
             'x-patris-event-id' => array($header_event_id, is_array($payload) ? ($payload['event_id'] ?? null) : null),
         );
         foreach ($header_checks as $header => $values) {
-            if ('' !== $values[0] && (!is_string($values[1]) || !hash_equals((string) $values[0], $values[1]))) {
+            $provided = $values[0];
+            $expected = $values[1];
+            if (null === $provided || '' === $provided) {
+                continue;
+            }
+
+            if (!is_string($provided) || !is_string($expected) || !hash_equals($provided, $expected)) {
                 return new WP_REST_Response(array(
                     'success' => false,
                     'code' => 'digitalogic_product_sync_header_mismatch',

--- a/tests/ProductSyncRestTest.php
+++ b/tests/ProductSyncRestTest.php
@@ -73,6 +73,45 @@ final class ProductSyncRestTest extends TestCase {
         $this->assertTrue($api->check_patris_product_sync_permission(new WP_REST_Request()));
     }
 
+    public function test_rest_callback_accepts_absent_optional_headers_returned_as_null(): void {
+        $payload = $this->emptySnapshot();
+        $request = new WP_REST_Request(
+            array(),
+            $payload,
+            array('X-Digitalogic-Product-Sync-Secret' => 'receiver-secret'),
+            json_encode($payload, JSON_UNESCAPED_SLASHES)
+        );
+
+        $this->assertNull($request->get_header('X-Patris-Contract'));
+        $this->assertNull($request->get_header('X-Patris-Contract-Version'));
+        $this->assertNull($request->get_header('X-Patris-Event-ID'));
+
+        $response = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
+        $this->assertSame(200, $response->get_status());
+        $this->assertTrue($response->get_data()['success']);
+        $this->assertSame('accepted', $response->get_data()['data']['status']);
+    }
+
+    public function test_rest_callback_accepts_explicitly_empty_optional_headers(): void {
+        $payload = $this->emptySnapshot();
+        $request = new WP_REST_Request(
+            array(),
+            $payload,
+            array(
+                'X-Digitalogic-Product-Sync-Secret' => 'receiver-secret',
+                'X-Patris-Contract' => '',
+                'X-Patris-Contract-Version' => '',
+                'X-Patris-Event-ID' => '',
+            ),
+            json_encode($payload, JSON_UNESCAPED_SLASHES)
+        );
+
+        $response = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
+        $this->assertSame(200, $response->get_status());
+        $this->assertTrue($response->get_data()['success']);
+        $this->assertSame('accepted', $response->get_data()['data']['status']);
+    }
+
     public function test_rest_callback_accepts_empty_snapshot_and_checks_headers(): void {
         $payload = $this->emptySnapshot();
         $body = json_encode($payload, JSON_UNESCAPED_SLASHES);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -84,7 +84,7 @@ class WP_REST_Request implements ArrayAccess {
 
     public function get_header($key) {
         $key = strtolower((string) $key);
-        return isset($this->headers[$key]) ? $this->headers[$key] : '';
+        return isset($this->headers[$key]) ? $this->headers[$key] : null;
     }
 
     public function get_body() {


### PR DESCRIPTION
Closes #56

## Summary
- treat absent (`null`) and explicitly empty Patris identity headers as optional
- continue rejecting every non-empty identity header that differs from the product-sync body
- make the REST request test double match WordPress behavior for absent headers
- add regressions for omitted, empty, matching, and mismatched contract metadata

## Verification
- `vendor/bin/phpunit --filter ProductSyncRestTest --testdox` — 7 tests, 38 assertions
- `vendor/bin/phpunit --testdox` — 120 tests, 716 assertions
- `php -l` on all three changed PHP files
- `git diff --check`