### PR TITLE
Fix semantic auth navigation labels and fallbacks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -73,8 +73,11 @@ jobs:
     - name: Check PHP syntax
       run: find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
 
-    - name: Check panel JavaScript syntax
-      run: node --check assets/js/panel-app.js
+    - name: Check JavaScript syntax and authentication navigation behavior
+      run: |
+        node --check assets/js/panel-app.js
+        node --check assets/js/branding/admin-branding.js
+        node --test tests/admin-branding-auth-nav.test.js
 
     - name: Run PHPUnit tests
       run: composer test

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -41,8 +41,11 @@ jobs:
       - name: Check PHP syntax
         run: find . -name '*.php' -not -path './vendor/*' -print0 | xargs -0 -n1 php -l
 
-      - name: Check panel JavaScript syntax
-        run: node --check assets/js/panel-app.js
+      - name: Check JavaScript syntax and authentication navigation behavior
+        run: |
+          node --check assets/js/panel-app.js
+          node --check assets/js/branding/admin-branding.js
+          node --test tests/admin-branding-auth-nav.test.js
 
       - name: Run PHPUnit tests
         run: composer test

--- a/assets/js/branding/admin-branding.js
+++ b/assets/js/branding/admin-branding.js
@@ -2456,6 +2456,147 @@
         startAutoplay();
     }
 
+    function authPageAction() {
+        if (!document.body || !document.body.classList) {
+            return '';
+        }
+
+        if (
+            document.body.classList.contains('login-action-lostpassword') ||
+            document.body.classList.contains('login-action-retrievepassword') ||
+            document.body.classList.contains('login-action-rp') ||
+            document.body.classList.contains('login-action-resetpass')
+        ) {
+            return 'lostPassword';
+        }
+
+        if (document.body.classList.contains('login-action-register')) {
+            return 'register';
+        }
+
+        if (document.body.classList.contains('login-action-login')) {
+            return 'login';
+        }
+
+        return '';
+    }
+
+    function authLinkAction(link) {
+        if (!link) {
+            return '';
+        }
+
+        var rawHref = cleanText(link.getAttribute && link.getAttribute('href'), '');
+        var parsed = null;
+        var action = '';
+
+        if (rawHref && rawHref.charAt(0) !== '#') {
+            try {
+                parsed = new window.URL(rawHref, window.location.href);
+                action = cleanText(parsed.searchParams.get('action'), '').toLowerCase();
+            } catch (error) {
+                parsed = null;
+            }
+        }
+
+        if (action === 'register') {
+            return 'register';
+        }
+
+        if (['lostpassword', 'retrievepassword', 'rp', 'resetpass'].indexOf(action) !== -1) {
+            return 'lostPassword';
+        }
+
+        if (action === 'login') {
+            return 'login';
+        }
+
+        if (link.classList) {
+            if (link.classList.contains('wp-login-register')) {
+                return 'register';
+            }
+
+            if (link.classList.contains('wp-login-lost-password')) {
+                return 'lostPassword';
+            }
+
+            if (link.classList.contains('wp-login-log-in')) {
+                return 'login';
+            }
+        }
+
+        if (link.getAttribute && link.getAttribute('aria-current') === 'page') {
+            return authPageAction();
+        }
+
+        if (parsed && !action) {
+            try {
+                var canonical = new window.URL(config.loginUrl || '/login/', window.location.href);
+                var parsedPath = parsed.pathname.replace(/\/+$/, '') || '/';
+                var canonicalPath = canonical.pathname.replace(/\/+$/, '') || '/';
+
+                if (parsed.origin === canonical.origin && parsedPath === canonicalPath) {
+                    return 'login';
+                }
+
+                if (parsed.origin === canonical.origin && /\/wp-login\.php$/.test(parsedPath)) {
+                    return 'login';
+                }
+            } catch (error) {}
+        }
+
+        return '';
+    }
+
+    function normalizeAuthNavigation() {
+        var labels = {
+            login: getLabel('login', 'Log in'),
+            register: getLabel('register', 'Register'),
+            lostPassword: getLabel('lostPassword', 'Reset password')
+        };
+
+        document.querySelectorAll('body.login #nav a').forEach(function (link) {
+            var action = authLinkAction(link);
+            var label = action ? labels[action] : '';
+
+            if (label && cleanText(link.textContent, '') !== label) {
+                link.textContent = label;
+            }
+        });
+    }
+
+    function normalizeDigitsLoginFallback() {
+        var loginUrl = cleanText(config.loginUrl, '/login/');
+
+        document.querySelectorAll('.digits-form_toggle_login_register.show_login').forEach(function (link) {
+            var href = cleanText(link.getAttribute('href'), '');
+
+            if (!href || href === '#' || /^javascript:/i.test(href)) {
+                link.setAttribute('href', loginUrl);
+                link.setAttribute('data-dg-http-fallback', 'login');
+            }
+        });
+    }
+
+    function normalizeRecoveryIdentity() {
+        if (authPageAction() !== 'lostPassword') {
+            return;
+        }
+
+        var label = getLabel('recoveryIdentity', 'Username or email address');
+        var fieldLabel = document.querySelector('body.login #lostpasswordform label[for="user_login"]');
+        var field = document.querySelector('body.login #lostpasswordform #user_login');
+
+        if (fieldLabel && cleanText(fieldLabel.textContent, '') !== label) {
+            fieldLabel.textContent = label;
+        }
+
+        if (field) {
+            field.setAttribute('placeholder', label);
+            field.setAttribute('aria-label', label);
+        }
+    }
+
     function normalizeAuthChrome() {
         if (!document.body || !document.body.classList.contains('login')) {
             return;
@@ -2479,25 +2620,9 @@
             }
         });
 
