### PR TITLE
Add bounded batch pricing-assignment reads

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -161,6 +161,7 @@ WooCommerce checkout, shipping-zone, or customer delivery APIs.
 - **GET|PUT|DELETE** `/import-freight-methods/{id}` - read, update, or delete an unassigned method
 - **GET|PUT** `/products/by-code/{code}/import-pricing` - read or assign by exact Patris Code/SKU
 - **POST** `/products/import-pricing/batch` - preflight and apply an atomic assignment batch
+- **POST** `/pricing-assignments/batch` - read up to 500 exact assignments in a versioned, ordered, no-write response
 
 GET routes use the `read` permission scope. Mutating routes use `write`.
 Deleting an assigned method returns HTTP 409; disabling it remains available.

--- a/docs/IMPORT-FREIGHT-API.md
+++ b/docs/IMPORT-FREIGHT-API.md
@@ -41,6 +41,7 @@ keys may provide that identity.
 - `GET|POST /wp-json/digitalogic/v1/import-freight-methods`
 - `GET|PUT|DELETE /wp-json/digitalogic/v1/import-freight-methods/{id}`
 - `GET|PUT /wp-json/digitalogic/v1/products/by-code/{code}/import-pricing`
+- `POST /wp-json/digitalogic/v1/pricing-assignments/batch` (read only)
 - `POST /wp-json/digitalogic/v1/products/import-pricing/batch`
 
 Method IDs are immutable. An assigned method returns HTTP 409 when deleted; it
@@ -58,6 +59,72 @@ no write occurs. Identifiers remain strings, so a code such as `00123` is never
 coerced to an integer. Missing and same-source duplicate identifiers fail
 without a write; names are never used for automatic matching. Trash and
 auto-draft records are excluded.
+
+### Versioned batch assignment reads
+
+Patris and other read-only pricing clients should prefetch with
+`POST /wp-json/digitalogic/v1/pricing-assignments/batch`:
+
+```json
+{"codes":["113007045","113007046"]}
+```
+
+The operation accepts 1-500 unique non-empty Codes. Codes remain strings,
+retain trimmed request order, and are resolved by the same collision-safe
+service as the single-Code endpoint. Duplicate Codes reject the whole request;
+not-found or ambiguous products become typed per-Code results so unrelated
+Codes still resolve. The response is
+`digitalogic.pricing-assignment-batch` version `1.0.0`, includes the exact
+default-markup snapshot read once for the request, and emits effective
+percentage values as canonical base-10 strings. The method catalog is also
+loaded once. No product, price, assignment, option, event, or lock is written.
+
+```json
+{
+  "schema": "digitalogic.pricing-assignment-batch",
+  "schema_version": "1.0.0",
+  "requested_count": 2,
+  "resolved_count": 1,
+  "error_count": 1,
+  "maximum_codes": 500,
+  "default_percentage_markup": {"configured": true, "profit_percent": "30"},
+  "results": [
+    {
+      "code": "113007045",
+      "status": "ok",
+      "assignment": {
+        "code": "113007045",
+        "import_freight_method_id": "air_express",
+        "profit_percent": "30"
+      }
+    },
+    {
+      "code": "MISSING",
+      "status": "error",
+      "error": {
+        "code": "digitalogic_product_code_not_found",
+        "http_status": 404,
+        "retryable": false
+      }
+    }
+  ]
+}
+```
+
+This POST is a read operation and uses `check_read_permission`: either the
+authenticated identity has `manage_woocommerce`, or the
+`digitalogic_rest_api_permission` filter returns the boolean `true` for the
+`read` scope and this exact request. It deliberately does not accept the Patris
+push token or the transformed product-sync write secret. A dedicated
+header-only, route-scoped machine read credential remains a separate hardening
+follow-up; do not grant Patris a write secret to bridge that gap.
+
+The same service operation is exposed as the
+`digitalogic_get_product_import_pricing_batch` command and through WP-CLI:
+
+```bash
+wp digitalogic pricing assignments 113007045 113007046
+```
 
 Example assignment:
 

--- a/docs/IMPORT-FREIGHT-API.md
+++ b/docs/IMPORT-FREIGHT-API.md
@@ -76,8 +76,12 @@ not-found or ambiguous products become typed per-Code results so unrelated
 Codes still resolve. The response is
 `digitalogic.pricing-assignment-batch` version `1.0.0`, includes the exact
 default-markup snapshot read once for the request, and emits effective
-percentage values as canonical base-10 strings. The method catalog is also
-loaded once. No product, price, assignment, option, event, or lock is written.
+percentage values as canonical base-10 strings. Each success is a deliberately
+minimal machine projection: requested Code, method ID, effective percentage,
+percentage source, and pricing warnings. No internal WooCommerce identity or
+localized error message is exposed. No product, price, assignment, option,
+event, or lock is written, and this read never invokes migration; activation or
+upgrade must complete migration separately.
 
 ```json
 {
@@ -95,7 +99,9 @@ loaded once. No product, price, assignment, option, event, or lock is written.
       "assignment": {
         "code": "113007045",
         "import_freight_method_id": "air_express",
-        "profit_percent": "30"
+        "profit_percent": "30",
+        "profit_percent_source": "global_default",
+        "pricing_warnings": []
       }
     },
     {

--- a/docs/IMPORT-FREIGHT-API.md
+++ b/docs/IMPORT-FREIGHT-API.md
@@ -69,7 +69,8 @@ Patris and other read-only pricing clients should prefetch with
 {"codes":["113007045","113007046"]}
 ```
 
-The operation accepts 1-500 unique non-empty Codes. Codes remain strings,
+The operation accepts an ordered JSON list of 1-500 unique non-empty Codes;
+associative objects are rejected rather than having their keys discarded. Codes remain strings,
 retain trimmed request order, and are resolved by the same collision-safe
 service as the single-Code endpoint. Duplicate Codes reject the whole request;
 not-found or ambiguous products become typed per-Code results so unrelated

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -325,11 +325,15 @@ class Digitalogic_REST_API {
             ),
         ));
 
-        register_rest_route('digitalogic/v1', '/pricing-assignments/batch', array(
-            'methods' => 'POST',
-            'callback' => array($this, 'get_product_import_pricing_batch'),
-            'permission_callback' => array($this, 'check_read_permission'),
-        ));
+		register_rest_route(
+			'digitalogic/v1',
+			'/pricing-assignments/batch',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'get_product_import_pricing_batch' ),
+				'permission_callback' => array( $this, 'check_read_permission' ),
+			)
+		);
 
         register_rest_route('digitalogic/v1', '/products/import-pricing/batch', array(
             'methods' => 'POST',
@@ -753,11 +757,17 @@ class Digitalogic_REST_API {
         );
     }
 
-    public function get_product_import_pricing_batch(WP_REST_Request $request) {
-        return $this->import_freight_response(
-            Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing_batch($this->request_payload($request))
-        );
-    }
+	/**
+	 * Read a bounded batch of product pricing assignments.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response
+	 */
+	public function get_product_import_pricing_batch( WP_REST_Request $request ) {
+		return $this->import_freight_response(
+			Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing_batch( $this->request_payload( $request ) )
+		);
+	}
 
     public function assign_product_import_freight(WP_REST_Request $request) {
         $payload = $this->request_payload($request);

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -325,6 +325,12 @@ class Digitalogic_REST_API {
             ),
         ));
 