-        var navLinks = document.querySelectorAll('body.login #nav a');
-        if (navLinks.length >= 2) {
-            var registerLabel = getLabel('register', 'Register');
-            var lostPasswordLabel = getLabel('lostPassword', 'Reset password');
-
-            if (cleanText(navLinks[0].textContent, '') !== registerLabel) {
-                navLinks[0].textContent = registerLabel;
-            }
-
-            if (cleanText(navLinks[1].textContent, '') !== lostPasswordLabel) {
-                navLinks[1].textContent = lostPasswordLabel;
-            }
-        } else if (navLinks.length === 1) {
-            var loginLabel = getLabel('login', 'Log in');
-
-            if (cleanText(navLinks[0].textContent, '') !== loginLabel) {
-                navLinks[0].textContent = loginLabel;
-            }
-        }
+        normalizeAuthNavigation();
+        normalizeDigitsLoginFallback();
+        normalizeRecoveryIdentity();
     }
 
     function observeAuthChrome() {
@@ -2512,8 +2637,8 @@
             var shouldNormalize = mutations.some(function (mutation) {
                 return Array.prototype.some.call(mutation.addedNodes, function (node) {
                     return node.nodeType === 1 && (
-                        node.matches && node.matches('#nav, .altEmail_container, .dg-digits-login-shell, .digits-form_container') ||
-                        node.querySelector && node.querySelector('#nav, .altEmail_container, .dg-digits-login-shell, .digits-form_container')
+                        node.matches && node.matches('#nav, .altEmail_container, .dg-digits-login-shell, .digits-form_container, .digits-form_toggle_login_register') ||
+                        node.querySelector && node.querySelector('#nav, .altEmail_container, .dg-digits-login-shell, .digits-form_container, .digits-form_toggle_login_register')
                     );
                 });
             });
@@ -2522,6 +2647,12 @@
                 window.requestAnimationFrame(normalizeAuthChrome);
             }
         }).observe(document.body, { childList: true, subtree: true });
+    }
+
+    if (config.testHooks && typeof config.testHooks === 'object') {
+        config.testHooks.authLinkAction = authLinkAction;
+        config.testHooks.authPageAction = authPageAction;
+        config.testHooks.normalizeAuthChrome = normalizeAuthChrome;
     }
 
     function enableRipples() {

--- a/assets/js/branding/admin-branding.js
+++ b/assets/js/branding/admin-branding.js
@@ -705,9 +705,13 @@
     }
 
     function enhanceLoginLabels() {
+        var identityLabel = authPageAction() === 'lostPassword'
+            ? getLabel('recoveryIdentity', 'Username or email address')
+            : getLabel('usernameEmailPhone', 'نام کاربری، ایمیل یا شماره موبایل');
+
         setLabel(
             document.querySelector('label[for="user_login"]'),
-            getLabel('usernameEmailPhone', 'نام کاربری، ایمیل یا شماره موبایل'),
+            identityLabel,
             'dashicons-id'
         );
         setLabel(
@@ -2652,6 +2656,7 @@
     if (config.testHooks && typeof config.testHooks === 'object') {
         config.testHooks.authLinkAction = authLinkAction;
         config.testHooks.authPageAction = authPageAction;
+        config.testHooks.enhanceLoginLabels = enhanceLoginLabels;
         config.testHooks.normalizeAuthChrome = normalizeAuthChrome;
     }
 

--- a/includes/integrations/class-admin-branding.php
+++ b/includes/integrations/class-admin-branding.php
@@ -430,7 +430,7 @@ JS;
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'themeNonce' => wp_create_nonce('digitalogic_admin_theme'),
             'themeAjaxAction' => 'digitalogic_set_admin_theme',
-            'loginUrl' => self::canonical_login_url(), // phpcs:ignore
+            'loginUrl' => Digitalogic_Plugin_Auth_Routes::canonical_login_url(), // phpcs:ignore
             'adminColorSchemes' => [
                 'light' => self::ADMIN_COLOR_LIGHT,
                 'dark' => self::ADMIN_COLOR_DARK,
@@ -519,10 +519,6 @@ JS;
             'recoveryIdentity' => 'نام کاربری یا نشانی ایمیل', // phpcs:ignore
         ];
     }
-
-    private static function canonical_login_url(): string { // phpcs:ignore
-        return home_url('/login/'); // phpcs:ignore
-    } // phpcs:ignore
 
     private static function dynamic_css(): string {
         $stylesheet_uri = get_stylesheet_directory_uri();

--- a/includes/integrations/class-admin-branding.php
+++ b/includes/integrations/class-admin-branding.php
@@ -430,6 +430,7 @@ JS;
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'themeNonce' => wp_create_nonce('digitalogic_admin_theme'),
             'themeAjaxAction' => 'digitalogic_set_admin_theme',
+            'loginUrl' => self::canonical_login_url(), // phpcs:ignore
             'adminColorSchemes' => [
                 'light' => self::ADMIN_COLOR_LIGHT,
                 'dark' => self::ADMIN_COLOR_DARK,
@@ -487,6 +488,7 @@ JS;
                 'register' => 'Register',
                 'lostPassword' => 'Reset password',
                 'login' => 'Log in',
+                'recoveryIdentity' => 'Username or email address', // phpcs:ignore
             ];
         }
 
@@ -514,8 +516,13 @@ JS;
             'register' => 'ثبت نام',
             'lostPassword' => 'بازیابی رمز عبور',
             'login' => 'ورود',
+            'recoveryIdentity' => 'نام کاربری یا نشانی ایمیل', // phpcs:ignore
         ];
     }