+        register_rest_route('digitalogic/v1', '/pricing-assignments/batch', array(
+            'methods' => 'POST',
+            'callback' => array($this, 'get_product_import_pricing_batch'),
+            'permission_callback' => array($this, 'check_read_permission'),
+        ));
+
         register_rest_route('digitalogic/v1', '/products/import-pricing/batch', array(
             'methods' => 'POST',
             'callback' => array($this, 'batch_assign_product_import_freight'),
@@ -744,6 +750,12 @@ class Digitalogic_REST_API {
     public function get_product_import_pricing(WP_REST_Request $request) {
         return $this->import_freight_response(
             Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing(array('code' => $request['code']))
+        );
+    }
+
+    public function get_product_import_pricing_batch(WP_REST_Request $request) {
+        return $this->import_freight_response(
+            Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing_batch($this->request_payload($request))
         );
     }
 

--- a/includes/class-command-dispatcher.php
+++ b/includes/class-command-dispatcher.php
@@ -93,6 +93,7 @@ class Digitalogic_Command_Dispatcher {
             'digitalogic_update_import_freight_method' => array($this, 'update_import_freight_method'),
             'digitalogic_delete_import_freight_method' => array($this, 'delete_import_freight_method'),
             'digitalogic_get_product_import_pricing' => array($this, 'get_product_import_pricing'),
+            'digitalogic_get_product_import_pricing_batch' => array($this, 'get_product_import_pricing_batch'),
             'digitalogic_assign_product_import_freight' => array($this, 'assign_product_import_freight'),
             'digitalogic_batch_assign_product_import_freight' => array($this, 'batch_assign_product_import_freight'),
         );
@@ -322,6 +323,14 @@ class Digitalogic_Command_Dispatcher {
         return Digitalogic_Import_Freight_Service::instance()->get_product_assignment_by_code(
             isset($payload['code']) ? $payload['code'] : ''
         );
+    }
+
+    public function get_product_import_pricing_batch($payload) {
+        $codes = isset($payload['codes']) && is_array($payload['codes'])
+            ? $payload['codes']
+            : array();
+
+        return Digitalogic_Import_Freight_Service::instance()->get_product_assignments_by_codes($codes);
     }
 
     public function assign_product_import_freight($payload) {

--- a/includes/class-command-dispatcher.php
+++ b/includes/class-command-dispatcher.php
@@ -93,7 +93,7 @@ class Digitalogic_Command_Dispatcher {
             'digitalogic_update_import_freight_method' => array($this, 'update_import_freight_method'),
             'digitalogic_delete_import_freight_method' => array($this, 'delete_import_freight_method'),
             'digitalogic_get_product_import_pricing' => array($this, 'get_product_import_pricing'),
-            'digitalogic_get_product_import_pricing_batch' => array($this, 'get_product_import_pricing_batch'),
+			'digitalogic_get_product_import_pricing_batch' => array( $this, 'get_product_import_pricing_batch' ),
             'digitalogic_assign_product_import_freight' => array($this, 'assign_product_import_freight'),
             'digitalogic_batch_assign_product_import_freight' => array($this, 'batch_assign_product_import_freight'),
         );
@@ -325,13 +325,19 @@ class Digitalogic_Command_Dispatcher {
         );
     }
 
-    public function get_product_import_pricing_batch($payload) {
-        $codes = isset($payload['codes']) && is_array($payload['codes'])
-            ? $payload['codes']
-            : array();
+	/**
+	 * Read a bounded batch of product pricing assignments.
+	 *
+	 * @param array $payload Command payload.
+	 * @return array|WP_Error
+	 */
+	public function get_product_import_pricing_batch( $payload ) {
+		$codes = isset( $payload['codes'] ) && is_array( $payload['codes'] )
+			? $payload['codes']
+			: array();
 
-        return Digitalogic_Import_Freight_Service::instance()->get_product_assignments_by_codes($codes);
-    }
+		return Digitalogic_Import_Freight_Service::instance()->get_product_assignments_by_codes( $codes );
+	}
 
     public function assign_product_import_freight($payload) {
         if (array_key_exists('import_freight_method_id', $payload)) {

--- a/includes/class-command-dispatcher.php
+++ b/includes/class-command-dispatcher.php
@@ -332,7 +332,7 @@ class Digitalogic_Command_Dispatcher {
 	 * @return array|WP_Error
 	 */
 	public function get_product_import_pricing_batch( $payload ) {
-		$codes = isset( $payload['codes'] ) && is_array( $payload['codes'] )
+		$codes = is_array( $payload ) && array_key_exists( 'codes', $payload )
 			? $payload['codes']
 			: array();
 

--- a/includes/class-import-freight-service.php
+++ b/includes/class-import-freight-service.php
@@ -29,6 +29,9 @@ final class Digitalogic_Import_Freight_Service {
     public const FORMULA_REVISION = '1.0.0';
     public const DEFAULT_MARKUP_SCHEMA = 'digitalogic.default-percentage-markup';
     public const DEFAULT_MARKUP_SCHEMA_VERSION = '1.0.0';
+    public const PRICING_ASSIGNMENT_BATCH_SCHEMA = 'digitalogic.pricing-assignment-batch';
+    public const PRICING_ASSIGNMENT_BATCH_SCHEMA_VERSION = '1.0.0';
+    public const MAX_PRICING_ASSIGNMENT_BATCH_SIZE = 500;
 
     private const MIGRATION_VERSION = 1;
     private const MAX_BATCH_SIZE = 500;
@@ -574,6 +577,113 @@ final class Digitalogic_Import_Freight_Service {
         }
 
         return $this->build_assignment_response($resolved);
+    }
+
+    /**
+     * Resolve a bounded list of exact product Codes without mutating state.
+     *
+     * Results retain normalized request order. Product lookup failures are
+     * represented per Code so one missing or ambiguous product does not hide
+     * valid assignments in the same read. Shared catalog/default-markup state
+     * is loaded once and reused for every successful row.
+     *
+     * @param array $codes Exact Patris Codes or SKU compatibility fallbacks.
+     * @return array|WP_Error
+     */
+    public function get_product_assignments_by_codes($codes) {
+        $migration = $this->maybe_migrate();
+        if (is_wp_error($migration)) {
+            return $migration;
+        }
+        if (!is_array($codes) || empty($codes)) {
+            return new WP_Error(
+                'digitalogic_pricing_assignment_batch_empty',
+                __('At least one product Code is required.', 'digitalogic'),
+                array('status' => 400)
+            );
+        }
+        if (count($codes) > self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE) {
+            return new WP_Error(
+                'digitalogic_pricing_assignment_batch_too_large',
+                sprintf(
+                    /* translators: %d: maximum number of Codes per request. */
+                    __('Pricing assignment read batches are limited to %d Codes.', 'digitalogic'),
+                    self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE
+                ),
+                array(
+                    'status' => 413,
+                    'maximum_codes' => self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE,
+                )
+            );
+        }
+
+        $normalized_codes = array();
+        $seen = array();
+        foreach (array_values($codes) as $index => $code) {
+            $normalized = $this->normalize_code($code);
+            if ('' === $normalized) {
+                return new WP_Error(
+                    'digitalogic_pricing_assignment_batch_code_invalid',
+                    __('Every pricing assignment batch item must be a non-empty string or integer Code.', 'digitalogic'),
+                    array('status' => 400, 'index' => $index)
+                );
+            }
+            if (isset($seen[$normalized])) {
+                return new WP_Error(
+                    'digitalogic_pricing_assignment_batch_code_duplicate',
+                    __('Duplicate product Codes are not allowed in a pricing assignment read batch.', 'digitalogic'),
+                    array(
+                        'status' => 400,
+                        'code_value' => $normalized,
+                        'first_index' => $seen[$normalized],
+                        'index' => $index,
+                    )
+                );
+            }
+            $seen[$normalized] = $index;
+            $normalized_codes[] = $normalized;
+        }
+
+        $default_markup = $this->load_default_percentage_markup();
+        $methods = $this->load_methods();
+        $results = array();
+        $resolved_count = 0;
+        foreach ($normalized_codes as $code) {
+            $resolved = $this->resolve_freight_product($code);
+            if (is_wp_error($resolved)) {
+                $data = $resolved->get_error_data();
+                $status = is_array($data) && isset($data['status']) ? (int) $data['status'] : 400;
+                $results[] = array(
+                    'code' => $code,
+                    'status' => 'error',
+                    'error' => array(
+                        'code' => (string) $resolved->get_error_code(),
+                        'message' => (string) $resolved->get_error_message(),
+                        'http_status' => $status,
+                        'retryable' => $status >= 500,
+                    ),
+                );
+                continue;
+            }
+
+            $resolved_count++;
+            $results[] = array(
+                'code' => $code,
+                'status' => 'ok',
+                'assignment' => $this->build_assignment_response($resolved, $default_markup, $methods, true),
+            );
+        }
+
+        return array(
+            'schema' => self::PRICING_ASSIGNMENT_BATCH_SCHEMA,
+            'schema_version' => self::PRICING_ASSIGNMENT_BATCH_SCHEMA_VERSION,
+            'requested_count' => count($normalized_codes),
+            'resolved_count' => $resolved_count,
+            'error_count' => count($normalized_codes) - $resolved_count,
+            'maximum_codes' => self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE,
+            'default_percentage_markup' => $default_markup,
+            'results' => $results,
+        );
     }
 
     /**
@@ -1314,15 +1424,17 @@ final class Digitalogic_Import_Freight_Service {
         return array('changed' => $changed, 'product_id' => (int) $product_id);
     }
 
-    private function build_assignment_response($resolved, $default_markup = null) {
+    private function build_assignment_response($resolved, $default_markup = null, $methods = null, $exact_decimals = false) {
         $method_row = $this->read_post_meta_db($resolved['product_id'], self::PRODUCT_METHOD_META);
         $legacy_row = $this->read_post_meta_db($resolved['product_id'], self::LEGACY_PRODUCT_METHOD_META);
         $method_id = $method_row['exists'] ? (string) $method_row['value'] : '';
-        $methods = $this->load_methods();
+        if (!is_array($methods)) {
+            $methods = $this->load_methods();
+        }
         if (!is_array($default_markup)) {
             $default_markup = $this->load_default_percentage_markup();
         }
-        $markup = $this->build_markup_contract($resolved['product_id'], $default_markup);
+        $markup = $this->build_markup_contract($resolved['product_id'], $default_markup, $exact_decimals);
 
         return array_merge($resolved, array(
             'import_freight_method_id' => $method_id,
@@ -2068,7 +2180,7 @@ final class Digitalogic_Import_Freight_Service {
         });
     }
 
-    private function build_markup_contract($product_id, $default_markup) {
+    private function build_markup_contract($product_id, $default_markup, $exact_decimals = false) {
         $type_exists = metadata_exists('post', $product_id, '_digitalogic_markup_type');
         $value_exists = metadata_exists('post', $product_id, '_digitalogic_markup');
         $raw_type = get_post_meta($product_id, '_digitalogic_markup_type', true);
@@ -2120,6 +2232,19 @@ final class Digitalogic_Import_Freight_Service {
             $warning = 'markup_type_missing';
         } else {
             $warning = 'markup_type_unsupported';
+        }
+
+        if ($exact_decimals && 'percentage' === $type && 'product_override' === $source) {
+            $canonical = $this->canonical_default_percentage($raw_value);
+            if (is_wp_error($canonical)) {
+                $value = null;
+                $profit_percent = null;
+                $source = null;
+                $warning = 'percentage_markup_value_invalid';
+            } else {
+                $value = $canonical;
+                $profit_percent = $canonical;
+            }
         }
 
         return array(

--- a/includes/class-import-freight-service.php
+++ b/includes/class-import-freight-service.php
@@ -592,7 +592,14 @@ final class Digitalogic_Import_Freight_Service {
 	 * @return array|WP_Error
 	 */
 	public function get_product_assignments_by_codes( $codes ) {
-		if ( ! is_array( $codes ) || empty( $codes ) ) {
+		if ( ! is_array( $codes ) || array_values( $codes ) !== $codes ) {
+			return new WP_Error(
+				'digitalogic_pricing_assignment_batch_shape_invalid',
+				__( 'Product Codes must be provided as an ordered JSON list.', 'digitalogic' ),
+				array( 'status' => 400 )
+			);
+		}
+		if ( empty( $codes ) ) {
 			return new WP_Error(
 				'digitalogic_pricing_assignment_batch_empty',
 				__( 'At least one product Code is required.', 'digitalogic' ),

--- a/includes/class-import-freight-service.php
+++ b/includes/class-import-freight-service.php
@@ -29,9 +29,10 @@ final class Digitalogic_Import_Freight_Service {
     public const FORMULA_REVISION = '1.0.0';
     public const DEFAULT_MARKUP_SCHEMA = 'digitalogic.default-percentage-markup';
     public const DEFAULT_MARKUP_SCHEMA_VERSION = '1.0.0';
-    public const PRICING_ASSIGNMENT_BATCH_SCHEMA = 'digitalogic.pricing-assignment-batch';
-    public const PRICING_ASSIGNMENT_BATCH_SCHEMA_VERSION = '1.0.0';
-    public const MAX_PRICING_ASSIGNMENT_BATCH_SIZE = 500;
+
+	public const PRICING_ASSIGNMENT_BATCH_SCHEMA         = 'digitalogic.pricing-assignment-batch';
+	public const PRICING_ASSIGNMENT_BATCH_SCHEMA_VERSION = '1.0.0';
+	public const MAX_PRICING_ASSIGNMENT_BATCH_SIZE       = 500;
 
     private const MIGRATION_VERSION = 1;
     private const MAX_BATCH_SIZE = 500;
@@ -579,112 +580,109 @@ final class Digitalogic_Import_Freight_Service {
         return $this->build_assignment_response($resolved);
     }
 
-    /**
-     * Resolve a bounded list of exact product Codes without mutating state.
-     *
-     * Results retain normalized request order. Product lookup failures are
-     * represented per Code so one missing or ambiguous product does not hide
-     * valid assignments in the same read. Shared catalog/default-markup state
-     * is loaded once and reused for every successful row.
-     *
-     * @param array $codes Exact Patris Codes or SKU compatibility fallbacks.
-     * @return array|WP_Error
-     */
-    public function get_product_assignments_by_codes($codes) {
-        $migration = $this->maybe_migrate();
-        if (is_wp_error($migration)) {
-            return $migration;
-        }
-        if (!is_array($codes) || empty($codes)) {
-            return new WP_Error(
-                'digitalogic_pricing_assignment_batch_empty',
-                __('At least one product Code is required.', 'digitalogic'),
-                array('status' => 400)
-            );
-        }
-        if (count($codes) > self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE) {
-            return new WP_Error(
-                'digitalogic_pricing_assignment_batch_too_large',
-                sprintf(
-                    /* translators: %d: maximum number of Codes per request. */
-                    __('Pricing assignment read batches are limited to %d Codes.', 'digitalogic'),
-                    self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE
-                ),
-                array(
-                    'status' => 413,
-                    'maximum_codes' => self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE,
-                )
-            );
-        }
+	/**
+	 * Resolve a bounded list of exact product Codes without mutating state.
+	 *
+	 * Results retain normalized request order. Product lookup failures are
+	 * represented per Code so one missing or ambiguous product does not hide
+	 * valid assignments in the same read. Shared default-markup state is loaded
+	 * once and reused for every successful row.
+	 *
+	 * @param array $codes Exact Patris Codes or SKU compatibility fallbacks.
+	 * @return array|WP_Error
+	 */
+	public function get_product_assignments_by_codes( $codes ) {
+		if ( ! is_array( $codes ) || empty( $codes ) ) {
+			return new WP_Error(
+				'digitalogic_pricing_assignment_batch_empty',
+				__( 'At least one product Code is required.', 'digitalogic' ),
+				array( 'status' => 400 )
+			);
+		}
+		if ( count( $codes ) > self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE ) {
+			return new WP_Error(
+				'digitalogic_pricing_assignment_batch_too_large',
+				sprintf(
+					/* translators: %d: maximum number of Codes per request. */
+					__( 'Pricing assignment read batches are limited to %d Codes.', 'digitalogic' ),
+					self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE
+				),
+				array(
+					'status'        => 413,
+					'maximum_codes' => self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE,
+				)
+			);
+		}
 
-        $normalized_codes = array();
-        $seen = array();
-        foreach (array_values($codes) as $index => $code) {
-            $normalized = $this->normalize_code($code);
-            if ('' === $normalized) {
-                return new WP_Error(
-                    'digitalogic_pricing_assignment_batch_code_invalid',
-                    __('Every pricing assignment batch item must be a non-empty string or integer Code.', 'digitalogic'),
-                    array('status' => 400, 'index' => $index)
-                );
-            }
-            if (isset($seen[$normalized])) {
-                return new WP_Error(
-                    'digitalogic_pricing_assignment_batch_code_duplicate',
-                    __('Duplicate product Codes are not allowed in a pricing assignment read batch.', 'digitalogic'),
-                    array(
-                        'status' => 400,
-                        'code_value' => $normalized,
-                        'first_index' => $seen[$normalized],
-                        'index' => $index,
-                    )
-                );
-            }
-            $seen[$normalized] = $index;
-            $normalized_codes[] = $normalized;
-        }
+		$normalized_codes = array();
+		$seen             = array();
+		foreach ( array_values( $codes ) as $index => $code ) {
+			$normalized = $this->normalize_code( $code );
+			if ( '' === $normalized ) {
+				return new WP_Error(
+					'digitalogic_pricing_assignment_batch_code_invalid',
+					__( 'Every pricing assignment batch item must be a non-empty string or integer Code.', 'digitalogic' ),
+					array(
+						'status' => 400,
+						'index'  => $index,
+					)
+				);
+			}
+			if ( isset( $seen[ $normalized ] ) ) {
+				return new WP_Error(
+					'digitalogic_pricing_assignment_batch_code_duplicate',
+					__( 'Duplicate product Codes are not allowed in a pricing assignment read batch.', 'digitalogic' ),
+					array(
+						'status'      => 400,
+						'code_value'  => $normalized,
+						'first_index' => $seen[ $normalized ],
+						'index'       => $index,
+					)
+				);
+			}
+			$seen[ $normalized ] = $index;
+			$normalized_codes[]  = $normalized;
+		}
 
-        $default_markup = $this->load_default_percentage_markup();
-        $methods = $this->load_methods();
-        $results = array();
-        $resolved_count = 0;
-        foreach ($normalized_codes as $code) {
-            $resolved = $this->resolve_freight_product($code);
-            if (is_wp_error($resolved)) {
-                $data = $resolved->get_error_data();
-                $status = is_array($data) && isset($data['status']) ? (int) $data['status'] : 400;
-                $results[] = array(
-                    'code' => $code,
-                    'status' => 'error',
-                    'error' => array(
-                        'code' => (string) $resolved->get_error_code(),
-                        'message' => (string) $resolved->get_error_message(),
-                        'http_status' => $status,
-                        'retryable' => $status >= 500,
-                    ),
-                );
-                continue;
-            }
+		$default_markup = $this->load_default_percentage_markup();
+		$results        = array();
+		$resolved_count = 0;
+		foreach ( $normalized_codes as $code ) {
+			$resolved = $this->resolve_freight_product( $code );
+			if ( is_wp_error( $resolved ) ) {
+				$data      = $resolved->get_error_data();
+				$status    = is_array( $data ) && isset( $data['status'] ) ? (int) $data['status'] : 400;
+				$results[] = array(
+					'code'   => $code,
+					'status' => 'error',
+					'error'  => array(
+						'code'        => (string) $resolved->get_error_code(),
+						'http_status' => $status,
+						'retryable'   => $status >= 500,
+					),
+				);
+				continue;
+			}
 
-            $resolved_count++;
-            $results[] = array(
-                'code' => $code,
-                'status' => 'ok',
-                'assignment' => $this->build_assignment_response($resolved, $default_markup, $methods, true),
-            );
-        }
+			++$resolved_count;
+			$results[] = array(
+				'code'       => $code,
+				'status'     => 'ok',
+				'assignment' => $this->build_pricing_assignment_projection( $code, $resolved, $default_markup ),
+			);
+		}
 
-        return array(
-            'schema' => self::PRICING_ASSIGNMENT_BATCH_SCHEMA,
-            'schema_version' => self::PRICING_ASSIGNMENT_BATCH_SCHEMA_VERSION,
-            'requested_count' => count($normalized_codes),
-            'resolved_count' => $resolved_count,
-            'error_count' => count($normalized_codes) - $resolved_count,
-            'maximum_codes' => self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE,
-            'default_percentage_markup' => $default_markup,
-            'results' => $results,
-        );
-    }
+		return array(
+			'schema'                    => self::PRICING_ASSIGNMENT_BATCH_SCHEMA,
+			'schema_version'            => self::PRICING_ASSIGNMENT_BATCH_SCHEMA_VERSION,
+			'requested_count'           => count( $normalized_codes ),
+			'resolved_count'            => $resolved_count,
+			'error_count'               => count( $normalized_codes ) - $resolved_count,
+			'maximum_codes'             => self::MAX_PRICING_ASSIGNMENT_BATCH_SIZE,
+			'default_percentage_markup' => $default_markup,
+			'results'                   => $results,
+		);
+	}
 
     /**
      * Assign or clear a method through deterministic Code/SKU resolution.
@@ -1424,17 +1422,15 @@ final class Digitalogic_Import_Freight_Service {
         return array('changed' => $changed, 'product_id' => (int) $product_id);
     }
 
-    private function build_assignment_response($resolved, $default_markup = null, $methods = null, $exact_decimals = false) {
+    private function build_assignment_response($resolved, $default_markup = null) {
         $method_row = $this->read_post_meta_db($resolved['product_id'], self::PRODUCT_METHOD_META);
         $legacy_row = $this->read_post_meta_db($resolved['product_id'], self::LEGACY_PRODUCT_METHOD_META);
         $method_id = $method_row['exists'] ? (string) $method_row['value'] : '';
-        if (!is_array($methods)) {
-            $methods = $this->load_methods();
-        }
+        $methods = $this->load_methods();
         if (!is_array($default_markup)) {
             $default_markup = $this->load_default_percentage_markup();
         }
-        $markup = $this->build_markup_contract($resolved['product_id'], $default_markup, $exact_decimals);
+        $markup = $this->build_markup_contract($resolved['product_id'], $default_markup);
 
         return array_merge($resolved, array(
             'import_freight_method_id' => $method_id,
@@ -1446,6 +1442,54 @@ final class Digitalogic_Import_Freight_Service {
             'pricing_warnings' => $markup['warning'] ? array($markup['warning']) : array(),
         ));
     }
+
+	/**
+	 * Build the stable machine projection used by the batch read contract.
+	 *
+	 * @param string $requested_code Normalized Code from the request.
+	 * @param array  $resolved Resolved internal product identity.
+	 * @param array  $default_markup Preloaded default-markup contract.
+	 * @return array
+	 */
+	private function build_pricing_assignment_projection( $requested_code, $resolved, $default_markup ) {
+		$method_row = $this->read_post_meta_db( $resolved['product_id'], self::PRODUCT_METHOD_META );
+		$markup     = $this->build_exact_markup_contract( $resolved['product_id'], $default_markup );
+
+		return array(
+			'code'                     => $requested_code,
+			'import_freight_method_id' => $method_row['exists'] ? (string) $method_row['value'] : '',
+			'profit_percent'           => $markup['profit_percent'],
+			'profit_percent_source'    => $markup['source'],
+			'pricing_warnings'         => $markup['warning'] ? array( $markup['warning'] ) : array(),
+		);
+	}
+
+	/**
+	 * Preserve an exact product percentage in the machine batch projection.
+	 *
+	 * @param int   $product_id Product post ID.
+	 * @param array $default_markup Preloaded default-markup contract.
+	 * @return array
+	 */
+	private function build_exact_markup_contract( $product_id, $default_markup ) {
+		$markup = $this->build_markup_contract( $product_id, $default_markup );
+		if ( 'percentage' !== $markup['type'] || 'product_override' !== $markup['source'] ) {
+			return $markup;
+		}
+
+		$canonical = $this->canonical_default_percentage( get_post_meta( $product_id, '_digitalogic_markup', true ) );
+		if ( is_wp_error( $canonical ) ) {
+			$markup['value']          = null;
+			$markup['profit_percent'] = null;
+			$markup['source']         = null;
+			$markup['warning']        = 'percentage_markup_value_invalid';
+			return $markup;
+		}
+
+		$markup['value']          = $canonical;
+		$markup['profit_percent'] = $canonical;
+		return $markup;
+	}
 
     private function count_assignments($method_id) {
         $ids = get_posts(array(
@@ -2180,7 +2224,7 @@ final class Digitalogic_Import_Freight_Service {
         });
     }
 
-    private function build_markup_contract($product_id, $default_markup, $exact_decimals = false) {
+    private function build_markup_contract($product_id, $default_markup) {
         $type_exists = metadata_exists('post', $product_id, '_digitalogic_markup_type');
         $value_exists = metadata_exists('post', $product_id, '_digitalogic_markup');
         $raw_type = get_post_meta($product_id, '_digitalogic_markup_type', true);
@@ -2232,19 +2276,6 @@ final class Digitalogic_Import_Freight_Service {
             $warning = 'markup_type_missing';
         } else {
             $warning = 'markup_type_unsupported';
-        }
-
-        if ($exact_decimals && 'percentage' === $type && 'product_override' === $source) {
-            $canonical = $this->canonical_default_percentage($raw_value);
-            if (is_wp_error($canonical)) {
-                $value = null;
-                $profit_percent = null;
-                $source = null;
-                $warning = 'percentage_markup_value_invalid';
-            } else {
-                $value = $canonical;
-                $profit_percent = $canonical;
-            }
         }
 
         return array(

--- a/includes/cli/class-cli-commands.php
+++ b/includes/cli/class-cli-commands.php
@@ -560,39 +560,47 @@ class Digitalogic_CLI_Commands {
         WP_CLI::success('Panel broadcast queued.');
     }
 
-    /**
-     * Read exact import-pricing assignments for a bounded Code list.
-     *
-     * ## OPTIONS
-     *
-     * [<code>...]
-     * : One or more exact Patris Codes or SKU compatibility fallbacks.
-     *
-     * [--codes=<codes>]
-     * : Additional comma-separated Codes.
-     *
-     * ## EXAMPLES
-     *
-     *     wp digitalogic pricing assignments 113007045 113007046
-     *     wp digitalogic pricing assignments --codes=113007045,113007046
-     *
-     * @when after_wp_load
-     */
-    public function pricing_assignments($args, $assoc_args) {
-        $codes = array_values(array_map('strval', $args));
-        if (isset($assoc_args['codes'])) {
-            $codes = array_merge($codes, explode(',', (string) $assoc_args['codes']));
-        }
+	/**
+	 * Read exact import-pricing assignments for a bounded Code list.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<code>...]
+	 * : One or more exact Patris Codes or SKU compatibility fallbacks.
+	 *
+	 * [--codes=<codes>]
+	 * : Additional comma-separated Codes.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp digitalogic pricing assignments 113007045 113007046
+	 *     wp digitalogic pricing assignments --codes=113007045,113007046
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args Positional Codes.
+	 * @param array $assoc_args Named command arguments.
+	 * @return void
+	 */
+	public function pricing_assignments( $args, $assoc_args ) {
+		$codes = array_values( array_map( 'strval', $args ) );
+		if ( isset( $assoc_args['codes'] ) ) {
+			$codes = array_merge( $codes, explode( ',', (string) $assoc_args['codes'] ) );
+		}
 
-        $result = Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing_batch(array(
-            'codes' => $codes,
-        ));
-        if (is_wp_error($result)) {
-            WP_CLI::error($result->get_error_message());
-        }
+		$result = Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing_batch(
+			array(
+				'codes' => $codes,
+			)
+		);
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
 
-        WP_CLI::line(wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
-    }
+		WP_CLI::line(
+			wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES )
+		);
+	}
 }
 
 // Register commands
@@ -611,4 +619,7 @@ WP_CLI::add_command('digitalogic websocket serve', array('Digitalogic_CLI_Comman
 WP_CLI::add_command('digitalogic websocket token', array('Digitalogic_CLI_Commands', 'websocket_token'));
 WP_CLI::add_command('digitalogic panel token', array('Digitalogic_CLI_Commands', 'panel_token'));
 WP_CLI::add_command('digitalogic panel broadcast', array('Digitalogic_CLI_Commands', 'panel_broadcast'));
-WP_CLI::add_command('digitalogic pricing assignments', array('Digitalogic_CLI_Commands', 'pricing_assignments'));
+WP_CLI::add_command(
+	'digitalogic pricing assignments',
+	array( 'Digitalogic_CLI_Commands', 'pricing_assignments' )
+);

--- a/includes/cli/class-cli-commands.php
+++ b/includes/cli/class-cli-commands.php
@@ -559,6 +559,40 @@ class Digitalogic_CLI_Commands {
         Digitalogic_Panel::broadcast_panel_message($payload);
         WP_CLI::success('Panel broadcast queued.');
     }
+
+    /**
+     * Read exact import-pricing assignments for a bounded Code list.
+     *
+     * ## OPTIONS
+     *
+     * [<code>...]
+     * : One or more exact Patris Codes or SKU compatibility fallbacks.
+     *
+     * [--codes=<codes>]
+     * : Additional comma-separated Codes.
+     *
+     * ## EXAMPLES
+     *
+     *     wp digitalogic pricing assignments 113007045 113007046
+     *     wp digitalogic pricing assignments --codes=113007045,113007046
+     *
+     * @when after_wp_load
+     */
+    public function pricing_assignments($args, $assoc_args) {
+        $codes = array_values(array_map('strval', $args));
+        if (isset($assoc_args['codes'])) {
+            $codes = array_merge($codes, explode(',', (string) $assoc_args['codes']));
+        }
+
+        $result = Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing_batch(array(
+            'codes' => $codes,
+        ));
+        if (is_wp_error($result)) {
+            WP_CLI::error($result->get_error_message());
+        }
+
+        WP_CLI::line(wp_json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
 }
 
 // Register commands
@@ -577,3 +611,4 @@ WP_CLI::add_command('digitalogic websocket serve', array('Digitalogic_CLI_Comman
 WP_CLI::add_command('digitalogic websocket token', array('Digitalogic_CLI_Commands', 'websocket_token'));
 WP_CLI::add_command('digitalogic panel token', array('Digitalogic_CLI_Commands', 'panel_token'));
 WP_CLI::add_command('digitalogic panel broadcast', array('Digitalogic_CLI_Commands', 'panel_broadcast'));
+WP_CLI::add_command('digitalogic pricing assignments', array('Digitalogic_CLI_Commands', 'pricing_assignments'));

--- a/tests/ImportFreightServiceTest.php
+++ b/tests/ImportFreightServiceTest.php
@@ -218,123 +218,165 @@ final class ImportFreightServiceTest extends TestCase {
         $this->assertSame($before, get_post_meta(301, '_digitalogic_import_freight_method_id', true));
     }
 
-    public function test_batch_assignment_read_is_ordered_typed_read_only_and_preloads_defaults_once() {
-        $GLOBALS['digitalogic_test_posts'][306] = array(
-            'post_type' => 'product',
-            'meta' => array(
-                '_sku' => 'SKU-306',
-                '_digitalogic_patris_product_code' => '113007045',
-                '_digitalogic_import_freight_method_id' => 'air_express',
-            ),
-        );
-        $this->service->migrate_legacy_data();
-        $this->service->update_default_percentage_markup('30');
+	/**
+	 * The batch response matches the shared golden contract and stays read-only.
+	 */
+	public function test_batch_assignment_read_is_ordered_typed_read_only_and_preloads_defaults_once() {
+		$GLOBALS['digitalogic_test_posts'][306] = array(
+			'post_type' => 'product',
+			'meta'      => array(
+				'_sku'                                  => 'SKU-306',
+				'_digitalogic_patris_product_code'      => '113007045',
+				'_digitalogic_import_freight_method_id' => 'air_express',
+			),
+		);
+		$this->service->migrate_legacy_data();
+		$this->service->update_default_percentage_markup( '30' );
 
-        $fixture = json_decode(
-            file_get_contents(__DIR__ . '/fixtures/pricing-assignment-batch-v1-golden.json'),
-            true,
-            512,
-            JSON_THROW_ON_ERROR
-        );
-        $options_before = $GLOBALS['digitalogic_test_options'];
-        $posts_before = $GLOBALS['digitalogic_test_posts'];
-        $actions_before = $GLOBALS['digitalogic_test_actions'];
-        $queries_before = $GLOBALS['wpdb']->queries;
-        $locks_before = $GLOBALS['wpdb']->acquire_count;
-        $default_reads_before = $GLOBALS['wpdb']->option_read_counts[Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION] ?? 0;
-        $method_reads_before = $GLOBALS['wpdb']->option_read_counts[Digitalogic_Import_Freight_Service::METHODS_OPTION] ?? 0;
+		$fixture = json_decode(
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Test-only local fixture.
+			file_get_contents( __DIR__ . '/fixtures/pricing-assignment-batch-v1-golden.json' ),
+			true,
+			512,
+			JSON_THROW_ON_ERROR
+		);
+		$options_before       = $GLOBALS['digitalogic_test_options'];
+		$posts_before         = $GLOBALS['digitalogic_test_posts'];
+		$actions_before       = $GLOBALS['digitalogic_test_actions'];
+		$queries_before       = $GLOBALS['wpdb']->queries;
+		$locks_before         = $GLOBALS['wpdb']->acquire_count;
+		$default_reads_before = $GLOBALS['wpdb']->option_read_counts[ Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION ] ?? 0;
 
-        $result = $this->service->get_product_assignments_by_codes(array('113007045', 'MISSING'));
+		$result = $this->service->get_product_assignments_by_codes( array( '113007045', 'MISSING' ) );
 
-        $this->assertSame($fixture['schema'], $result['schema']);
-        $this->assertSame($fixture['schema_version'], $result['schema_version']);
-        $this->assertSame(array('113007045', 'MISSING'), array_column($result['results'], 'code'));
-        $this->assertSame(array('ok', 'error'), array_column($result['results'], 'status'));
-        $this->assertSame('air_express', $result['results'][0]['assignment']['import_freight_method_id']);
-        $this->assertSame('30', $result['results'][0]['assignment']['profit_percent']);
-        $this->assertSame($fixture['results'][1]['error'], $result['results'][1]['error']);
-        $this->assertSame('30', $result['default_percentage_markup']['profit_percent']);
-        $this->assertSame($default_reads_before + 1, $GLOBALS['wpdb']->option_read_counts[Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION]);
-        $this->assertSame($method_reads_before + 1, $GLOBALS['wpdb']->option_read_counts[Digitalogic_Import_Freight_Service::METHODS_OPTION]);
-        $this->assertSame($options_before, $GLOBALS['digitalogic_test_options']);
-        $this->assertSame($posts_before, $GLOBALS['digitalogic_test_posts']);
-        $this->assertSame($actions_before, $GLOBALS['digitalogic_test_actions']);
-        $this->assertSame($queries_before, $GLOBALS['wpdb']->queries);
-        $this->assertSame($locks_before, $GLOBALS['wpdb']->acquire_count);
-    }
+		$this->assertSame( $fixture, $result );
+		$this->assertSame(
+			$default_reads_before + 1,
+			$GLOBALS['wpdb']->option_read_counts[ Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION ]
+		);
+		$this->assertSame( $options_before, $GLOBALS['digitalogic_test_options'] );
+		$this->assertSame( $posts_before, $GLOBALS['digitalogic_test_posts'] );
+		$this->assertSame( $actions_before, $GLOBALS['digitalogic_test_actions'] );
+		$this->assertSame( $queries_before, $GLOBALS['wpdb']->queries );
+		$this->assertSame( $locks_before, $GLOBALS['wpdb']->acquire_count );
+	}
 
-    public function test_batch_assignment_read_preserves_exact_markup_and_collision_errors() {
-        $GLOBALS['digitalogic_test_posts'] = array(
-            307 => array(
-                'post_type' => 'product',
-                'meta' => array(
-                    '_digitalogic_patris_product_code' => 'EXACT-MARKUP',
-                    '_digitalogic_import_freight_method_id' => 'air_freight',
-                    '_digitalogic_markup_type' => 'percentage',
-                    '_digitalogic_markup' => '12.500000000001',
-                ),
-            ),
-            308 => array(
-                'post_type' => 'product',
-                'meta' => array('_digitalogic_patris_product_code' => 'COLLISION'),
-            ),
-            309 => array(
-                'post_type' => 'product_variation',
-                'meta' => array('_sku' => 'COLLISION'),
-            ),
-        );
-        $this->service->migrate_legacy_data();
+	/**
+	 * A cold read cannot invoke migration or mutate canonical storage.
+	 */
+	public function test_batch_assignment_read_is_write_free_before_migration() {
+		$GLOBALS['digitalogic_test_posts'][311] = array(
+			'post_type' => 'product',
+			'meta'      => array(
+				'_digitalogic_patris_product_code'      => 'COLD-READ',
+				'_digitalogic_import_freight_method_id' => 'air_express',
+			),
+		);
+		$this->assertArrayNotHasKey( Digitalogic_Import_Freight_Service::MIGRATION_OPTION, $GLOBALS['digitalogic_test_options'] );
+		$before = array(
+			'options' => $GLOBALS['digitalogic_test_options'],
+			'posts'   => $GLOBALS['digitalogic_test_posts'],
+			'actions' => $GLOBALS['digitalogic_test_actions'],
+			'queries' => $GLOBALS['wpdb']->queries,
+			'locks'   => $GLOBALS['wpdb']->acquire_count,
+		);
 
-        $result = $this->service->get_product_assignments_by_codes(array('EXACT-MARKUP', 'COLLISION'));
+		$result = $this->service->get_product_assignments_by_codes( array( 'COLD-READ' ) );
 
-        $this->assertSame('12.500000000001', $result['results'][0]['assignment']['profit_percent']);
-        $this->assertSame('12.500000000001', $result['results'][0]['assignment']['markup']['value']);
-        $this->assertSame('digitalogic_product_code_ambiguous', $result['results'][1]['error']['code']);
-        $this->assertSame(409, $result['results'][1]['error']['http_status']);
-        $this->assertFalse($result['results'][1]['error']['retryable']);
-        $this->assertArrayNotHasKey('assignment', $result['results'][1]);
-    }
+		$this->assertSame( 'ok', $result['results'][0]['status'] );
+		$this->assertSame( 'air_express', $result['results'][0]['assignment']['import_freight_method_id'] );
+		$this->assertArrayNotHasKey( Digitalogic_Import_Freight_Service::METHODS_OPTION, $GLOBALS['digitalogic_test_options'] );
+		$this->assertSame( $before['options'], $GLOBALS['digitalogic_test_options'] );
+		$this->assertSame( $before['posts'], $GLOBALS['digitalogic_test_posts'] );
+		$this->assertSame( $before['actions'], $GLOBALS['digitalogic_test_actions'] );
+		$this->assertSame( $before['queries'], $GLOBALS['wpdb']->queries );
+		$this->assertSame( $before['locks'], $GLOBALS['wpdb']->acquire_count );
+	}
 
-    public function test_batch_assignment_read_rejects_invalid_duplicate_and_oversize_requests() {
-        $empty = $this->service->get_product_assignments_by_codes(array());
-        $invalid = $this->service->get_product_assignments_by_codes(array('VALID', array('not-a-code')));
-        $duplicate = $this->service->get_product_assignments_by_codes(array(' 00123 ', '00123'));
-        $oversize = $this->service->get_product_assignments_by_codes(
-            array_fill(0, Digitalogic_Import_Freight_Service::MAX_PRICING_ASSIGNMENT_BATCH_SIZE + 1, 'X')
-        );
+	/**
+	 * Exact decimal overrides and collision errors survive the projection.
+	 */
+	public function test_batch_assignment_read_preserves_exact_markup_and_collision_errors() {
+		$GLOBALS['digitalogic_test_posts'] = array(
+			307 => array(
+				'post_type' => 'product',
+				'meta'      => array(
+					'_digitalogic_patris_product_code' => 'EXACT-MARKUP',
+					'_digitalogic_import_freight_method_id' => 'air_freight',
+					'_digitalogic_markup_type'         => 'percentage',
+					'_digitalogic_markup'              => '12.500000000001',
+				),
+			),
+			308 => array(
+				'post_type' => 'product',
+				'meta'      => array( '_digitalogic_patris_product_code' => 'COLLISION' ),
+			),
+			309 => array(
+				'post_type' => 'product_variation',
+				'meta'      => array( '_sku' => 'COLLISION' ),
+			),
+		);
+		$this->service->migrate_legacy_data();
 
-        $this->assertSame('digitalogic_pricing_assignment_batch_empty', $empty->get_error_code());
-        $this->assertSame('digitalogic_pricing_assignment_batch_code_invalid', $invalid->get_error_code());
-        $this->assertSame('digitalogic_pricing_assignment_batch_code_duplicate', $duplicate->get_error_code());
-        $this->assertSame('digitalogic_pricing_assignment_batch_too_large', $oversize->get_error_code());
-        $this->assertSame(500, $oversize->get_error_data()['maximum_codes']);
-    }
+		$result = $this->service->get_product_assignments_by_codes( array( 'EXACT-MARKUP', 'COLLISION' ) );
 
-    public function test_batch_assignment_rest_command_and_service_share_one_contract() {
-        $GLOBALS['digitalogic_test_posts'][310] = array(
-            'post_type' => 'product',
-            'meta' => array(
-                '_sku' => 'COMMAND-310',
-                '_digitalogic_import_freight_method_id' => 'sea_freight',
-            ),
-        );
-        $this->service->migrate_legacy_data();
-        $payload = array('codes' => array('COMMAND-310'));
-        $service = $this->service->get_product_assignments_by_codes($payload['codes']);
-        $command = Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing_batch($payload);
-        $GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
-        $transport_command = Digitalogic_Command_Dispatcher::instance()->execute(
-            'digitalogic_get_product_import_pricing_batch',
-            $payload,
-            'websocket'
-        );
-        $rest = Digitalogic_REST_API::instance()->get_product_import_pricing_batch(new WP_REST_Request(array(), $payload));
+		$this->assertSame( '12.500000000001', $result['results'][0]['assignment']['profit_percent'] );
+		$this->assertSame( 'product_override', $result['results'][0]['assignment']['profit_percent_source'] );
+		$this->assertArrayNotHasKey( 'markup', $result['results'][0]['assignment'] );
+		$this->assertSame( 'digitalogic_product_code_ambiguous', $result['results'][1]['error']['code'] );
+		$this->assertSame( 409, $result['results'][1]['error']['http_status'] );
+		$this->assertFalse( $result['results'][1]['error']['retryable'] );
+		$this->assertArrayNotHasKey( 'assignment', $result['results'][1] );
+	}
 
-        $this->assertSame($service, $command);
-        $this->assertSame($service, $transport_command);
-        $this->assertSame(200, $rest->get_status());
-        $this->assertSame($service, $rest->get_data()['data']);
-    }
+	/**
+	 * Whole-request validation rejects invalid batch envelopes.
+	 */
+	public function test_batch_assignment_read_rejects_invalid_duplicate_and_oversize_requests() {
+		$empty     = $this->service->get_product_assignments_by_codes( array() );
+		$invalid   = $this->service->get_product_assignments_by_codes( array( 'VALID', array( 'not-a-code' ) ) );
+		$duplicate = $this->service->get_product_assignments_by_codes( array( ' 00123 ', '00123' ) );
+		$oversize  = $this->service->get_product_assignments_by_codes(
+			array_fill( 0, Digitalogic_Import_Freight_Service::MAX_PRICING_ASSIGNMENT_BATCH_SIZE + 1, 'X' )
+		);
+
+		$this->assertSame( 'digitalogic_pricing_assignment_batch_empty', $empty->get_error_code() );
+		$this->assertSame( 'digitalogic_pricing_assignment_batch_code_invalid', $invalid->get_error_code() );
+		$this->assertSame( 'digitalogic_pricing_assignment_batch_code_duplicate', $duplicate->get_error_code() );
+		$this->assertSame( 'digitalogic_pricing_assignment_batch_too_large', $oversize->get_error_code() );
+		$this->assertSame( 500, $oversize->get_error_data()['maximum_codes'] );
+	}
+
+	/**
+	 * REST, dispatcher, and transport commands expose one service contract.
+	 */
+	public function test_batch_assignment_rest_command_and_service_share_one_contract() {
+		$GLOBALS['digitalogic_test_posts'][310] = array(
+			'post_type' => 'product',
+			'meta'      => array(
+				'_sku'                                  => 'COMMAND-310',
+				'_digitalogic_import_freight_method_id' => 'sea_freight',
+			),
+		);
+		$this->service->migrate_legacy_data();
+		$payload = array( 'codes' => array( 'COMMAND-310' ) );
+		$service = $this->service->get_product_assignments_by_codes( $payload['codes'] );
+		$command = Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing_batch( $payload );
+		$GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
+		$transport_command = Digitalogic_Command_Dispatcher::instance()->execute(
+			'digitalogic_get_product_import_pricing_batch',
+			$payload,
+			'websocket'
+		);
+		$rest              = Digitalogic_REST_API::instance()->get_product_import_pricing_batch(
+			new WP_REST_Request( array(), $payload )
+		);
+
+		$this->assertSame( $service, $command );
+		$this->assertSame( $service, $transport_command );
+		$this->assertSame( 200, $rest->get_status() );
+		$this->assertSame( $service, $rest->get_data()['data'] );
+	}
 
     public function test_rest_and_dispatcher_share_identical_service_results_and_scoped_permissions() {
         $this->service->migrate_legacy_data();

--- a/tests/ImportFreightServiceTest.php
+++ b/tests/ImportFreightServiceTest.php
@@ -334,6 +334,7 @@ final class ImportFreightServiceTest extends TestCase {
 	 */
 	public function test_batch_assignment_read_rejects_invalid_duplicate_and_oversize_requests() {
 		$empty     = $this->service->get_product_assignments_by_codes( array() );
+		$object    = $this->service->get_product_assignments_by_codes( array( 'named' => 'VALID' ) );
 		$invalid   = $this->service->get_product_assignments_by_codes( array( 'VALID', array( 'not-a-code' ) ) );
 		$duplicate = $this->service->get_product_assignments_by_codes( array( ' 00123 ', '00123' ) );
 		$oversize  = $this->service->get_product_assignments_by_codes(
@@ -341,10 +342,17 @@ final class ImportFreightServiceTest extends TestCase {
 		);
 
 		$this->assertSame( 'digitalogic_pricing_assignment_batch_empty', $empty->get_error_code() );
+		$this->assertSame( 'digitalogic_pricing_assignment_batch_shape_invalid', $object->get_error_code() );
 		$this->assertSame( 'digitalogic_pricing_assignment_batch_code_invalid', $invalid->get_error_code() );
 		$this->assertSame( 'digitalogic_pricing_assignment_batch_code_duplicate', $duplicate->get_error_code() );
 		$this->assertSame( 'digitalogic_pricing_assignment_batch_too_large', $oversize->get_error_code() );
 		$this->assertSame( 500, $oversize->get_error_data()['maximum_codes'] );
+		$this->assertSame(
+			'digitalogic_pricing_assignment_batch_shape_invalid',
+			Digitalogic_Command_Dispatcher::instance()
+				->get_product_import_pricing_batch( array( 'codes' => '113007045' ) )
+				->get_error_code()
+		);
 	}
 
 	/**

--- a/tests/ImportFreightServiceTest.php
+++ b/tests/ImportFreightServiceTest.php
@@ -218,6 +218,124 @@ final class ImportFreightServiceTest extends TestCase {
         $this->assertSame($before, get_post_meta(301, '_digitalogic_import_freight_method_id', true));
     }
 
+    public function test_batch_assignment_read_is_ordered_typed_read_only_and_preloads_defaults_once() {
+        $GLOBALS['digitalogic_test_posts'][306] = array(
+            'post_type' => 'product',
+            'meta' => array(
+                '_sku' => 'SKU-306',
+                '_digitalogic_patris_product_code' => '113007045',
+                '_digitalogic_import_freight_method_id' => 'air_express',
+            ),
+        );
+        $this->service->migrate_legacy_data();
+        $this->service->update_default_percentage_markup('30');
+
+        $fixture = json_decode(
+            file_get_contents(__DIR__ . '/fixtures/pricing-assignment-batch-v1-golden.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $options_before = $GLOBALS['digitalogic_test_options'];
+        $posts_before = $GLOBALS['digitalogic_test_posts'];
+        $actions_before = $GLOBALS['digitalogic_test_actions'];
+        $queries_before = $GLOBALS['wpdb']->queries;
+        $locks_before = $GLOBALS['wpdb']->acquire_count;
+        $default_reads_before = $GLOBALS['wpdb']->option_read_counts[Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION] ?? 0;
+        $method_reads_before = $GLOBALS['wpdb']->option_read_counts[Digitalogic_Import_Freight_Service::METHODS_OPTION] ?? 0;
+
+        $result = $this->service->get_product_assignments_by_codes(array('113007045', 'MISSING'));
+
+        $this->assertSame($fixture['schema'], $result['schema']);
+        $this->assertSame($fixture['schema_version'], $result['schema_version']);
+        $this->assertSame(array('113007045', 'MISSING'), array_column($result['results'], 'code'));
+        $this->assertSame(array('ok', 'error'), array_column($result['results'], 'status'));
+        $this->assertSame('air_express', $result['results'][0]['assignment']['import_freight_method_id']);
+        $this->assertSame('30', $result['results'][0]['assignment']['profit_percent']);
+        $this->assertSame($fixture['results'][1]['error'], $result['results'][1]['error']);
+        $this->assertSame('30', $result['default_percentage_markup']['profit_percent']);
+        $this->assertSame($default_reads_before + 1, $GLOBALS['wpdb']->option_read_counts[Digitalogic_Import_Freight_Service::DEFAULT_MARKUP_OPTION]);
+        $this->assertSame($method_reads_before + 1, $GLOBALS['wpdb']->option_read_counts[Digitalogic_Import_Freight_Service::METHODS_OPTION]);
+        $this->assertSame($options_before, $GLOBALS['digitalogic_test_options']);
+        $this->assertSame($posts_before, $GLOBALS['digitalogic_test_posts']);
+        $this->assertSame($actions_before, $GLOBALS['digitalogic_test_actions']);
+        $this->assertSame($queries_before, $GLOBALS['wpdb']->queries);
+        $this->assertSame($locks_before, $GLOBALS['wpdb']->acquire_count);
+    }
+
+    public function test_batch_assignment_read_preserves_exact_markup_and_collision_errors() {
+        $GLOBALS['digitalogic_test_posts'] = array(
+            307 => array(
+                'post_type' => 'product',
+                'meta' => array(
+                    '_digitalogic_patris_product_code' => 'EXACT-MARKUP',
+                    '_digitalogic_import_freight_method_id' => 'air_freight',
+                    '_digitalogic_markup_type' => 'percentage',
+                    '_digitalogic_markup' => '12.500000000001',
+                ),
+            ),
+            308 => array(
+                'post_type' => 'product',
+                'meta' => array('_digitalogic_patris_product_code' => 'COLLISION'),
+            ),
+            309 => array(
+                'post_type' => 'product_variation',
+                'meta' => array('_sku' => 'COLLISION'),
+            ),
+        );
+        $this->service->migrate_legacy_data();
+
+        $result = $this->service->get_product_assignments_by_codes(array('EXACT-MARKUP', 'COLLISION'));
+
+        $this->assertSame('12.500000000001', $result['results'][0]['assignment']['profit_percent']);
+        $this->assertSame('12.500000000001', $result['results'][0]['assignment']['markup']['value']);
+        $this->assertSame('digitalogic_product_code_ambiguous', $result['results'][1]['error']['code']);
+        $this->assertSame(409, $result['results'][1]['error']['http_status']);
+        $this->assertFalse($result['results'][1]['error']['retryable']);
+        $this->assertArrayNotHasKey('assignment', $result['results'][1]);
+    }
+
+    public function test_batch_assignment_read_rejects_invalid_duplicate_and_oversize_requests() {
+        $empty = $this->service->get_product_assignments_by_codes(array());
+        $invalid = $this->service->get_product_assignments_by_codes(array('VALID', array('not-a-code')));
+        $duplicate = $this->service->get_product_assignments_by_codes(array(' 00123 ', '00123'));
+        $oversize = $this->service->get_product_assignments_by_codes(
+            array_fill(0, Digitalogic_Import_Freight_Service::MAX_PRICING_ASSIGNMENT_BATCH_SIZE + 1, 'X')
+        );
+
+        $this->assertSame('digitalogic_pricing_assignment_batch_empty', $empty->get_error_code());
+        $this->assertSame('digitalogic_pricing_assignment_batch_code_invalid', $invalid->get_error_code());
+        $this->assertSame('digitalogic_pricing_assignment_batch_code_duplicate', $duplicate->get_error_code());
+        $this->assertSame('digitalogic_pricing_assignment_batch_too_large', $oversize->get_error_code());
+        $this->assertSame(500, $oversize->get_error_data()['maximum_codes']);
+    }
+
+    public function test_batch_assignment_rest_command_and_service_share_one_contract() {
+        $GLOBALS['digitalogic_test_posts'][310] = array(
+            'post_type' => 'product',
+            'meta' => array(
+                '_sku' => 'COMMAND-310',
+                '_digitalogic_import_freight_method_id' => 'sea_freight',
+            ),
+        );
+        $this->service->migrate_legacy_data();
+        $payload = array('codes' => array('COMMAND-310'));
+        $service = $this->service->get_product_assignments_by_codes($payload['codes']);
+        $command = Digitalogic_Command_Dispatcher::instance()->get_product_import_pricing_batch($payload);
+        $GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
+        $transport_command = Digitalogic_Command_Dispatcher::instance()->execute(
+            'digitalogic_get_product_import_pricing_batch',
+            $payload,
+            'websocket'
+        );
+        $rest = Digitalogic_REST_API::instance()->get_product_import_pricing_batch(new WP_REST_Request(array(), $payload));
+
+        $this->assertSame($service, $command);
+        $this->assertSame($service, $transport_command);
+        $this->assertSame(200, $rest->get_status());
+        $this->assertSame($service, $rest->get_data()['data']);
+    }
+
     public function test_rest_and_dispatcher_share_identical_service_results_and_scoped_permissions() {
         $this->service->migrate_legacy_data();
         $GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -257,6 +257,7 @@ final class RestApiPermissionsTest extends TestCase {
             'DELETE /import-freight-methods/(?P<id>[a-z][a-z0-9_]{1,63})' => 'check_write_permission',
             'GET /products/by-code/(?P<code>[^/]+)/import-pricing' => 'check_read_permission',
             'PUT /products/by-code/(?P<code>[^/]+)/import-pricing' => 'check_write_permission',
+            'POST /pricing-assignments/batch' => 'check_read_permission',
             'POST /products/import-pricing/batch' => 'check_write_permission',
         );
 

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -257,7 +257,7 @@ final class RestApiPermissionsTest extends TestCase {
             'DELETE /import-freight-methods/(?P<id>[a-z][a-z0-9_]{1,63})' => 'check_write_permission',
             'GET /products/by-code/(?P<code>[^/]+)/import-pricing' => 'check_read_permission',
             'PUT /products/by-code/(?P<code>[^/]+)/import-pricing' => 'check_write_permission',
-            'POST /pricing-assignments/batch' => 'check_read_permission',
+			'POST /pricing-assignments/batch'     => 'check_read_permission',
             'POST /products/import-pricing/batch' => 'check_write_permission',
         );
 

--- a/tests/fixtures/pricing-assignment-batch-v1-golden.json
+++ b/tests/fixtures/pricing-assignment-batch-v1-golden.json
@@ -12,9 +12,9 @@
     "type": "percentage",
     "profit_percent": "30",
     "source": "global_default",
-    "revision": "sha256:fixture-default-markup",
+    "revision": "sha256:e1d7fcacade8a8c44486ae63e7ab3188205ac8135c1cb5c60d8e71e715b9f87e",
     "updated_at": "2026-07-16 12:00:00",
-    "updated_by": 1,
+    "updated_by": 0,
     "storage_present": true,
     "bounds": {
       "minimum": "0",
@@ -31,11 +31,8 @@
         "code": "113007045",
         "import_freight_method_id": "air_express",
         "profit_percent": "30",
-        "pricing_warnings": [],
-        "markup": {
-          "profit_percent": "30",
-          "warning": null
-        }
+        "profit_percent_source": "global_default",
+        "pricing_warnings": []
       }
     },
     {
@@ -43,7 +40,6 @@
       "status": "error",
       "error": {
         "code": "digitalogic_product_code_not_found",
-        "message": "No product has that exact Patris Code or SKU.",
         "http_status": 404,
         "retryable": false
       }

--- a/tests/fixtures/pricing-assignment-batch-v1-golden.json
+++ b/tests/fixtures/pricing-assignment-batch-v1-golden.json
@@ -1,0 +1,52 @@
+{
+  "schema": "digitalogic.pricing-assignment-batch",
+  "schema_version": "1.0.0",
+  "requested_count": 2,
+  "resolved_count": 1,
+  "error_count": 1,
+  "maximum_codes": 500,
+  "default_percentage_markup": {
+    "schema": "digitalogic.default-percentage-markup",
+    "schema_version": "1.0.0",
+    "configured": true,
+    "type": "percentage",
+    "profit_percent": "30",
+    "source": "global_default",
+    "revision": "sha256:fixture-default-markup",
+    "updated_at": "2026-07-16 12:00:00",
+    "updated_by": 1,
+    "storage_present": true,
+    "bounds": {
+      "minimum": "0",
+      "maximum": "1000",
+      "maximum_fraction_digits": 12
+    },
+    "warnings": []
+  },
+  "results": [
+    {
+      "code": "113007045",
+      "status": "ok",
+      "assignment": {
+        "code": "113007045",
+        "import_freight_method_id": "air_express",
+        "profit_percent": "30",
+        "pricing_warnings": [],
+        "markup": {
+          "profit_percent": "30",
+          "warning": null
+        }
+      }
+    },
+    {
+      "code": "MISSING",
+      "status": "error",
+      "error": {
+        "code": "digitalogic_product_code_not_found",
+        "message": "No product has that exact Patris Code or SKU.",
+        "http_status": 404,
+        "retryable": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
﻿Refs #59. Dedicated least-privilege machine authentication remains tracked by #60, so #59 must stay open.

## Summary
- adds the single current read-only `digitalogic.pricing-assignment-batch` service shape with a hard 500-Code bound and no alternate parser or route negotiation, strict ordered-list input, deterministic request-order results, collision-safe shared resolution, and typed per-Code errors
- returns a deliberately minimal stable assignment projection: requested Code, method ID, exact `profit_percent`, source, and warnings; unavailable source/reference keys are omitted, JSON `null` is preserved only when explicitly supplied upstream, and localized errors or internal WooCommerce identities are not exposed
- reads the default markup exactly once and never invokes migration or writes products, assignments, prices, options, events, transactions, or locks, including on a cold/unmigrated request
- exposes the same service through the command dispatcher, `POST /pricing-assignments/batch` under the existing read permission, and WP-CLI
- adds the exact cross-project golden fixture consumed by atomicdeploy/patris-export#142 and documents auth and rollout sequencing

## Verification
- full import-freight service + REST permission files: 71 tests, 575 assertions
- all non-WebSocket test files on Windows: 116 tests, 858 assertions
- cold/unmigrated no-write regression and whole-response golden fixture assertions: pass
- repository PHPCS debt guard: 43,221 errors / 3,016 warnings, exactly at the allowed baseline (no increase)
- PHP syntax checks: pass for all touched PHP files
- `composer validate --strict --no-check-publish`: pass
- `git diff --check`: pass
- shared fixture SHA-256: `f56e4ce23c4e461e3676b79f743a5dc3182086cf40caa27fab325fc03750daa0`
- local full-suite limitation: the Windows host lacks `STREAM_PF_UNIX` for one pre-existing WebSocket test and the interactive WebSocket CLI test blocks by design; GitHub Linux CI remains authoritative
- local `composer audit --locked` could not reach Packagist's advisory endpoint (curl timeout); networked CI is authoritative

## Auth and sequencing
The route uses `check_read_permission`: `manage_woocommerce` or an exact boolean grant from `digitalogic_rest_api_permission` for `scope=read`. It does not reuse either Patris write secret. Merge/deploy this endpoint before enabling Patris's default batch path. #60 supplies the dedicated header-only, route-scoped read credential needed for a least-privilege machine identity.