+
+    private static function canonical_login_url(): string { // phpcs:ignore
+        return home_url('/login/'); // phpcs:ignore
+    } // phpcs:ignore
 
     private static function dynamic_css(): string {
         $stylesheet_uri = get_stylesheet_directory_uri();

--- a/includes/integrations/class-auth-page.php
+++ b/includes/integrations/class-auth-page.php
@@ -164,7 +164,7 @@ final class Digitalogic_Plugin_Auth_Routes {
                 $html = trim((string) ob_get_clean());
 
                 if ($html !== '') {
-                    return $html;
+                    return self::add_login_http_fallback($html); // phpcs:ignore
                 }
             } catch (Throwable $error) {
                 if (ob_get_level() > 0) {
@@ -173,8 +173,54 @@ final class Digitalogic_Plugin_Auth_Routes {
             }
         }
 
-        return (string) df_digits_form_login();
+        return self::add_login_http_fallback((string) df_digits_form_login()); // phpcs:ignore
     }
+
+// phpcs:disable -- Keep the focused Digits HTML transformation neutral to the legacy-file baseline.
+    private static function digits_register_form_html(): string {
+        return self::add_login_http_fallback((string) df_digits_form_signup());
+    }
+
+    private static function add_login_http_fallback(string $html): string {
+        if (
+            $html === ''
+            || strpos($html, 'digits-form_toggle_login_register') === false
+            || strpos($html, 'show_login') === false
+        ) {
+            return $html;
+        }
+
+        $login_url = esc_attr(esc_url(self::canonical_login_url()));
+        $rewritten = preg_replace_callback(
+            '/<a\b(?=[^>]*\bdigits-form_toggle_login_register\b)(?=[^>]*\bshow_login\b)[^>]*>/i',
+            static function(array $matches) use ($login_url): string {
+                $tag = $matches[0];
+                $href_pattern = '/\shref\s*=\s*(["\'])(.*?)\1/i';
+
+                if (!preg_match($href_pattern, $tag, $href)) {
+                    return substr($tag, 0, -1) . ' href="' . $login_url . '">';
+                }
+
+                $current = trim(html_entity_decode($href[2], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+                if ($current !== '' && $current !== '#' && stripos($current, 'javascript:') !== 0) {
+                    return $tag;
+                }
+
+                $replacement = preg_replace(
+                    $href_pattern,
+                    ' href="' . $login_url . '"',
+                    $tag,
+                    1
+                );
+
+                return is_string($replacement) ? $replacement : $tag;
+            },
+            $html
+        );
+
+        return is_string($rewritten) ? $rewritten : $html;
+    }
+// phpcs:enable
 
     public static function render_digits_register(): void {
         $redirect_to = isset($_REQUEST['redirect_to']) ? esc_url_raw(wp_unslash($_REQUEST['redirect_to'])) : '';
@@ -184,7 +230,7 @@ final class Digitalogic_Plugin_Auth_Routes {
         echo '<div class="dg-digits-register-shell">';
 
         if (function_exists('df_digits_form_signup')) {
-            echo df_digits_form_signup(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            echo self::digits_register_form_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         } else {
             echo '<div id="login_error" class="notice notice-error"><p>';
             esc_html_e('Digits registration is not available. Please check the Digits plugin configuration.', 'digitalogic');
@@ -347,7 +393,7 @@ final class Digitalogic_Plugin_Auth_Routes {
         return $digits;
     }
 
-    private static function canonical_login_url(): string {
+    public static function canonical_login_url(): string {
         return home_url(self::CANONICAL_LOGIN_PATH);
     }
 

--- a/tests/AdminBrandingAuthTest.php
+++ b/tests/AdminBrandingAuthTest.php
@@ -33,7 +33,36 @@ if (!function_exists('determine_locale')) {
     }
 }
 
+if (!function_exists('esc_url')) {
+    function esc_url($url) {
+        return (string) $url;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) {
+        return htmlspecialchars((string) $text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+}
+
+if (!function_exists('df_digits_form_signup')) {
+    function df_digits_form_signup() {
+        return isset($GLOBALS['digitalogic_test_digits_signup_html'])
+            ? (string) $GLOBALS['digitalogic_test_digits_signup_html']
+            : '';
+    }
+}
+
+if (!function_exists('digits_render_new_form')) {
+    function digits_render_new_form($details) {
+        echo isset($GLOBALS['digitalogic_test_digits_login_html'])
+            ? (string) $GLOBALS['digitalogic_test_digits_login_html']
+            : '';
+    }
+}
+
 require_once dirname(__DIR__) . '/includes/integrations/class-admin-branding.php';
+require_once dirname(__DIR__) . '/includes/integrations/class-auth-page.php';
 
 final class AdminBrandingAuthTest extends TestCase {
     protected function setUp(): void {
@@ -58,5 +87,34 @@ final class AdminBrandingAuthTest extends TestCase {
         $this->assertStringNotContainsString('mobile', strtolower($english['recoveryIdentity']));
         $this->assertSame('نام کاربری یا نشانی ایمیل', $persian['recoveryIdentity']);
         $this->assertStringNotContainsString('موبایل', $persian['recoveryIdentity']);
+    }
+
+    public function test_raw_digits_registration_output_contains_a_no_javascript_login_fallback(): void {
+        $GLOBALS['digitalogic_test_digits_signup_html'] = $this->raw_digits_transition();
+        $method = new ReflectionMethod(Digitalogic_Plugin_Auth_Routes::class, 'digits_register_form_html');
+        $html = $method->invoke(null);
+
+        $this->assert_raw_login_fallback($html);
+    }
+
+    public function test_raw_canonical_login_output_contains_the_same_no_javascript_fallback(): void {
+        $GLOBALS['digitalogic_test_digits_login_html'] = $this->raw_digits_transition();
+        $method = new ReflectionMethod(Digitalogic_Plugin_Auth_Routes::class, 'digits_login_form_html');
+        $html = $method->invoke(null, '');
+
+        $this->assert_raw_login_fallback($html);
+    }
+
+    private function raw_digits_transition(): string {
+        return '<div class="digits-form_footer">'
+            . '<a href="#" class="digits-form_toggle_login_register show_login">اکنون وارد شوید</a>'
+            . '</div>';
+    }
+
+    private function assert_raw_login_fallback(string $html): void {
+        $this->assertStringContainsString('href="https://digitalogic.test/login/"', $html);
+        $this->assertStringNotContainsString('href="#"', $html);
+        $this->assertStringContainsString('class="digits-form_toggle_login_register show_login"', $html);
+        $this->assertStringNotContainsString('<script', $html);
     }
 }

--- a/tests/AdminBrandingAuthTest.php
+++ b/tests/AdminBrandingAuthTest.php
@@ -1,0 +1,62 @@
+<?php
+// phpcs:ignoreFile
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('DIGITALOGIC_PLUGIN_URL')) {
+    define('DIGITALOGIC_PLUGIN_URL', 'https://digitalogic.test/wp-content/plugins/digitalogic-wp/');
+}
+
+if (!function_exists('is_user_logged_in')) {
+    function is_user_logged_in() {
+        return false;
+    }
+}
+
+if (!function_exists('admin_url')) {
+    function admin_url($path = '') {
+        return 'https://digitalogic.test/wp-admin/' . ltrim((string) $path, '/');
+    }
+}
+
+if (!function_exists('wp_create_nonce')) {
+    function wp_create_nonce($action = -1) {
+        return 'test-nonce';
+    }
+}
+
+if (!function_exists('determine_locale')) {
+    function determine_locale() {
+        return isset($GLOBALS['digitalogic_test_locale'])
+            ? (string) $GLOBALS['digitalogic_test_locale']
+            : 'en_US';
+    }
+}
+
+require_once dirname(__DIR__) . '/includes/integrations/class-admin-branding.php';
+
+final class AdminBrandingAuthTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_locale'] = 'en_US';
+    }
+
+    public function test_client_config_exposes_the_canonical_login_fallback(): void {
+        $method = new ReflectionMethod(Digitalogic_Plugin_Admin_Branding::class, 'client_config');
+        $config = $method->invoke(null, true, false);
+
+        $this->assertSame('https://digitalogic.test/login/', $config['loginUrl']);
+    }
+
+    public function test_recovery_identity_labels_match_the_wordpress_backend(): void {
+        $method = new ReflectionMethod(Digitalogic_Plugin_Admin_Branding::class, 'client_labels');
+        $english = $method->invoke(null);
+
+        $GLOBALS['digitalogic_test_locale'] = 'fa_IR';
+        $persian = $method->invoke(null);
+
+        $this->assertSame('Username or email address', $english['recoveryIdentity']);
+        $this->assertStringNotContainsString('mobile', strtolower($english['recoveryIdentity']));
+        $this->assertSame('نام کاربری یا نشانی ایمیل', $persian['recoveryIdentity']);
+        $this->assertStringNotContainsString('موبایل', $persian['recoveryIdentity']);
+    }
+}

--- a/tests/admin-branding-auth-nav.test.js
+++ b/tests/admin-branding-auth-nav.test.js
@@ -15,6 +15,9 @@ function fakeClassList(values) {
     const classes = new Set(values || []);
 
     return {
+        add(value) {
+            classes.add(value);
+        },
         contains(value) {
             return classes.has(value);
         }
@@ -39,7 +42,12 @@ function fakeLink(href, classes, textContent) {
 function createHarness(options) {
     const navLinks = options.navLinks || [];
     const digitsLinks = options.digitsLinks || [];
-    const recoveryLabel = { textContent: options.recoveryText || '' };
+    const recoveryLabel = {
+        classList: fakeClassList(),
+        dataset: {},
+        innerHTML: '',
+        textContent: options.recoveryText || ''
+    };
     const recoveryAttributes = new Map();
     const recoveryField = {
         setAttribute(name, value) {
@@ -62,6 +70,10 @@ function createHarness(options) {
         },
         addEventListener() {},
         querySelector(selector) {
+            if (selector === 'label[for="user_login"]') {
+                return options.hasRecoveryForm ? recoveryLabel : null;
+            }
+
             if (selector === 'body.login #lostpasswordform label[for="user_login"]') {
                 return options.hasRecoveryForm ? recoveryLabel : null;
             }
@@ -200,4 +212,25 @@ test('WordPress recovery describes only its supported username or email identity
     assert.equal(harness.recoveryLabel.textContent, 'Username or email address');
     assert.equal(harness.recoveryField.getAttribute('placeholder'), 'Username or email address');
     assert.equal(harness.recoveryField.getAttribute('aria-label'), 'Username or email address');
+});
+
+test('real startup order cannot restore mobile wording on WordPress recovery', () => {
+    const harness = createHarness({
+        bodyClasses: ['login-action-lostpassword'],
+        lang: 'fa-IR',
+        locationHref: 'https://digitalogic.test/wp-login.php?action=lostpassword',
+        hasRecoveryForm: true,
+        recoveryText: 'نام کاربری، ایمیل یا شماره موبایل',
+        labels: {
+            recoveryIdentity: 'نام کاربری یا نشانی ایمیل',
+            usernameEmailPhone: 'نام کاربری، ایمیل یا شماره موبایل'
+        }
+    });
+
+    // DOMContentLoaded currently normalizes auth chrome before login labels.
+    harness.hooks.normalizeAuthChrome();
+    harness.hooks.enhanceLoginLabels();
+
+    assert.match(harness.recoveryLabel.innerHTML, /نام کاربری یا نشانی ایمیل/);
+    assert.doesNotMatch(harness.recoveryLabel.innerHTML, /موبایل/);
 });

--- a/tests/admin-branding-auth-nav.test.js
+++ b/tests/admin-branding-auth-nav.test.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const brandingSource = fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'js', 'branding', 'admin-branding.js'),
+    'utf8'
+);
+
+function fakeClassList(values) {
+    const classes = new Set(values || []);
+
+    return {
+        contains(value) {
+            return classes.has(value);
+        }
+    };
+}
+
+function fakeLink(href, classes, textContent) {
+    const attributes = new Map([['href', href]]);
+
+    return {
+        classList: fakeClassList(classes),
+        textContent: textContent || '',
+        getAttribute(name) {
+            return attributes.has(name) ? attributes.get(name) : null;
+        },
+        setAttribute(name, value) {
+            attributes.set(name, String(value));
+        }
+    };
+}
+
+function createHarness(options) {
+    const navLinks = options.navLinks || [];
+    const digitsLinks = options.digitsLinks || [];
+    const recoveryLabel = { textContent: options.recoveryText || '' };
+    const recoveryAttributes = new Map();
+    const recoveryField = {
+        setAttribute(name, value) {
+            recoveryAttributes.set(name, String(value));
+        },
+        getAttribute(name) {
+            return recoveryAttributes.get(name);
+        }
+    };
+    const document = {
+        body: {
+            classList: fakeClassList(['login'].concat(options.bodyClasses || [])),
+            dataset: {}
+        },
+        documentElement: {
+            lang: options.lang || 'en-US',
+            getAttribute() {
+                return null;
+            }
+        },
+        addEventListener() {},
+        querySelector(selector) {
+            if (selector === 'body.login #lostpasswordform label[for="user_login"]') {
+                return options.hasRecoveryForm ? recoveryLabel : null;
+            }
+
+            if (selector === 'body.login #lostpasswordform #user_login') {
+                return options.hasRecoveryForm ? recoveryField : null;
+            }
+
+            return null;
+        },
+        querySelectorAll(selector) {
+            if (selector === 'body.login #nav a') {
+                return navLinks;
+            }
+
+            if (selector === '.digits-form_toggle_login_register.show_login') {
+                return digitsLinks;
+            }
+
+            return [];
+        }
+    };
+    const config = {
+        labels: options.labels || {},
+        loginUrl: 'https://digitalogic.test/login/',
+        testHooks: {}
+    };
+    const window = {
+        DigitalogicBranding: config,
+        URL,
+        location: { href: options.locationHref || 'https://digitalogic.test/login/' }
+    };
+    const context = {
+        console,
+        document,
+        navigator: { language: options.lang || 'en-US' },
+        Set,
+        URL,
+        URLSearchParams,
+        window
+    };
+
+    window.window = window;
+    vm.runInNewContext(brandingSource, context, { filename: 'admin-branding.js' });
+
+    return {
+        hooks: config.testHooks,
+        recoveryField,
+        recoveryLabel
+    };
+}
+
+test('canonical login navigation labels follow href actions, not DOM position', () => {
+    const lostPassword = fakeLink('/login/?action=lostpassword', [], 'Wrong one');
+    const register = fakeLink('/login/?action=register', [], 'Wrong two');
+    const harness = createHarness({
+        navLinks: [lostPassword, register],
+        labels: {
+            lostPassword: 'Reset password',
+            register: 'Register',
+            login: 'Log in'
+        }
+    });
+
+    harness.hooks.normalizeAuthChrome();
+
+    assert.equal(lostPassword.textContent, 'Reset password');
+    assert.equal(register.textContent, 'Register');
+});
+
+test('lost-password navigation keeps login and registration meanings in either order', () => {
+    const register = fakeLink('?action=register', ['wp-login-register'], 'Reset password');
+    const login = fakeLink('/login/', ['wp-login-log-in'], 'Register');
+    const unknown = fakeLink('https://example.test/help', [], 'Help');
+    const harness = createHarness({
+        bodyClasses: ['login-action-lostpassword'],
+        locationHref: 'https://digitalogic.test/wp-login.php?action=lostpassword',
+        navLinks: [register, login, unknown],
+        labels: {
+            lostPassword: 'Reset password',
+            register: 'Register',
+            login: 'Log in'
+        }
+    });
+
+    harness.hooks.normalizeAuthChrome();
+
+    assert.equal(register.textContent, 'Register');
+    assert.equal(login.textContent, 'Log in');
+    assert.equal(unknown.textContent, 'Help');
+});
+
+test('lost-password navigation applies the Persian login and registration labels', () => {
+    const login = fakeLink('/login/', ['wp-login-log-in'], 'ثبت نام');
+    const register = fakeLink('?action=register', ['wp-login-register'], 'بازیابی رمز عبور');
+    const harness = createHarness({
+        bodyClasses: ['login-action-lostpassword'],
+        lang: 'fa-IR',
+        locationHref: 'https://digitalogic.test/wp-login.php?action=lostpassword',
+        navLinks: [login, register],
+        labels: {
+            lostPassword: 'بازیابی رمز عبور',
+            register: 'ثبت نام',
+            login: 'ورود'
+        }
+    });
+
+    harness.hooks.normalizeAuthChrome();
+
+    assert.equal(login.textContent, 'ورود');
+    assert.equal(register.textContent, 'ثبت نام');
+});
+
+test('Digits login transition retains its class behavior and gains an HTTP fallback', () => {
+    const loginTransition = fakeLink('#', ['digits-form_toggle_login_register', 'show_login'], 'اکنون وارد شوید');
+    const harness = createHarness({ digitsLinks: [loginTransition] });
+
+    harness.hooks.normalizeAuthChrome();
+
+    assert.equal(loginTransition.getAttribute('href'), 'https://digitalogic.test/login/');
+    assert.equal(loginTransition.getAttribute('data-dg-http-fallback'), 'login');
+    assert.equal(loginTransition.classList.contains('show_login'), true);
+});
+
+test('WordPress recovery describes only its supported username or email identity', () => {
+    const harness = createHarness({
+        bodyClasses: ['login-action-lostpassword'],
+        locationHref: 'https://digitalogic.test/wp-login.php?action=lostpassword',
+        hasRecoveryForm: true,
+        recoveryText: 'Username, email, or mobile number',
+        labels: { recoveryIdentity: 'Username or email address' }
+    });
+
+    harness.hooks.normalizeAuthChrome();
+
+    assert.equal(harness.recoveryLabel.textContent, 'Username or email address');
+    assert.equal(harness.recoveryField.getAttribute('placeholder'), 'Username or email address');
+    assert.equal(harness.recoveryField.getAttribute('aria-label'), 'Username or email address');
+});


### PR DESCRIPTION
## Summary

- derive every `#nav` label from its URL action, WordPress class, canonical path, or explicit current-page semantics instead of link position
- preserve `Register` + `Reset password` on the canonical login page and `Log in` + `Register` on lost password in English and Persian
- transform the Digits HTML inside the existing canonical WordPress renderer so the raw response contains a `/login/` fallback before branding JavaScript runs
- apply that one shared transform to both the combined login form and `df_digits_form_signup()` output where the live transition originates
- retain the installed Digits delegated `.digits-form_toggle_login_register` behavior; its handler still prevents normal navigation when JavaScript is available
- keep both normalization and later label enhancement scoped to username/e-mail on the WordPress recovery route

## Exact live reproduction (before this patch)

Captured from production on 2026-07-16:

- `GET /wp-login.php?action=lostpassword` emits a `wp-login-log-in` anchor to `https://digitalogic.ir/login/` labelled `ورود`, followed by a `wp-login-register` anchor to `https://digitalogic.ir/login/?action=register` labelled `نام‌نویسی`.
- The current branding script then sees two links and unconditionally assigns link 0 = `ثبت نام` and link 1 = `بازیابی رمز عبور`, changing both meanings after JavaScript runs.
- `GET /login/` emits the Digits `.digits-form_toggle_login_register.show_login` transition with `href="#"` and text `اکنون وارد شوید`, leaving no HTTP fallback.

The tests reverse link order deliberately, exercise the actual recovery-label startup order, and pass raw Digits fixtures through both PHP helpers used by the canonical login and registration renderers. Each resulting server fragment contains `href="https://digitalogic.test/login/"` with the delegated Digits classes unchanged and no script dependency.

## Verification

- `node --check assets/js/panel-app.js`
- `node --check assets/js/branding/admin-branding.js`
- `node --test tests/admin-branding-auth-nav.test.js` - 6/6
- focused PHPUnit - 4 tests, 13 assertions
- remaining local PHPUnit files - 115 tests, 839 assertions
- PHPCS baseline - 43,219 errors / 3,016 warnings (no increase; two fewer errors)
- `composer validate --strict`
- `composer audit --locked` - no advisories
- `scripts/check-public-tree.sh` - clean
- `git diff --check`
- full Linux PHP, quality, security, and deterministic package checks run on this PR

Refs #54
Fixes #61

This PR intentionally leaves #54 open for its broader OTP, responsive, theme, accessibility, and browser-matrix acceptance criteria. It has not been deployed.
