### PR TITLE
Add scoped Patris pricing-input credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ curl -X POST https://yoursite.com/wp-json/digitalogic/v1/products/batch \
 
 #### Import Freight Integration
 - `GET /wp-json/digitalogic/v1/integration/catalog` - Read the versioned pricing/freight catalog
+- `POST /wp-json/digitalogic/v1/pricing-assignments/batch` - Read a bounded ordered Code assignment projection
 - `GET|POST /wp-json/digitalogic/v1/import-freight-methods` - List or create supplier import methods
 - `GET|PUT|DELETE /wp-json/digitalogic/v1/import-freight-methods/{id}` - Manage an immutable method ID
 - `GET|PUT /wp-json/digitalogic/v1/products/by-code/{code}/import-pricing` - Read or assign by exact Patris Code/SKU
@@ -198,6 +199,13 @@ The plugin uses WooCommerce REST API authentication:
 1. Go to WooCommerce → Settings → Advanced → REST API
 2. Create API keys (consumer key & secret)
 3. Use Basic Auth with consumer key as username and secret as password
+
+Patris pricing uses a separate one-way, rotatable Bearer credential confined to
+`GET /integration/catalog` and `POST /pricing-assignments/batch`. See
+[Patris pricing-input machine credential](docs/PRICING-INPUT-CREDENTIAL.md) for
+administrator-only WP-CLI lifecycle commands and environment-name wiring. Do
+not reuse write, webhook, product-sync, WooCommerce consumer, or login secrets
+for this machine identity.
 
 ### Webhooks
 

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -114,6 +114,7 @@ final class Digitalogic {
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-import-export.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-unit-converter.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-identifier-resolver.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-pricing-input-credential.php'; // phpcs:ignore
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-patris-feed.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-sync-receiver.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-import-freight-service.php';

--- a/docs/IMPORT-FREIGHT-API.md
+++ b/docs/IMPORT-FREIGHT-API.md
@@ -33,8 +33,11 @@ The old free-form `shipping_methods` member of
 ## REST endpoints
 
 All routes require an authenticated identity with the plugin's read or write
-integration permission (normally `manage_woocommerce`). WooCommerce REST API
-keys may provide that identity.
+integration permission (normally `manage_woocommerce`). The catalog and bounded
+pricing-assignment batch additionally accept the dedicated header-only Patris
+pricing-input credential documented in
+[PRICING-INPUT-CREDENTIAL.md](PRICING-INPUT-CREDENTIAL.md). That machine identity
+is confined to those two exact route/method pairs.
 
 - `GET /wp-json/digitalogic/v1/integration/catalog`
 - `GET|PUT /wp-json/digitalogic/v1/pricing/default-markup`
@@ -118,13 +121,12 @@ upgrade must complete migration separately.
 }
 ```
 
-This POST is a read operation and uses `check_read_permission`: either the
-authenticated identity has `manage_woocommerce`, or the
-`digitalogic_rest_api_permission` filter returns the boolean `true` for the
-`read` scope and this exact request. It deliberately does not accept the Patris
-push token or the transformed product-sync write secret. A dedicated
-header-only, route-scoped machine read credential remains a separate hardening
-follow-up; do not grant Patris a write secret to bridge that gap.
+This POST is a read operation. A human identity with `manage_woocommerce` keeps
+normal access. Patris uses the same dedicated Bearer credential as
+`GET /integration/catalog`; the verifier itself enforces both exact route and
+method tuples. It deliberately does not accept the broad read filter, a
+WooCommerce Basic credential as the Patris machine identity, the Patris push
+token, or the transformed product-sync write secret.
 
 The same service operation is exposed as the
 `digitalogic_get_product_import_pricing_batch` command and through WP-CLI:

--- a/docs/PRICING-INPUT-CREDENTIAL.md
+++ b/docs/PRICING-INPUT-CREDENTIAL.md
@@ -1,0 +1,86 @@
+# Patris pricing-input machine credential
+
+Digitalogic exposes one least-privilege machine identity for the two read-only
+contracts needed by Patris pricing:
+
+- `GET /wp-json/digitalogic/v1/integration/catalog`
+- `POST /wp-json/digitalogic/v1/pricing-assignments/batch`
+
+The second operation uses POST only because it accepts a bounded JSON Code
+list. It does not mutate products, assignments, prices, options, events, or
+locks.
+
+The catalog GET is also strictly non-mutating. If activation/init migration has
+not run yet, it projects the canonical default freight methods in memory; it
+does not use the request to migrate or persist them.
+
+The credential is not accepted by any other route or method. It is also not a
+Patris push token, product-sync receiver secret, webhook secret, WooCommerce
+consumer key, WordPress login, panel token, or WebSocket token. Only an exact
+`Authorization: Bearer ...` header is read. Query parameters, cookies, URL
+userinfo, Basic authentication, legacy headers, and product-sync headers do not
+act as this machine identity.
+
+## Administrator lifecycle
+
+Run lifecycle commands with an explicit WordPress administrator. A shop manager
+is intentionally insufficient even though shop managers retain normal
+`manage_woocommerce` access to the two REST contracts.
+
+```bash
+wp digitalogic pricing-input-credential create --user=<administrator-login>
+wp digitalogic pricing-input-credential status --user=<administrator-login>
+wp digitalogic pricing-input-credential rotate --user=<administrator-login>
+wp digitalogic pricing-input-credential revoke --user=<administrator-login>
+```
+
+Create and rotate print the new Bearer value on the first output line exactly
+once, followed by nonsecret JSON metadata. Move that first line directly into
+the protected Patris process environment. Status and revoke output metadata
+only. Rotation and revocation invalidate the preceding value immediately.
+
+WordPress stores only a SHA-256 verifier for the high-entropy generated value,
+its nonsecret ID/generation, state, and UTC lifecycle timestamps. The verifier
+is compared in constant time. Repeated failed supplied-Authorization attempts
+are throttled in a token-free client/generation bucket; a correct credential is
+verified before that bucket and clears it, so unrelated failures cannot lock
+Patris out. Tokens are not written to application logs or throttle state.
+
+## Patris environment wiring
+
+Use a secret environment variable for the value and configure Patris by the
+variable's name. Do not put the credential in Patris JSON/TOML/YAML, source
+control, service arguments, screenshots, or shell history.
+
+```text
+PATRIS_EXPORT_DIGITALOGIC_URL=https://digitalogic.ir/wp-json/digitalogic/v1/
+PATRIS_EXPORT_DIGITALOGIC_BEARER_ENV=DIGITALOGIC_PRICING_INPUT_TOKEN
+DIGITALOGIC_PRICING_INPUT_TOKEN=<value emitted once by WP-CLI>
+```
+
+`PATRIS_EXPORT_DIGITALOGIC_BEARER_ENV` is the environment-name setting consumed
+by Patris `BearerTokenEnv`; it is not the credential itself.
+
+## Deployment canaries
+
+After deployment and protected environment configuration, verify both exact
+contracts. The examples intentionally read the token from the process
+environment and contain no literal credential.
+
+```bash
+curl -fsS \
+  -H "Authorization: Bearer ${DIGITALOGIC_PRICING_INPUT_TOKEN}" \
+  https://digitalogic.ir/wp-json/digitalogic/v1/integration/catalog
+
+curl -fsS \
+  -H "Authorization: Bearer ${DIGITALOGIC_PRICING_INPUT_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  --data '{"codes":["113001002"]}' \
+  https://digitalogic.ir/wp-json/digitalogic/v1/pricing-assignments/batch
+```
+
+Before enabling Patris, also confirm that absent and deliberately wrong Bearer
+headers are denied on both routes, and that the correct Bearer is denied on a
+representative unrelated route such as `GET /products`. After rotation, repeat
+with the old value to confirm immediate invalidation, then restart Patris with
+the new protected environment value.

--- a/docs/PRICING-INPUT-CREDENTIAL.md
+++ b/docs/PRICING-INPUT-CREDENTIAL.md
@@ -39,12 +39,22 @@ once, followed by nonsecret JSON metadata. Move that first line directly into
 the protected Patris process environment. Status and revoke output metadata
 only. Rotation and revocation invalidate the preceding value immediately.
 
+Lifecycle mutations use a bounded, site-specific MySQL advisory lock plus a
+row-locked transaction and exact readback. Create and rotate compare the
+authoritative record they observed before waiting with the record inside the
+lock, so overlapping callers cannot both reveal credentials. Revoke always
+acts on the current locked generation, which prevents a waiting rotation from
+undoing it. A secret is printed only after its transaction commits and passes
+readback; retry a reported busy or concurrent-change error as a new command.
+
 WordPress stores only a SHA-256 verifier for the high-entropy generated value,
 its nonsecret ID/generation, state, and UTC lifecycle timestamps. The verifier
 is compared in constant time. Repeated failed supplied-Authorization attempts
 are throttled in a token-free client/generation bucket; a correct credential is
 verified before that bucket and clears it, so unrelated failures cannot lock
 Patris out. Tokens are not written to application logs or throttle state.
+Verification and status bypass WordPress/Redis option caches, so a stale cached
+verifier cannot extend an old credential after rotation or revocation.
 
 ## Patris environment wiring
 

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -265,7 +265,7 @@ class Digitalogic_REST_API {
         register_rest_route('digitalogic/v1', '/integration/catalog', array(
             'methods' => 'GET',
             'callback' => array($this, 'get_integration_catalog'),
-            'permission_callback' => array($this, 'check_read_permission'),
+            'permission_callback' => array($this, 'check_pricing_input_permission'),
         ));
 
         register_rest_route('digitalogic/v1', '/pricing/default-markup', array(
@@ -331,7 +331,7 @@ class Digitalogic_REST_API {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'get_product_import_pricing_batch' ),
-				'permission_callback' => array( $this, 'check_read_permission' ),
+				'permission_callback' => array( $this, 'check_pricing_input_permission' ),
 			)
 		);
 
@@ -388,6 +388,24 @@ class Digitalogic_REST_API {
     public function check_diagnostic_permission($request = null) {
         return $this->check_scoped_permission('diagnostic', $request);
     }
+
+	/**
+	 * Authorize the two exact Patris pricing-input contracts.
+	 *
+	 * Human administrators and shop managers retain their normal capability
+	 * access. The separate machine identity is verified by its route-aware,
+	 * header-only credential service and cannot fall through to other scopes.
+	 *
+	 * @param WP_REST_Request $request Current REST request.
+	 * @return true|WP_Error
+	 */
+	public function check_pricing_input_permission( WP_REST_Request $request ) {
+		if ( current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+			return true;
+		}
+
+		return Digitalogic_Pricing_Input_Credential::instance()->authorize( $request );
+	}
 
     /**
      * Resolve a REST permission scope.

--- a/includes/class-digitalogic-pricing-input-credential.php
+++ b/includes/class-digitalogic-pricing-input-credential.php
@@ -22,6 +22,8 @@ final class Digitalogic_Pricing_Input_Credential {
 	private const FAILURE_WINDOW       = 60;
 	private const FAILURE_BLOCK_PERIOD = 300;
 	private const THROTTLE_PREFIX      = 'digitalogic_pricing_input_auth_';
+	private const LOCK_NAME            = 'digitalogic_pricing_input_credential_v1';
+	private const LOCK_TIMEOUT_SECONDS = 3;
 
 	/**
 	 * Shared service instance.
@@ -59,7 +61,11 @@ final class Digitalogic_Pricing_Input_Credential {
 			return $this->error( 'digitalogic_pricing_input_unauthorized', 401 );
 		}
 
-		$record         = $this->read_record();
+		$record_row = $this->read_record_db();
+		if ( is_wp_error( $record_row ) ) {
+			return $this->error( 'digitalogic_pricing_input_unavailable', 503 );
+		}
+		$record         = $record_row['value'];
 		$throttle_key   = $this->throttle_key( $record );
 		$throttle_state = get_transient( $throttle_key );
 
@@ -96,24 +102,40 @@ final class Digitalogic_Pricing_Input_Credential {
 	 * @return array|WP_Error Secret and nonsecret metadata, or an error.
 	 */
 	public function create() {
-		$record = $this->read_record();
-		$state  = $this->record_state( $record );
-
-		if ( 'active' === $state ) {
-			return new WP_Error(
-				'digitalogic_pricing_input_already_active',
-				'An active pricing-input credential already exists; rotate it instead.',
-				array( 'status' => 409 )
-			);
+		$observed = $this->read_record_db();
+		if ( is_wp_error( $observed ) ) {
+			return $observed;
 		}
+		$fingerprint = $this->record_fingerprint( $observed );
 
-		if ( 'invalid' === $state ) {
-			return $this->configuration_error();
-		}
+		return $this->with_lifecycle_lock(
+			function () use ( $fingerprint ) {
+				$current = $this->read_record_db();
+				if ( is_wp_error( $current ) ) {
+					return $current;
+				}
+				if ( ! hash_equals( $fingerprint, $this->record_fingerprint( $current ) ) ) {
+					return $this->concurrency_error();
+				}
 
-		$generation = 'revoked' === $state ? ( (int) $record['generation'] + 1 ) : 1;
+				$record = $current['value'];
+				$state  = $this->record_state( $record );
+				if ( 'active' === $state ) {
+					return new WP_Error(
+						'digitalogic_pricing_input_already_active',
+						'An active pricing-input credential already exists; rotate it instead.',
+						array( 'status' => 409 )
+					);
+				}
+				if ( 'invalid' === $state ) {
+					return $this->configuration_error();
+				}
 
-		return $this->issue( null, $generation, false );
+				$generation = 'revoked' === $state ? ( (int) $record['generation'] + 1 ) : 1;
+
+				return $this->issue_locked( $current, null, $generation, false );
+			}
+		);
 	}
 
 	/**
@@ -122,16 +144,34 @@ final class Digitalogic_Pricing_Input_Credential {
 	 * @return array|WP_Error Secret and nonsecret metadata, or an error.
 	 */
 	public function rotate() {
-		$record = $this->read_record();
-		if ( 'active' !== $this->record_state( $record ) ) {
-			return new WP_Error(
-				'digitalogic_pricing_input_not_active',
-				'No active pricing-input credential is available to rotate.',
-				array( 'status' => 409 )
-			);
+		$observed = $this->read_record_db();
+		if ( is_wp_error( $observed ) ) {
+			return $observed;
 		}
+		$fingerprint = $this->record_fingerprint( $observed );
 
-		return $this->issue( $record, (int) $record['generation'] + 1, true );
+		return $this->with_lifecycle_lock(
+			function () use ( $fingerprint ) {
+				$current = $this->read_record_db();
+				if ( is_wp_error( $current ) ) {
+					return $current;
+				}
+				if ( ! hash_equals( $fingerprint, $this->record_fingerprint( $current ) ) ) {
+					return $this->concurrency_error();
+				}
+
+				$record = $current['value'];
+				if ( 'active' !== $this->record_state( $record ) ) {
+					return new WP_Error(
+						'digitalogic_pricing_input_not_active',
+						'No active pricing-input credential is available to rotate.',
+						array( 'status' => 409 )
+					);
+				}
+
+				return $this->issue_locked( $current, $record, (int) $record['generation'] + 1, true );
+			}
+		);
 	}
 
 	/**
@@ -140,39 +180,50 @@ final class Digitalogic_Pricing_Input_Credential {
 	 * @return array|WP_Error Nonsecret status metadata, or an error.
 	 */
 	public function revoke() {
-		$record = $this->read_record();
-		$state  = $this->record_state( $record );
+		return $this->with_lifecycle_lock(
+			function () {
+				$current = $this->read_record_db();
+				if ( is_wp_error( $current ) ) {
+					return $current;
+				}
 
-		if ( 'revoked' === $state ) {
-			return $this->metadata( $record );
-		}
+				$record = $current['value'];
+				$state  = $this->record_state( $record );
+				if ( 'revoked' === $state ) {
+					return $this->metadata( $record );
+				}
+				if ( 'active' !== $state ) {
+					return new WP_Error(
+						'digitalogic_pricing_input_not_active',
+						'No active pricing-input credential is available to revoke.',
+						array( 'status' => 409 )
+					);
+				}
 
-		if ( 'active' !== $state ) {
-			return new WP_Error(
-				'digitalogic_pricing_input_not_active',
-				'No active pricing-input credential is available to revoke.',
-				array( 'status' => 409 )
-			);
-		}
+				$record['status']     = 'revoked';
+				$record['revoked_at'] = $this->timestamp();
+				unset( $record['verifier'] );
+				$stored = $this->persist_record_locked( $current, $record );
+				if ( is_wp_error( $stored ) ) {
+					return $stored;
+				}
 
-		$record['status']     = 'revoked';
-		$record['revoked_at'] = $this->timestamp();
-		unset( $record['verifier'] );
-
-		if ( ! update_option( self::OPTION_NAME, $record, false ) ) {
-			return $this->write_error();
-		}
-
-		return $this->metadata( $record );
+				return $this->metadata( $stored );
+			}
+		);
 	}
 
 	/**
 	 * Return only nonsecret credential metadata.
 	 *
-	 * @return array
+	 * @return array|WP_Error
 	 */
 	public function status() {
-		$record = $this->read_record();
+		$record_row = $this->read_record_db();
+		if ( is_wp_error( $record_row ) ) {
+			return $record_row;
+		}
+		$record = $record_row['value'];
 		$state  = $this->record_state( $record );
 
 		if ( 'active' === $state || 'revoked' === $state ) {
@@ -189,14 +240,15 @@ final class Digitalogic_Pricing_Input_Credential {
 	}
 
 	/**
-	 * Generate and persist a new one-way credential record.
+	 * Generate and persist a new one-way credential record while locked.
 	 *
+	 * @param array      $current    Authoritative current option row.
 	 * @param array|null $previous   Previous active record during rotation.
 	 * @param int        $generation New generation number.
 	 * @param bool       $rotation   Whether this is a rotation.
-	 * @return array|WP_Error
+	 * @return array
 	 */
-	private function issue( $previous, $generation, $rotation ) {
+	private function issue_locked( $current, $previous, $generation, $rotation ) {
 		try {
 			$credential_id = bin2hex( random_bytes( 8 ) );
 			$secret_bytes  = random_bytes( 32 );
@@ -222,13 +274,14 @@ final class Digitalogic_Pricing_Input_Credential {
 			'generation'     => (int) $generation,
 		);
 
-		if ( ! update_option( self::OPTION_NAME, $record, false ) ) {
-			return $this->write_error();
+		$stored = $this->persist_record_locked( $current, $record );
+		if ( is_wp_error( $stored ) ) {
+			return $stored;
 		}
 
 		return array(
 			'secret'   => $token,
-			'metadata' => $this->metadata( $record ),
+			'metadata' => $this->metadata( $stored ),
 		);
 	}
 
@@ -307,12 +360,272 @@ final class Digitalogic_Pricing_Input_Credential {
 	}
 
 	/**
-	 * Return the stored record without coercion.
+	 * Serialize a lifecycle operation with a bounded database advisory lock.
 	 *
-	 * @return mixed
+	 * @param callable $callback Operation performed while the lock is held.
+	 * @return mixed|WP_Error
 	 */
-	private function read_record() {
-		return get_option( self::OPTION_NAME, null );
+	private function with_lifecycle_lock( $callback ) {
+		$acquired = $this->acquire_lifecycle_lock();
+		if ( is_wp_error( $acquired ) ) {
+			return $acquired;
+		}
+
+		try {
+			return call_user_func( $callback );
+		} catch ( Throwable $error ) {
+			return $this->lifecycle_error();
+		} finally {
+			$this->release_lifecycle_lock();
+		}
+	}
+
+	/**
+	 * Acquire the credential lifecycle advisory lock.
+	 *
+	 * @return true|WP_Error
+	 */
+	private function acquire_lifecycle_lock() {
+		global $wpdb;
+
+		if ( ! is_object( $wpdb ) || ! method_exists( $wpdb, 'prepare' ) || ! method_exists( $wpdb, 'get_var' ) ) {
+			return $this->storage_error();
+		}
+
+		try {
+			$locked = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Advisory lock intentionally bypasses caches.
+				$wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $this->lifecycle_lock_name(), self::LOCK_TIMEOUT_SECONDS ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared immediately above.
+			);
+		} catch ( Throwable $error ) {
+			return $this->storage_error();
+		}
+
+		if ( '1' !== (string) $locked ) {
+			return new WP_Error(
+				'digitalogic_pricing_input_lifecycle_busy',
+				'The pricing-input credential lifecycle is busy; retry later.',
+				array(
+					'status'    => 503,
+					'retryable' => true,
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Release the credential lifecycle advisory lock without masking a result.
+	 *
+	 * @return void
+	 */
+	private function release_lifecycle_lock() {
+		global $wpdb;
+
+		if ( ! is_object( $wpdb ) || ! method_exists( $wpdb, 'prepare' ) || ! method_exists( $wpdb, 'get_var' ) ) {
+			return;
+		}
+
+		try {
+			$wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Advisory lock intentionally bypasses caches.
+				$wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $this->lifecycle_lock_name() ) // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared immediately above.
+			);
+		} catch ( Throwable $error ) {
+			// The lifecycle result is already determined; never expose internals.
+			unset( $error );
+		}
+	}
+
+	/**
+	 * Build a site-specific advisory lock name within MySQL's 64-byte limit.
+	 *
+	 * @return string
+	 */
+	private function lifecycle_lock_name() {
+		global $wpdb;
+
+		$prefix = is_object( $wpdb ) && isset( $wpdb->prefix ) ? (string) $wpdb->prefix : 'wp_';
+
+		return substr( self::LOCK_NAME . '_' . hash( 'sha256', $prefix ), 0, 64 );
+	}
+
+	/**
+	 * Read the option from authoritative MySQL state, bypassing object caches.
+	 *
+	 * @param bool $for_update Whether to lock the row inside a transaction.
+	 * @return array|WP_Error
+	 */
+	private function read_record_db( $for_update = false ) {
+		global $wpdb;
+
+		if ( ! is_object( $wpdb ) || ! method_exists( $wpdb, 'prepare' ) || ! method_exists( $wpdb, 'get_row' ) ) {
+			return $this->storage_error();
+		}
+
+		$table = isset( $wpdb->options ) ? $wpdb->options : $wpdb->prefix . 'options';
+		$sql   = "SELECT option_value FROM {$table} WHERE option_name = %s LIMIT 1";
+		if ( $for_update ) {
+			$sql .= ' FOR UPDATE';
+		}
+
+		try {
+			$query = $wpdb->prepare( $sql, self::OPTION_NAME ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table and optional lock clause are trusted constants.
+			$row   = $wpdb->get_row( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Lifecycle decisions require authoritative state.
+		} catch ( Throwable $error ) {
+			return $this->storage_error();
+		}
+
+		if ( isset( $wpdb->last_error ) && '' !== (string) $wpdb->last_error ) {
+			return $this->storage_error();
+		}
+		if ( null === $row ) {
+			return array(
+				'exists' => false,
+				'value'  => null,
+			);
+		}
+		if ( ! is_array( $row ) || ! array_key_exists( 'option_value', $row ) ) {
+			return $this->storage_error();
+		}
+
+		return array(
+			'exists' => true,
+			'value'  => maybe_unserialize( $row['option_value'] ),
+		);
+	}
+
+	/**
+	 * Persist and verify a record inside both advisory and row locks.
+	 *
+	 * @param array $current Authoritative option row observed while locked.
+	 * @param array $record  Desired validated record.
+	 * @return array|WP_Error
+	 */
+	private function persist_record_locked( $current, $record ) {
+		global $wpdb;
+
+		if (
+			! is_object( $wpdb )
+			|| ! method_exists( $wpdb, 'query' )
+			|| ! method_exists( $wpdb, 'insert' )
+			|| ! method_exists( $wpdb, 'update' )
+		) {
+			return $this->storage_error();
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Transaction protects verified lifecycle persistence.
+		if ( false === $wpdb->query( 'START TRANSACTION' ) ) {
+			return $this->write_error();
+		}
+
+		try {
+			$locked_current = $this->read_record_db( true );
+			if ( is_wp_error( $locked_current ) ) {
+				$this->rollback_lifecycle_write();
+				return $locked_current;
+			}
+			if ( ! hash_equals( $this->record_fingerprint( $current ), $this->record_fingerprint( $locked_current ) ) ) {
+				$this->rollback_lifecycle_write();
+				return $this->concurrency_error();
+			}
+
+			$table      = isset( $wpdb->options ) ? $wpdb->options : $wpdb->prefix . 'options';
+			$serialized = maybe_serialize( $record );
+			if ( $locked_current['exists'] ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Row is locked and read back before commit.
+				$written = $wpdb->update(
+					$table,
+					array( 'option_value' => $serialized ),
+					array( 'option_name' => self::OPTION_NAME ),
+					array( '%s' ),
+					array( '%s' )
+				);
+			} else {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Row is inserted and read back before commit.
+				$written = $wpdb->insert(
+					$table,
+					array(
+						'option_name'  => self::OPTION_NAME,
+						'option_value' => $serialized,
+						'autoload'     => 'no',
+					),
+					array( '%s', '%s', '%s' )
+				);
+			}
+
+			if ( false === $written || 0 === $written ) {
+				$this->rollback_lifecycle_write();
+				return $this->write_error();
+			}
+
+			$readback = $this->read_record_db( true );
+			if ( is_wp_error( $readback ) || ! $readback['exists'] || $record !== $readback['value'] ) {
+				$this->rollback_lifecycle_write();
+				return $this->write_error();
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Commit follows exact readback.
+			if ( false === $wpdb->query( 'COMMIT' ) ) {
+				$this->rollback_lifecycle_write();
+				$this->invalidate_record_cache();
+				return $this->write_error();
+			}
+		} catch ( Throwable $error ) {
+			$this->rollback_lifecycle_write();
+			return $this->lifecycle_error();
+		}
+
+		$this->invalidate_record_cache();
+
+		return $readback['value'];
+	}
+
+	/**
+	 * Roll back a failed lifecycle transaction without exposing DB details.
+	 *
+	 * @return void
+	 */
+	private function rollback_lifecycle_write() {
+		global $wpdb;
+
+		if ( is_object( $wpdb ) && method_exists( $wpdb, 'query' ) ) {
+			try {
+				$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Error recovery.
+			} catch ( Throwable $error ) {
+				// Preserve the sanitized lifecycle error selected by the caller.
+				unset( $error );
+			}
+		}
+	}
+
+	/**
+	 * Return a stable fingerprint for optimistic pre-lock observation.
+	 *
+	 * @param array $row Authoritative option row.
+	 * @return string
+	 */
+	private function record_fingerprint( $row ) {
+		$material = ! empty( $row['exists'] )
+			? 'present:' . maybe_serialize( $row['value'] )
+			: 'missing';
+
+		return hash( 'sha256', $material );
+	}
+
+	/**
+	 * Invalidate all WordPress option-cache views after a direct DB commit.
+	 *
+	 * @return void
+	 */
+	private function invalidate_record_cache() {
+		try {
+			wp_cache_delete( self::OPTION_NAME, 'options' );
+			wp_cache_delete( 'notoptions', 'options' );
+			wp_cache_delete( 'alloptions', 'options' );
+		} catch ( Throwable $error ) {
+			// Authentication/status use authoritative reads; cache failure is safe.
+			unset( $error );
+		}
 	}
 
 	/**
@@ -450,6 +763,51 @@ final class Digitalogic_Pricing_Input_Credential {
 		return new WP_Error(
 			'digitalogic_pricing_input_configuration_invalid',
 			'The pricing-input credential configuration is invalid.',
+			array( 'status' => 500 )
+		);
+	}
+
+	/**
+	 * Return a retryable optimistic-observation conflict.
+	 *
+	 * @return WP_Error
+	 */
+	private function concurrency_error() {
+		return new WP_Error(
+			'digitalogic_pricing_input_lifecycle_conflict',
+			'The pricing-input credential changed concurrently; retry.',
+			array(
+				'status'    => 409,
+				'retryable' => true,
+			)
+		);
+	}
+
+	/**
+	 * Return a sanitized authoritative-storage error.
+	 *
+	 * @return WP_Error
+	 */
+	private function storage_error() {
+		return new WP_Error(
+			'digitalogic_pricing_input_storage_unavailable',
+			'The pricing-input credential storage is unavailable.',
+			array(
+				'status'    => 503,
+				'retryable' => true,
+			)
+		);
+	}
+
+	/**
+	 * Return a sanitized unexpected lifecycle error.
+	 *
+	 * @return WP_Error
+	 */
+	private function lifecycle_error() {
+		return new WP_Error(
+			'digitalogic_pricing_input_lifecycle_failed',
+			'The pricing-input credential lifecycle could not be completed.',
 			array( 'status' => 500 )
 		);
 	}

--- a/includes/class-digitalogic-pricing-input-credential.php
+++ b/includes/class-digitalogic-pricing-input-credential.php
@@ -1,0 +1,489 @@
+<?php
+/**
+ * Route-scoped machine credential for Patris pricing-input reads.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Owns the credential lifecycle, one-way storage, request verification, and
+ * failed-authentication throttle for the two pricing-input contracts.
+ */
+final class Digitalogic_Pricing_Input_Credential {
+	public const OPTION_NAME   = 'digitalogic_pricing_input_machine_credential';
+	public const FAILURE_LIMIT = 5;
+
+	private const SCHEMA_VERSION       = 1;
+	private const TOKEN_PREFIX         = 'dgp1';
+	private const FAILURE_WINDOW       = 60;
+	private const FAILURE_BLOCK_PERIOD = 300;
+	private const THROTTLE_PREFIX      = 'digitalogic_pricing_input_auth_';
+
+	/**
+	 * Shared service instance.
+	 *
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Return the shared credential service.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Authorize one exact pricing-input request.
+	 *
+	 * @param WP_REST_Request $request Current REST request.
+	 * @return true|WP_Error
+	 */
+	public function authorize( WP_REST_Request $request ) {
+		if ( ! $this->request_is_allowed( $request ) ) {
+			return $this->error( 'digitalogic_pricing_input_scope_denied', 403 );
+		}
+
+		$authorization = $request->get_header( 'authorization' );
+		if ( ! is_string( $authorization ) || '' === $authorization ) {
+			return $this->error( 'digitalogic_pricing_input_unauthorized', 401 );
+		}
+
+		$record         = $this->read_record();
+		$throttle_key   = $this->throttle_key( $record );
+		$throttle_state = get_transient( $throttle_key );
+
+		$pattern = '/\A(?i:Bearer) (' . self::TOKEN_PREFIX . '\.([a-f0-9]{16})\.[A-Za-z0-9_-]{43})\z/D';
+		if (
+			1 === preg_match( $pattern, $authorization, $matches )
+			&& 'active' === $this->record_state( $record )
+		) {
+			$token            = $matches[1];
+			$credential_id    = $matches[2];
+			$id_matches       = hash_equals( $record['credential_id'], $credential_id );
+			$verifier_matches = hash_equals( $record['verifier'], hash( 'sha256', $token ) );
+
+			if ( $id_matches && $verifier_matches ) {
+				if ( false !== $throttle_state ) {
+					delete_transient( $throttle_key );
+				}
+
+				return true;
+			}
+		}
+
+		if ( $this->is_throttled( $throttle_state ) ) {
+			return $this->error( 'digitalogic_pricing_input_throttled', 429 );
+		}
+		$this->record_failure( $throttle_key, $throttle_state );
+
+		return $this->error( 'digitalogic_pricing_input_unauthorized', 401 );
+	}
+
+	/**
+	 * Create a credential when none is active.
+	 *
+	 * @return array|WP_Error Secret and nonsecret metadata, or an error.
+	 */
+	public function create() {
+		$record = $this->read_record();
+		$state  = $this->record_state( $record );
+
+		if ( 'active' === $state ) {
+			return new WP_Error(
+				'digitalogic_pricing_input_already_active',
+				'An active pricing-input credential already exists; rotate it instead.',
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( 'invalid' === $state ) {
+			return $this->configuration_error();
+		}
+
+		$generation = 'revoked' === $state ? ( (int) $record['generation'] + 1 ) : 1;
+
+		return $this->issue( null, $generation, false );
+	}
+
+	/**
+	 * Rotate the active credential and invalidate its old value immediately.
+	 *
+	 * @return array|WP_Error Secret and nonsecret metadata, or an error.
+	 */
+	public function rotate() {
+		$record = $this->read_record();
+		if ( 'active' !== $this->record_state( $record ) ) {
+			return new WP_Error(
+				'digitalogic_pricing_input_not_active',
+				'No active pricing-input credential is available to rotate.',
+				array( 'status' => 409 )
+			);
+		}
+
+		return $this->issue( $record, (int) $record['generation'] + 1, true );
+	}
+
+	/**
+	 * Revoke the active credential.
+	 *
+	 * @return array|WP_Error Nonsecret status metadata, or an error.
+	 */
+	public function revoke() {
+		$record = $this->read_record();
+		$state  = $this->record_state( $record );
+
+		if ( 'revoked' === $state ) {
+			return $this->metadata( $record );
+		}
+
+		if ( 'active' !== $state ) {
+			return new WP_Error(
+				'digitalogic_pricing_input_not_active',
+				'No active pricing-input credential is available to revoke.',
+				array( 'status' => 409 )
+			);
+		}
+
+		$record['status']     = 'revoked';
+		$record['revoked_at'] = $this->timestamp();
+		unset( $record['verifier'] );
+
+		if ( ! update_option( self::OPTION_NAME, $record, false ) ) {
+			return $this->write_error();
+		}
+
+		return $this->metadata( $record );
+	}
+
+	/**
+	 * Return only nonsecret credential metadata.
+	 *
+	 * @return array
+	 */
+	public function status() {
+		$record = $this->read_record();
+		$state  = $this->record_state( $record );
+
+		if ( 'active' === $state || 'revoked' === $state ) {
+			return $this->metadata( $record );
+		}
+
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'configured'     => 'invalid' === $state,
+			'active'         => false,
+			'state'          => $state,
+			'contracts'      => $this->contracts(),
+		);
+	}
+
+	/**
+	 * Generate and persist a new one-way credential record.
+	 *
+	 * @param array|null $previous   Previous active record during rotation.
+	 * @param int        $generation New generation number.
+	 * @param bool       $rotation   Whether this is a rotation.
+	 * @return array|WP_Error
+	 */
+	private function issue( $previous, $generation, $rotation ) {
+		try {
+			$credential_id = bin2hex( random_bytes( 8 ) );
+			$secret_bytes  = random_bytes( 32 );
+		} catch ( Throwable $error ) {
+			return new WP_Error(
+				'digitalogic_pricing_input_generation_failed',
+				'The pricing-input credential could not be generated.',
+				array( 'status' => 500 )
+			);
+		}
+
+		$secret = rtrim( strtr( base64_encode( $secret_bytes ), '+/', '-_' ), '=' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- URL-safe random bytes, not code obfuscation.
+		$token  = self::TOKEN_PREFIX . '.' . $credential_id . '.' . $secret;
+		$now    = $this->timestamp();
+		$record = array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'status'         => 'active',
+			'credential_id'  => $credential_id,
+			'verifier'       => hash( 'sha256', $token ),
+			'created_at'     => $rotation ? $previous['created_at'] : $now,
+			'rotated_at'     => $rotation ? $now : null,
+			'revoked_at'     => null,
+			'generation'     => (int) $generation,
+		);
+
+		if ( ! update_option( self::OPTION_NAME, $record, false ) ) {
+			return $this->write_error();
+		}
+
+		return array(
+			'secret'   => $token,
+			'metadata' => $this->metadata( $record ),
+		);
+	}
+
+	/**
+	 * Classify a stored record without trusting malformed option data.
+	 *
+	 * @param mixed $record Stored option value.
+	 * @return string missing, invalid, active, or revoked.
+	 */
+	private function record_state( $record ) {
+		if ( null === $record || false === $record ) {
+			return 'missing';
+		}
+
+		if ( ! is_array( $record ) ) {
+			return 'invalid';
+		}
+
+		$allowed_keys = array(
+			'schema_version',
+			'status',
+			'credential_id',
+			'verifier',
+			'created_at',
+			'rotated_at',
+			'revoked_at',
+			'generation',
+		);
+		if ( array_diff( array_keys( $record ), $allowed_keys ) ) {
+			return 'invalid';
+		}
+		$required_keys = array(
+			'schema_version',
+			'status',
+			'credential_id',
+			'created_at',
+			'rotated_at',
+			'revoked_at',
+			'generation',
+		);
+		if ( array_diff( $required_keys, array_keys( $record ) ) ) {
+			return 'invalid';
+		}
+
+		if (
+			self::SCHEMA_VERSION !== ( $record['schema_version'] ?? null )
+			|| ! isset( $record['credential_id'], $record['status'], $record['created_at'], $record['generation'] )
+			|| ! is_string( $record['credential_id'] )
+			|| ! is_string( $record['status'] )
+			|| 1 !== preg_match( '/\A[a-f0-9]{16}\z/D', $record['credential_id'] )
+			|| ! is_int( $record['generation'] )
+			|| $record['generation'] < 1
+			|| ! $this->valid_timestamp( $record['created_at'] )
+			|| ( null !== ( $record['rotated_at'] ?? null ) && ! $this->valid_timestamp( $record['rotated_at'] ) )
+		) {
+			return 'invalid';
+		}
+
+		if ( 'active' === $record['status'] ) {
+			return isset( $record['verifier'] )
+				&& is_string( $record['verifier'] )
+				&& 1 === preg_match( '/\A[a-f0-9]{64}\z/D', $record['verifier'] )
+				&& null === ( $record['revoked_at'] ?? null )
+					? 'active'
+					: 'invalid';
+		}
+
+		if ( 'revoked' === $record['status'] ) {
+			return ! array_key_exists( 'verifier', $record )
+				&& $this->valid_timestamp( $record['revoked_at'] ?? null )
+					? 'revoked'
+					: 'invalid';
+		}
+
+		return 'invalid';
+	}
+
+	/**
+	 * Return the stored record without coercion.
+	 *
+	 * @return mixed
+	 */
+	private function read_record() {
+		return get_option( self::OPTION_NAME, null );
+	}
+
+	/**
+	 * Return nonsecret metadata for a validated active or revoked record.
+	 *
+	 * @param array $record Validated record.
+	 * @return array
+	 */
+	private function metadata( $record ) {
+		return array(
+			'schema_version' => self::SCHEMA_VERSION,
+			'configured'     => true,
+			'active'         => 'active' === $record['status'],
+			'state'          => $record['status'],
+			'credential_id'  => $record['credential_id'],
+			'generation'     => $record['generation'],
+			'created_at'     => $record['created_at'],
+			'rotated_at'     => $record['rotated_at'],
+			'revoked_at'     => $record['revoked_at'],
+			'contracts'      => $this->contracts(),
+		);
+	}
+
+	/**
+	 * Describe the exact non-mutating contracts authorized by the credential.
+	 *
+	 * @return array
+	 */
+	private function contracts() {
+		return array(
+			'GET /digitalogic/v1/integration/catalog',
+			'POST /digitalogic/v1/pricing-assignments/batch',
+		);
+	}
+
+	/**
+	 * Enforce the exact route and method tuple inside the verifier itself.
+	 *
+	 * @param WP_REST_Request $request Current REST request.
+	 * @return bool
+	 */
+	private function request_is_allowed( WP_REST_Request $request ) {
+		$route  = method_exists( $request, 'get_route' ) ? $request->get_route() : '';
+		$method = method_exists( $request, 'get_method' ) ? $request->get_method() : '';
+		$key    = strtoupper( (string) $method ) . ' ' . (string) $route;
+
+		return in_array( $key, $this->contracts(), true );
+	}
+
+	/**
+	 * Check the current client/generation failure bucket.
+	 *
+	 * @param mixed $state Current throttle state.
+	 * @return bool
+	 */
+	private function is_throttled( $state ) {
+		return is_array( $state )
+			&& isset( $state['blocked_until'] )
+			&& is_int( $state['blocked_until'] )
+			&& $state['blocked_until'] > time();
+	}
+
+	/**
+	 * Record one failed supplied-Authorization attempt without retaining it.
+	 *
+	 * @param string $key   Token-free throttle key.
+	 * @param mixed  $state Current throttle state.
+	 * @return void
+	 */
+	private function record_failure( $key, $state ) {
+		$now = time();
+
+		if (
+			! is_array( $state )
+			|| ! isset( $state['window_started'], $state['count'] )
+			|| ! is_int( $state['window_started'] )
+			|| ! is_int( $state['count'] )
+			|| $state['window_started'] <= $now - self::FAILURE_WINDOW
+		) {
+			$state = array(
+				'window_started' => $now,
+				'count'          => 0,
+				'blocked_until'  => 0,
+			);
+		}
+
+		++$state['count'];
+		if ( $state['count'] >= self::FAILURE_LIMIT ) {
+			$state['blocked_until'] = $now + self::FAILURE_BLOCK_PERIOD;
+		}
+
+		$ttl = max( self::FAILURE_WINDOW, $state['blocked_until'] - $now );
+		set_transient( $key, $state, $ttl );
+	}
+
+	/**
+	 * Build a token-free throttle key from server-observed client metadata.
+	 *
+	 * @param mixed $record Current stored record.
+	 * @return string
+	 */
+	private function throttle_key( $record ) {
+		$remote = isset( $_SERVER['REMOTE_ADDR'] ) && is_string( $_SERVER['REMOTE_ADDR'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) )
+			: 'unknown';
+		$state  = $this->record_state( $record );
+		$scope  = ( 'active' === $state || 'revoked' === $state )
+			? $record['credential_id'] . ':' . $record['generation']
+			: $state;
+
+		return self::THROTTLE_PREFIX . substr( hash( 'sha256', $remote . '|' . $scope ), 0, 40 );
+	}
+
+	/**
+	 * Return a sanitized authentication error.
+	 *
+	 * @param string $code   Machine error code.
+	 * @param int    $status HTTP status.
+	 * @return WP_Error
+	 */
+	private function error( $code, $status ) {
+		$message = 429 === $status
+			? 'Pricing-input machine authentication is temporarily unavailable.'
+			: 'Pricing-input machine authentication failed.';
+
+		return new WP_Error( $code, $message, array( 'status' => $status ) );
+	}
+
+	/**
+	 * Return a sanitized malformed-configuration error.
+	 *
+	 * @return WP_Error
+	 */
+	private function configuration_error() {
+		return new WP_Error(
+			'digitalogic_pricing_input_configuration_invalid',
+			'The pricing-input credential configuration is invalid.',
+			array( 'status' => 500 )
+		);
+	}
+
+	/**
+	 * Return a sanitized option-write error.
+	 *
+	 * @return WP_Error
+	 */
+	private function write_error() {
+		return new WP_Error(
+			'digitalogic_pricing_input_write_failed',
+			'The pricing-input credential could not be stored.',
+			array( 'status' => 500 )
+		);
+	}
+
+	/**
+	 * Return a stable UTC timestamp.
+	 *
+	 * @return string
+	 */
+	private function timestamp() {
+		return gmdate( 'Y-m-d\TH:i:s\Z' );
+	}
+
+	/**
+	 * Validate one stored UTC timestamp.
+	 *
+	 * @param mixed $value Candidate value.
+	 * @return bool
+	 */
+	private function valid_timestamp( $value ) {
+		return is_string( $value )
+			&& 1 === preg_match( '/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/D', $value );
+	}
+}

--- a/includes/class-import-freight-service.php
+++ b/includes/class-import-freight-service.php
@@ -206,19 +206,8 @@ final class Digitalogic_Import_Freight_Service {
         if (is_wp_error($migration)) {
             return $migration;
         }
-        $methods = $this->load_methods();
-        $result = array();
 
-        foreach ($methods as $method) {
-            if (!$include_disabled && empty($method['enabled'])) {
-                continue;
-            }
-
-            $method['assigned_products'] = $this->count_assignments($method['id']);
-            $result[] = $method;
-        }
-
-        return $result;
+        return $this->present_methods($this->load_methods(), $include_disabled);
     }
 
     /**
@@ -890,10 +879,6 @@ final class Digitalogic_Import_Freight_Service {
      * @return array
      */
     public function get_integration_catalog() {
-        $migration = $this->maybe_migrate();
-        if (is_wp_error($migration)) {
-            return $migration;
-        }
         $settings = get_option('digitalogic_patris_feed_settings', array());
         $settings = is_array($settings) ? $settings : array();
         $warehouses = isset($settings['selected_warehouses']) && is_array($settings['selected_warehouses'])
@@ -901,7 +886,7 @@ final class Digitalogic_Import_Freight_Service {
             : array();
         sort($warehouses, SORT_STRING);
 
-        $methods = $this->list_methods(true);
+        $methods = $this->load_catalog_methods_for_read();
         if (is_wp_error($methods)) {
             return $methods;
         }
@@ -1498,7 +1483,7 @@ final class Digitalogic_Import_Freight_Service {
 		return $markup;
 	}
 
-    private function count_assignments($method_id) {
+    private function count_assignments($method_id, $methods = null) {
         $ids = get_posts(array(
             'post_type' => array('product', 'product_variation'),
             'post_status' => 'any',
@@ -1509,7 +1494,7 @@ final class Digitalogic_Import_Freight_Service {
             'meta_value' => $method_id,
         ));
 
-        $methods = $this->load_methods();
+        $methods = is_array($methods) ? $methods : $this->load_methods();
         if (isset($methods[$method_id])) {
             $legacy_value = $this->field_value_for_method($methods[$method_id]);
             $legacy_ids = get_posts(array(
@@ -1640,6 +1625,55 @@ final class Digitalogic_Import_Freight_Service {
 
         return $valid;
     }
+
+    // phpcs:disable -- New read projection is isolated inside a legacy non-WPCS class.
+    /**
+     * Build the complete integration catalog projection without migrating.
+     *
+     * Activation and init own persistence. A cold read overlays the same
+     * canonical defaults in memory so the machine contract remains typed and
+     * useful without turning a GET request into a write path.
+     *
+     * @return array|WP_Error
+     */
+    private function load_catalog_methods_for_read() {
+        $methods = $this->load_methods();
+        $defaults = $this->legacy_seed_methods();
+
+        foreach ($defaults as $id => $method) {
+            if (is_wp_error($method)) {
+                return $method;
+            }
+            if (!isset($methods[$id])) {
+                $methods[$id] = $method;
+            }
+        }
+        ksort($methods, SORT_STRING);
+
+        return $this->present_methods($methods, true);
+    }
+
+    /**
+     * Add assignment counts to a method map without repeating projection code.
+     *
+     * @param array $methods Canonical method map.
+     * @param bool  $include_disabled Whether disabled methods are returned.
+     * @return array
+     */
+    private function present_methods($methods, $include_disabled) {
+        $result = array();
+        foreach ($methods as $method) {
+            if (!$include_disabled && empty($method['enabled'])) {
+                continue;
+            }
+
+            $method['assigned_products'] = $this->count_assignments($method['id'], $methods);
+            $result[] = $method;
+        }
+
+        return $result;
+    }
+    // phpcs:enable
 
     private function store_methods($methods) {
         ksort($methods, SORT_STRING);

--- a/includes/cli/class-cli-commands.php
+++ b/includes/cli/class-cli-commands.php
@@ -601,6 +601,132 @@ class Digitalogic_CLI_Commands {
 			wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES )
 		);
 	}
+
+	/**
+	 * Create the route-scoped Patris pricing-input credential.
+	 *
+	 * The generated Bearer value is printed exactly once. Run this command with
+	 * an explicit administrator context and move the value directly into the
+	 * Patris environment secret configured by BearerTokenEnv.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp digitalogic pricing-input-credential create --user=<administrator>
+	 *
+	 * @when after_wp_load
+	 *
+	 * @return void
+	 */
+	public function pricing_input_credential_create() {
+		if ( ! $this->require_pricing_credential_admin() ) {
+			return;
+		}
+
+		$this->output_issued_pricing_credential(
+			Digitalogic_Pricing_Input_Credential::instance()->create()
+		);
+	}
+
+	/**
+	 * Rotate the pricing-input credential and invalidate its old value.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp digitalogic pricing-input-credential rotate --user=<administrator>
+	 *
+	 * @when after_wp_load
+	 *
+	 * @return void
+	 */
+	public function pricing_input_credential_rotate() {
+		if ( ! $this->require_pricing_credential_admin() ) {
+			return;
+		}
+
+		$this->output_issued_pricing_credential(
+			Digitalogic_Pricing_Input_Credential::instance()->rotate()
+		);
+	}
+
+	/**
+	 * Revoke the pricing-input credential immediately.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp digitalogic pricing-input-credential revoke --user=<administrator>
+	 *
+	 * @when after_wp_load
+	 *
+	 * @return void
+	 */
+	public function pricing_input_credential_revoke() {
+		if ( ! $this->require_pricing_credential_admin() ) {
+			return;
+		}
+
+		$result = Digitalogic_Pricing_Input_Credential::instance()->revoke();
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		WP_CLI::line( wp_json_encode( $result, JSON_UNESCAPED_SLASHES ) );
+	}
+
+	/**
+	 * Show nonsecret pricing-input credential metadata.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp digitalogic pricing-input-credential status --user=<administrator>
+	 *
+	 * @when after_wp_load
+	 *
+	 * @return void
+	 */
+	public function pricing_input_credential_status() {
+		if ( ! $this->require_pricing_credential_admin() ) {
+			return;
+		}
+
+		WP_CLI::line(
+			wp_json_encode(
+				Digitalogic_Pricing_Input_Credential::instance()->status(),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+	}
+
+	/**
+	 * Require an explicit administrator user for credential lifecycle commands.
+	 *
+	 * @return bool
+	 */
+	private function require_pricing_credential_admin() {
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		WP_CLI::error( 'Run this command with --user=<administrator>.' );
+
+		return false;
+	}
+
+	/**
+	 * Print a newly issued secret once, followed by nonsecret metadata.
+	 *
+	 * @param array|WP_Error $result Credential issuance result.
+	 * @return void
+	 */
+	private function output_issued_pricing_credential( $result ) {
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		WP_CLI::line( $result['secret'] );
+		WP_CLI::line( wp_json_encode( $result['metadata'], JSON_UNESCAPED_SLASHES ) );
+	}
 }
 
 // Register commands
@@ -622,4 +748,20 @@ WP_CLI::add_command('digitalogic panel broadcast', array('Digitalogic_CLI_Comman
 WP_CLI::add_command(
 	'digitalogic pricing assignments',
 	array( 'Digitalogic_CLI_Commands', 'pricing_assignments' )
+);
+WP_CLI::add_command(
+	'digitalogic pricing-input-credential create',
+	array( 'Digitalogic_CLI_Commands', 'pricing_input_credential_create' )
+);
+WP_CLI::add_command(
+	'digitalogic pricing-input-credential rotate',
+	array( 'Digitalogic_CLI_Commands', 'pricing_input_credential_rotate' )
+);
+WP_CLI::add_command(
+	'digitalogic pricing-input-credential revoke',
+	array( 'Digitalogic_CLI_Commands', 'pricing_input_credential_revoke' )
+);
+WP_CLI::add_command(
+	'digitalogic pricing-input-credential status',
+	array( 'Digitalogic_CLI_Commands', 'pricing_input_credential_status' )
 );

--- a/includes/cli/class-cli-commands.php
+++ b/includes/cli/class-cli-commands.php
@@ -689,9 +689,15 @@ class Digitalogic_CLI_Commands {
 			return;
 		}
 
+		$result = Digitalogic_Pricing_Input_Credential::instance()->status();
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
 		WP_CLI::line(
 			wp_json_encode(
-				Digitalogic_Pricing_Input_Credential::instance()->status(),
+				$result,
 				JSON_UNESCAPED_SLASHES
 			)
 		);

--- a/tests/ImportFreightServiceTest.php
+++ b/tests/ImportFreightServiceTest.php
@@ -145,6 +145,48 @@ final class ImportFreightServiceTest extends TestCase {
         $this->assertSame(87.0, $this->service->get_method('air_express')['price_per_kg_cny']);
     }
 
+    // phpcs:disable -- Focused regression follows this legacy test file's established style.
+    /**
+     * A cold catalog read projects defaults but leaves migration to init.
+     */
+    public function test_catalog_read_is_typed_and_write_free_before_migration() {
+        $this->assertArrayNotHasKey(Digitalogic_Import_Freight_Service::MIGRATION_OPTION, $GLOBALS['digitalogic_test_options']);
+        $this->assertArrayNotHasKey(Digitalogic_Import_Freight_Service::METHODS_OPTION, $GLOBALS['digitalogic_test_options']);
+        $before = array(
+            'options' => $GLOBALS['digitalogic_test_options'],
+            'option_cache' => $GLOBALS['digitalogic_test_option_cache'],
+            'posts' => $GLOBALS['digitalogic_test_posts'],
+            'actions' => $GLOBALS['digitalogic_test_actions'],
+            'queries' => $GLOBALS['wpdb']->queries,
+            'locks' => $GLOBALS['wpdb']->acquire_count,
+        );
+
+        $catalog = $this->service->get_integration_catalog();
+        $methods = $this->indexMethods($catalog['import_freight_methods']);
+
+        $this->assertSame('digitalogic.integration-catalog', $catalog['schema']);
+        $this->assertSame('1.0.0', $catalog['schema_version']);
+        $this->assertIsString($catalog['revision']);
+        $this->assertSame(25300.0, $catalog['currency']['cny_to_local']);
+        $this->assertFalse($catalog['pricing']['default_percentage_markup']['configured']);
+        $this->assertNull($catalog['pricing']['default_percentage_markup']['profit_percent']);
+        $this->assertSame(array('air_express', 'air_freight', 'sea_freight'), array_keys($methods));
+        $this->assertSame(85.0, $methods['air_express']['price_per_kg_cny']);
+        $this->assertIsBool($methods['air_express']['enabled']);
+        $this->assertIsInt($methods['air_express']['assigned_products']);
+        $this->assertIsArray($methods['air_express']['metadata']);
+        $this->assertIsArray($methods['air_express']['tiered_rates']);
+        $this->assertArrayNotHasKey(Digitalogic_Import_Freight_Service::MIGRATION_OPTION, $GLOBALS['digitalogic_test_options']);
+        $this->assertArrayNotHasKey(Digitalogic_Import_Freight_Service::METHODS_OPTION, $GLOBALS['digitalogic_test_options']);
+        $this->assertSame($before['options'], $GLOBALS['digitalogic_test_options']);
+        $this->assertSame($before['option_cache'], $GLOBALS['digitalogic_test_option_cache']);
+        $this->assertSame($before['posts'], $GLOBALS['digitalogic_test_posts']);
+        $this->assertSame($before['actions'], $GLOBALS['digitalogic_test_actions']);
+        $this->assertSame($before['queries'], $GLOBALS['wpdb']->queries);
+        $this->assertSame($before['locks'], $GLOBALS['wpdb']->acquire_count);
+    }
+    // phpcs:enable
+
     public function test_crud_enforces_immutable_ids_delete_conflict_and_disable_semantics() {
         $GLOBALS['digitalogic_test_posts'][201] = array(
             'post_type' => 'product',

--- a/tests/PricingInputCredentialTest.php
+++ b/tests/PricingInputCredentialTest.php
@@ -22,6 +22,7 @@ final class PricingInputCredentialTest extends TestCase {
         $GLOBALS['digitalogic_test_posts'] = array();
         $GLOBALS['digitalogic_test_wc_products'] = array();
         $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+        $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
         WP_CLI::$errors = array();
         WP_CLI::$warnings = array();
         WP_CLI::$logs = array();
@@ -194,6 +195,185 @@ final class PricingInputCredentialTest extends TestCase {
             $this->assertInstanceOf(WP_Error::class, $result, $name);
             $this->assertSame('digitalogic_pricing_input_unauthorized', $result->get_error_code(), $name);
         }
+    }
+
+    public function test_overlapping_creates_are_linearized_and_only_one_secret_is_revealed(): void {
+        $nested = null;
+        $GLOBALS['wpdb']->before_get_lock = function() use (&$nested): void {
+            $nested = $this->credential->create();
+        };
+
+        $outer = $this->credential->create();
+
+        $this->assertIsArray($nested);
+        $this->assertArrayHasKey('secret', $nested);
+        $this->assertInstanceOf(WP_Error::class, $outer);
+        $this->assertSame('digitalogic_pricing_input_lifecycle_conflict', $outer->get_error_code());
+        $this->assertStringNotContainsString($nested['secret'], serialize($outer));
+        $this->assertSame(1, $this->credential->status()['generation']);
+        $this->assertTrue(
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $nested['secret'])
+            )
+        );
+        $this->assertSame(array(3, 3), $GLOBALS['wpdb']->lock_timeouts);
+        $this->assertSame(2, $GLOBALS['wpdb']->acquire_count);
+        $this->assertSame(2, $GLOBALS['wpdb']->release_count);
+    }
+
+    public function test_overlapping_rotates_share_one_observation_and_only_one_can_issue(): void {
+        $initial = $this->createSecret();
+        $GLOBALS['wpdb']->acquire_count = 0;
+        $GLOBALS['wpdb']->release_count = 0;
+        $GLOBALS['wpdb']->lock_timeouts = array();
+        $nested = null;
+        $GLOBALS['wpdb']->before_get_lock = function() use (&$nested): void {
+            $nested = $this->credential->rotate();
+        };
+
+        $outer = $this->credential->rotate();
+
+        $this->assertIsArray($nested);
+        $this->assertArrayHasKey('secret', $nested);
+        $this->assertSame(2, $nested['metadata']['generation']);
+        $this->assertInstanceOf(WP_Error::class, $outer);
+        $this->assertSame('digitalogic_pricing_input_lifecycle_conflict', $outer->get_error_code());
+        $this->assertStringNotContainsString($nested['secret'], serialize($outer));
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $initial)
+            )
+        );
+        $this->assertTrue(
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $nested['secret'])
+            )
+        );
+
+        $later = $this->credential->rotate();
+        $this->assertIsArray($later);
+        $this->assertSame(3, $later['metadata']['generation']);
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $nested['secret'])
+            )
+        );
+        $this->assertTrue(
+            $this->credential->authorize(
+                $this->request('POST', '/digitalogic/v1/pricing-assignments/batch', $later['secret'])
+            )
+        );
+        $this->assertSame(array(3, 3, 3), $GLOBALS['wpdb']->lock_timeouts);
+        $this->assertSame(3, $GLOBALS['wpdb']->acquire_count);
+        $this->assertSame(3, $GLOBALS['wpdb']->release_count);
+    }
+
+    public function test_revoke_wins_both_lock_orders_against_an_overlapping_rotate(): void {
+        $initial = $this->createSecret();
+        $nested_revoke = null;
+        $GLOBALS['wpdb']->before_get_lock = function() use (&$nested_revoke): void {
+            $nested_revoke = $this->credential->revoke();
+        };
+
+        $outer_rotate = $this->credential->rotate();
+
+        $this->assertIsArray($nested_revoke);
+        $this->assertSame('revoked', $nested_revoke['state']);
+        $this->assertInstanceOf(WP_Error::class, $outer_rotate);
+        $this->assertSame('digitalogic_pricing_input_lifecycle_conflict', $outer_rotate->get_error_code());
+        $this->assertSame('revoked', $this->credential->status()['state']);
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $initial)
+            )
+        );
+
+        $active = $this->credential->create();
+        $nested_rotate = null;
+        $GLOBALS['wpdb']->before_get_lock = function() use (&$nested_rotate): void {
+            $nested_rotate = $this->credential->rotate();
+        };
+
+        $outer_revoke = $this->credential->revoke();
+
+        $this->assertIsArray($nested_rotate);
+        $this->assertArrayHasKey('secret', $nested_rotate);
+        $this->assertIsArray($outer_revoke);
+        $this->assertSame('revoked', $outer_revoke['state']);
+        $this->assertSame($nested_rotate['metadata']['generation'], $outer_revoke['generation']);
+        $this->assertSame('revoked', $this->credential->status()['state']);
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $active['secret'])
+            )
+        );
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $nested_rotate['secret'])
+            )
+        );
+    }
+
+    public function test_authoritative_verification_ignores_stale_cache_after_rotate_and_revoke(): void {
+        $issued = $this->credential->create();
+        $old_record = $GLOBALS['digitalogic_test_options'][Digitalogic_Pricing_Input_Credential::OPTION_NAME];
+        $GLOBALS['digitalogic_test_option_cache'][Digitalogic_Pricing_Input_Credential::OPTION_NAME] = $old_record;
+
+        $rotated = $this->credential->rotate();
+        $active_record = $GLOBALS['digitalogic_test_options'][Digitalogic_Pricing_Input_Credential::OPTION_NAME];
+        $GLOBALS['digitalogic_test_option_cache'][Digitalogic_Pricing_Input_Credential::OPTION_NAME] = $old_record;
+
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $issued['secret'])
+            )
+        );
+        $this->assertTrue(
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $rotated['secret'])
+            )
+        );
+
+        $this->credential->revoke();
+        $GLOBALS['digitalogic_test_option_cache'][Digitalogic_Pricing_Input_Credential::OPTION_NAME] = $active_record;
+
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('POST', '/digitalogic/v1/pricing-assignments/batch', $rotated['secret'])
+            )
+        );
+        $this->assertSame('revoked', $this->credential->status()['state']);
+    }
+
+    public function test_lifecycle_lock_timeout_and_failed_readback_reveal_no_secret_and_release_safely(): void {
+        $GLOBALS['wpdb']->acquire_result = 0;
+        $busy = $this->credential->create();
+
+        $this->assertInstanceOf(WP_Error::class, $busy);
+        $this->assertSame('digitalogic_pricing_input_lifecycle_busy', $busy->get_error_code());
+        $this->assertTrue($busy->get_error_data()['retryable']);
+        $this->assertArrayNotHasKey(Digitalogic_Pricing_Input_Credential::OPTION_NAME, $GLOBALS['digitalogic_test_options']);
+        $this->assertSame(array(3), $GLOBALS['wpdb']->lock_timeouts);
+        $this->assertSame(0, $GLOBALS['wpdb']->release_count);
+
+        $GLOBALS['wpdb']->acquire_result = 1;
+        $GLOBALS['wpdb']->after_option_write = function($wpdb, $name): void {
+            $GLOBALS['digitalogic_test_options'][$name]['generation'] = 999;
+        };
+        $failed = $this->credential->create();
+
+        $this->assertInstanceOf(WP_Error::class, $failed);
+        $this->assertSame('digitalogic_pricing_input_write_failed', $failed->get_error_code());
+        $this->assertArrayNotHasKey(Digitalogic_Pricing_Input_Credential::OPTION_NAME, $GLOBALS['digitalogic_test_options']);
+        $this->assertSame(1, $GLOBALS['wpdb']->release_count);
+        $this->assertStringNotContainsString('dgp1.', serialize($failed));
     }
 
     public function test_storage_status_errors_and_runtime_sources_never_leak_a_secret(): void {

--- a/tests/PricingInputCredentialTest.php
+++ b/tests/PricingInputCredentialTest.php
@@ -1,0 +1,398 @@
+<?php
+// phpcs:ignoreFile
+
+use PHPUnit\Framework\TestCase;
+
+final class PricingInputCredentialTest extends TestCase {
+    /** @var Digitalogic_Pricing_Input_Credential */
+    private $credential;
+
+    /** @var Digitalogic_REST_API */
+    private $api;
+
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_capabilities'] = array();
+        $GLOBALS['digitalogic_test_filters'] = array();
+        $GLOBALS['digitalogic_test_routes'] = array();
+        $GLOBALS['digitalogic_test_options'] = array();
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_transients'] = array();
+        $GLOBALS['digitalogic_test_transient_deletes'] = array();
+        $GLOBALS['digitalogic_test_posts'] = array();
+        $GLOBALS['digitalogic_test_wc_products'] = array();
+        $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+        WP_CLI::$errors = array();
+        WP_CLI::$warnings = array();
+        WP_CLI::$logs = array();
+        $_SERVER['REMOTE_ADDR'] = '192.0.2.60';
+        $_COOKIE = array();
+
+        $credential_instance = new ReflectionProperty(Digitalogic_Pricing_Input_Credential::class, 'instance');
+        $credential_instance->setValue(null, null);
+        $api_instance = new ReflectionProperty(Digitalogic_REST_API::class, 'instance');
+        $api_instance->setValue(null, null);
+
+        $this->credential = Digitalogic_Pricing_Input_Credential::instance();
+        $this->api = Digitalogic_REST_API::instance();
+    }
+
+    protected function tearDown(): void {
+        $_COOKIE = array();
+        unset($_SERVER['REMOTE_ADDR']);
+    }
+
+    public function test_bearer_authorizes_only_both_exact_pricing_input_contracts_and_humans_remain_supported(): void {
+        $secret = $this->createSecret();
+        $catalog = $this->request('GET', '/digitalogic/v1/integration/catalog', $secret);
+        $batch = $this->request('POST', '/digitalogic/v1/pricing-assignments/batch', $secret);
+
+        $this->assertTrue($this->api->check_pricing_input_permission($catalog));
+        $this->assertTrue($this->api->check_pricing_input_permission($batch));
+
+        $this->assertSame(
+            'digitalogic_pricing_input_scope_denied',
+            $this->api->check_pricing_input_permission(
+                $this->request('POST', '/digitalogic/v1/integration/catalog', $secret)
+            )->get_error_code()
+        );
+        $this->assertSame(
+            'digitalogic_pricing_input_scope_denied',
+            $this->api->check_pricing_input_permission(
+                $this->request('GET', '/digitalogic/v1/pricing-assignments/batch', $secret)
+            )->get_error_code()
+        );
+
+        $GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
+        $this->assertTrue(
+            $this->api->check_pricing_input_permission(
+                $this->request('GET', '/digitalogic/v1/integration/catalog')
+            )
+        );
+        $this->assertTrue(
+            $this->api->check_pricing_input_permission(
+                $this->request('POST', '/digitalogic/v1/pricing-assignments/batch')
+            )
+        );
+    }
+
+    public function test_machine_bearer_cannot_authorize_any_other_registered_route_or_method(): void {
+        $secret = $this->createSecret();
+        $this->api->register_routes();
+        $allowed = array(
+            'GET /integration/catalog',
+            'POST /pricing-assignments/batch',
+        );
+        $authorized = array();
+
+        foreach ($GLOBALS['digitalogic_test_routes'] as $registration) {
+            $definitions = isset($registration['args']['callback'])
+                ? array($registration['args'])
+                : $registration['args'];
+            foreach ($definitions as $definition) {
+                $key = $definition['methods'] . ' ' . $registration['route'];
+                $request = $this->request(
+                    $definition['methods'],
+                    '/digitalogic/v1' . $registration['route'],
+                    $secret
+                );
+                $result = call_user_func($definition['permission_callback'], $request);
+
+                if (in_array($key, $allowed, true)) {
+                    $this->assertTrue($result, $key);
+                    $authorized[] = $key;
+                } else {
+                    $this->assertNotTrue($result, $key);
+                }
+            }
+        }
+
+        $this->assertSame($allowed, $authorized);
+        $this->assertFalse($this->api->check_read_permission($this->request('GET', '/digitalogic/v1/products', $secret)));
+        $this->assertFalse($this->api->check_write_permission($this->request('POST', '/digitalogic/v1/patris/sync', $secret)));
+        $this->assertFalse($this->api->check_diagnostic_permission($this->request('GET', '/digitalogic/v1/reports', $secret)));
+    }
+
+    public function test_absent_wrong_rotated_and_revoked_credentials_fail_closed(): void {
+        $absent = $this->api->check_pricing_input_permission(
+            $this->request('GET', '/digitalogic/v1/integration/catalog')
+        );
+        $this->assertSame('digitalogic_pricing_input_unauthorized', $absent->get_error_code());
+        $this->assertSame(401, $absent->get_error_data()['status']);
+
+        $issued = $this->credential->create();
+        $old = $issued['secret'];
+        $wrong = substr($old, 0, -1) . ($old[-1] === 'A' ? 'B' : 'A');
+        $this->assertSame(
+            'digitalogic_pricing_input_unauthorized',
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $wrong)
+            )->get_error_code()
+        );
+        $this->assertTrue(
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $old)
+            )
+        );
+
+        $rotated = $this->credential->rotate();
+        $new = $rotated['secret'];
+        $this->assertNotSame($old, $new);
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $old)
+            )
+        );
+        $this->assertTrue(
+            $this->credential->authorize(
+                $this->request('POST', '/digitalogic/v1/pricing-assignments/batch', $new)
+            )
+        );
+
+        $revoked = $this->credential->revoke();
+        $this->assertFalse($revoked['active']);
+        $this->assertSame('revoked', $revoked['state']);
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('POST', '/digitalogic/v1/pricing-assignments/batch', $new)
+            )
+        );
+    }
+
+    public function test_query_cookie_basic_legacy_and_product_sync_credentials_are_rejected(): void {
+        $secret = $this->createSecret();
+        $GLOBALS['digitalogic_test_options']['digitalogic_patris_feed_push_token'] = 'legacy-push-secret';
+        $GLOBALS['digitalogic_test_options'][Digitalogic_Patris_Feed::PRODUCT_SYNC_SECRET_OPTION] = 'product-sync-secret';
+
+        $_COOKIE['Authorization'] = $secret;
+        $requests = array(
+            'query' => new WP_REST_Request(array('access_token' => $secret)),
+            'cookie' => new WP_REST_Request(),
+            'basic' => new WP_REST_Request(array(), array(), array(
+                'Authorization' => 'Basic ' . base64_encode($secret . ':ignored'),
+            )),
+            'userinfo' => new WP_REST_Request(array('url' => 'https://' . rawurlencode($secret) . '@digitalogic.test/')),
+            'legacy header' => new WP_REST_Request(array(), array(), array(
+                'X-Digitalogic-Token' => 'legacy-push-secret',
+            )),
+            'product sync header' => new WP_REST_Request(array(), array(), array(
+                'X-Digitalogic-Product-Sync-Secret' => 'product-sync-secret',
+            )),
+            'legacy bearer' => new WP_REST_Request(array(), array(), array(
+                'Authorization' => 'Bearer legacy-push-secret',
+            )),
+        );
+
+        foreach ($requests as $name => $request) {
+            $GLOBALS['digitalogic_test_transients'] = array();
+            $request->set_route('/digitalogic/v1/integration/catalog');
+            $request->set_method('GET');
+            $result = $this->api->check_pricing_input_permission($request);
+
+            $this->assertInstanceOf(WP_Error::class, $result, $name);
+            $this->assertSame('digitalogic_pricing_input_unauthorized', $result->get_error_code(), $name);
+        }
+    }
+
+    public function test_storage_status_errors_and_runtime_sources_never_leak_a_secret(): void {
+        $issued = $this->credential->create();
+        $secret = $issued['secret'];
+        $stored = $GLOBALS['digitalogic_test_options'][Digitalogic_Pricing_Input_Credential::OPTION_NAME];
+        $status = $this->credential->status();
+
+        $this->assertMatchesRegularExpression('/\Adgp1\.[a-f0-9]{16}\.[A-Za-z0-9_-]{43}\z/D', $secret);
+        $this->assertSame(hash('sha256', $secret), $stored['verifier']);
+        $this->assertStringNotContainsString($secret, serialize($stored));
+        $this->assertArrayNotHasKey('verifier', $status);
+        $this->assertArrayNotHasKey('secret', $status);
+        $this->assertStringNotContainsString($secret, wp_json_encode($status));
+
+        $wrong = substr($secret, 0, -1) . ($secret[-1] === 'A' ? 'B' : 'A');
+        $error = $this->credential->authorize(
+            $this->request('GET', '/digitalogic/v1/integration/catalog', $wrong)
+        );
+        $this->assertStringNotContainsString($wrong, $error->get_error_message());
+        $this->assertStringNotContainsString($secret, serialize($error->get_error_data()));
+
+        $source = file_get_contents(dirname(__DIR__) . '/includes/class-digitalogic-pricing-input-credential.php');
+        $this->assertStringContainsString('hash_equals(', $source);
+        $this->assertStringNotContainsString('error_log(', $source);
+        $this->assertStringNotContainsString('Digitalogic_Logger', $source);
+    }
+
+    public function test_malformed_or_unavailable_storage_fails_closed_without_revealing_generated_material(): void {
+        $GLOBALS['digitalogic_test_options'][Digitalogic_Pricing_Input_Credential::OPTION_NAME] = array(
+            'secret' => 'must-never-be-trusted',
+        );
+        $status = $this->credential->status();
+        $result = $this->credential->authorize(
+            $this->request(
+                'GET',
+                '/digitalogic/v1/integration/catalog',
+                'dgp1.' . str_repeat('0', 16) . '.' . str_repeat('A', 43)
+            )
+        );
+
+        $this->assertSame('invalid', $status['state']);
+        $this->assertArrayNotHasKey('secret', $status);
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringNotContainsString('must-never-be-trusted', $result->get_error_message());
+
+        $GLOBALS['digitalogic_test_options'] = array();
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $issued = $this->credential->create();
+        $malformed = $GLOBALS['digitalogic_test_options'][Digitalogic_Pricing_Input_Credential::OPTION_NAME];
+        unset($malformed['rotated_at']);
+        $GLOBALS['digitalogic_test_options'][Digitalogic_Pricing_Input_Credential::OPTION_NAME] = $malformed;
+        $GLOBALS['digitalogic_test_option_cache'][Digitalogic_Pricing_Input_Credential::OPTION_NAME] = $malformed;
+        $this->assertSame('invalid', $this->credential->status()['state']);
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $issued['secret'])
+            )
+        );
+
+        $GLOBALS['digitalogic_test_options'] = array();
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_update_failures'][] = Digitalogic_Pricing_Input_Credential::OPTION_NAME;
+        $failed = $this->credential->create();
+        $this->assertSame('digitalogic_pricing_input_write_failed', $failed->get_error_code());
+        $this->assertArrayNotHasKey(Digitalogic_Pricing_Input_Credential::OPTION_NAME, $GLOBALS['digitalogic_test_options']);
+    }
+
+    public function test_repeated_failures_are_throttled_without_retaining_or_logging_tokens(): void {
+        $secret = $this->createSecret();
+        $wrong = substr($secret, 0, -1) . ($secret[-1] === 'A' ? 'B' : 'A');
+
+        for ($attempt = 0; $attempt < Digitalogic_Pricing_Input_Credential::FAILURE_LIMIT; $attempt++) {
+            $result = $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $wrong)
+            );
+            $this->assertSame(401, $result->get_error_data()['status']);
+        }
+
+        $this->assertTrue(
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $secret)
+            )
+        );
+        $this->assertSame(array(), $GLOBALS['digitalogic_test_transients']);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_transient_deletes']);
+
+        for ($attempt = 0; $attempt < Digitalogic_Pricing_Input_Credential::FAILURE_LIMIT; $attempt++) {
+            $result = $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $wrong)
+            );
+            $this->assertSame(401, $result->get_error_data()['status']);
+        }
+
+        $blocked = $this->credential->authorize(
+            $this->request('GET', '/digitalogic/v1/integration/catalog', $secret)
+        );
+        $this->assertTrue($blocked);
+
+        for ($attempt = 0; $attempt < Digitalogic_Pricing_Input_Credential::FAILURE_LIMIT; $attempt++) {
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $wrong)
+            );
+        }
+        $throttled_invalid = $this->credential->authorize(
+            $this->request('GET', '/digitalogic/v1/integration/catalog', $wrong)
+        );
+        $this->assertSame('digitalogic_pricing_input_throttled', $throttled_invalid->get_error_code());
+        $this->assertSame(429, $throttled_invalid->get_error_data()['status']);
+        $this->assertStringNotContainsString($wrong, serialize($GLOBALS['digitalogic_test_transients']));
+        $this->assertStringNotContainsString($secret, serialize($GLOBALS['digitalogic_test_transients']));
+    }
+
+    public function test_first_correct_authentication_is_strictly_write_free(): void {
+        $secret = $this->createSecret();
+        $GLOBALS['digitalogic_test_transient_deletes'] = array();
+        $before = array(
+            'options' => $GLOBALS['digitalogic_test_options'],
+            'option_cache' => $GLOBALS['digitalogic_test_option_cache'],
+            'queries' => $GLOBALS['wpdb']->queries,
+            'transients' => $GLOBALS['digitalogic_test_transients'],
+        );
+
+        $result = $this->credential->authorize(
+            $this->request('GET', '/digitalogic/v1/integration/catalog', $secret)
+        );
+
+        $this->assertTrue($result);
+        $this->assertSame($before['options'], $GLOBALS['digitalogic_test_options']);
+        $this->assertSame($before['option_cache'], $GLOBALS['digitalogic_test_option_cache']);
+        $this->assertSame($before['queries'], $GLOBALS['wpdb']->queries);
+        $this->assertSame($before['transients'], $GLOBALS['digitalogic_test_transients']);
+        $this->assertSame(array(), $GLOBALS['digitalogic_test_transient_deletes']);
+    }
+
+    public function test_administrator_only_cli_reveals_new_secrets_once_and_status_never_does(): void {
+        $commands = new Digitalogic_CLI_Commands();
+
+        $GLOBALS['digitalogic_test_capabilities'] = array('manage_woocommerce' => true);
+        $commands->pricing_input_credential_create();
+        $this->assertNotEmpty(WP_CLI::$errors);
+        $this->assertArrayNotHasKey(Digitalogic_Pricing_Input_Credential::OPTION_NAME, $GLOBALS['digitalogic_test_options']);
+
+        $GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+        WP_CLI::$errors = array();
+        WP_CLI::$logs = array();
+        $commands->pricing_input_credential_create();
+        $secret = WP_CLI::$logs[0];
+        $this->assertMatchesRegularExpression('/\Adgp1\./', $secret);
+        $this->assertSame(1, substr_count(implode("\n", WP_CLI::$logs), $secret));
+        $this->assertStringNotContainsString('verifier', implode("\n", WP_CLI::$logs));
+
+        WP_CLI::$logs = array();
+        $commands->pricing_input_credential_status();
+        $status_output = implode("\n", WP_CLI::$logs);
+        $this->assertStringNotContainsString($secret, $status_output);
+        $this->assertStringNotContainsString('verifier', $status_output);
+
+        WP_CLI::$logs = array();
+        $commands->pricing_input_credential_rotate();
+        $rotated = WP_CLI::$logs[0];
+        $this->assertNotSame($secret, $rotated);
+        $this->assertSame(1, substr_count(implode("\n", WP_CLI::$logs), $rotated));
+        $this->assertInstanceOf(
+            WP_Error::class,
+            $this->credential->authorize(
+                $this->request('GET', '/digitalogic/v1/integration/catalog', $secret)
+            )
+        );
+
+        WP_CLI::$logs = array();
+        $commands->pricing_input_credential_revoke();
+        $this->assertStringNotContainsString($rotated, implode("\n", WP_CLI::$logs));
+        $this->assertStringNotContainsString('verifier', implode("\n", WP_CLI::$logs));
+
+        $this->assertArrayHasKey('digitalogic pricing-input-credential create', WP_CLI::$commands);
+        $this->assertArrayHasKey('digitalogic pricing-input-credential rotate', WP_CLI::$commands);
+        $this->assertArrayHasKey('digitalogic pricing-input-credential revoke', WP_CLI::$commands);
+        $this->assertArrayHasKey('digitalogic pricing-input-credential status', WP_CLI::$commands);
+    }
+
+    private function createSecret(): string {
+        $result = $this->credential->create();
+        $this->assertFalse(is_wp_error($result));
+
+        return $result['secret'];
+    }
+
+    private function request(string $method, string $route, ?string $secret = null): WP_REST_Request {
+        $headers = array();
+        if (null !== $secret) {
+            $headers['Authorization'] = 'Bearer ' . $secret;
+        }
+
+        $request = new WP_REST_Request(array(), array(), $headers);
+        $request->set_method($method);
+        $request->set_route($route);
+
+        return $request;
+    }
+}

--- a/tests/RestApiPermissionsTest.php
+++ b/tests/RestApiPermissionsTest.php
@@ -247,7 +247,7 @@ final class RestApiPermissionsTest extends TestCase {
             'POST /patris/sync' => 'check_write_permission',
             'POST /patris/push' => 'check_patris_push_permission',
             'POST /patris/product-sync' => 'check_patris_product_sync_permission',
-            'GET /integration/catalog' => 'check_read_permission',
+            'GET /integration/catalog' => 'check_pricing_input_permission',
             'GET /pricing/default-markup' => 'check_read_permission',
             'PUT /pricing/default-markup' => 'check_write_permission',
             'GET /import-freight-methods' => 'check_read_permission',
@@ -257,7 +257,7 @@ final class RestApiPermissionsTest extends TestCase {
             'DELETE /import-freight-methods/(?P<id>[a-z][a-z0-9_]{1,63})' => 'check_write_permission',
             'GET /products/by-code/(?P<code>[^/]+)/import-pricing' => 'check_read_permission',
             'PUT /products/by-code/(?P<code>[^/]+)/import-pricing' => 'check_write_permission',
-			'POST /pricing-assignments/batch'     => 'check_read_permission',
+			'POST /pricing-assignments/batch'     => 'check_pricing_input_permission',
             'POST /products/import-pricing/batch' => 'check_write_permission',
         );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,7 @@ define('ABSPATH', __DIR__ . '/');
 define('WP_CLI', true);
 define('ARRAY_A', 'ARRAY_A');
 
+// phpcs:disable Generic.Formatting.MultipleStatementAlignment -- Preserve the intentionally simple test-global registry.
 $GLOBALS['digitalogic_test_capabilities'] = array();
 $GLOBALS['digitalogic_test_filters'] = array();
 $GLOBALS['digitalogic_test_routes'] = array();
@@ -31,6 +32,9 @@ $GLOBALS['digitalogic_test_wc_products'] = array();
 $GLOBALS['digitalogic_test_wc_product_saves'] = array();
 $GLOBALS['digitalogic_test_wc_save_failures'] = array();
 $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
+$GLOBALS['digitalogic_test_transients'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_transient_deletes'] = array(); // phpcs:ignore
+// phpcs:enable Generic.Formatting.MultipleStatementAlignment
 
 class WP_Error {
     private $code;
@@ -61,6 +65,8 @@ class WP_REST_Request implements ArrayAccess {
     private $json;
     private $headers;
     private $body;
+    private $route = ''; // phpcs:ignore
+    private $method = ''; // phpcs:ignore
 
     public function __construct($params = array(), $json = array(), $headers = array(), $body = null) {
         $this->params = is_array($params) ? $params : array();
@@ -90,6 +96,26 @@ class WP_REST_Request implements ArrayAccess {
     public function get_body() {
         return $this->body;
     }
+
+// phpcs:disable -- Test-only REST request compatibility methods follow the legacy bootstrap style.
+    public function set_route($route) {
+        $this->route = (string) $route;
+        return $this;
+    }
+
+    public function get_route() {
+        return $this->route;
+    }
+
+    public function set_method($method) {
+        $this->method = strtoupper((string) $method);
+        return $this;
+    }
+
+    public function get_method() {
+        return $this->method;
+    }
+// phpcs:enable
 
     public function offsetExists($offset): bool {
         return array_key_exists($offset, $this->params);
@@ -312,6 +338,39 @@ function delete_option($name) {
     unset($GLOBALS['digitalogic_test_option_cache'][$name]);
     return true;
 }
+
+// phpcs:disable -- Test-only transient stubs follow the legacy bootstrap style.
+function get_transient($name) {
+    if (!isset($GLOBALS['digitalogic_test_transients'][$name])) {
+        return false;
+    }
+
+    $transient = $GLOBALS['digitalogic_test_transients'][$name];
+    if ($transient['expires'] > 0 && $transient['expires'] <= time()) {
+        unset($GLOBALS['digitalogic_test_transients'][$name]);
+        return false;
+    }
+
+    return $transient['value'];
+}
+
+function set_transient($name, $value, $expiration = 0) {
+    $GLOBALS['digitalogic_test_transients'][$name] = array(
+        'value' => $value,
+        'expires' => $expiration > 0 ? time() + (int) $expiration : 0,
+    );
+
+    return true;
+}
+
+function delete_transient($name) {
+    $GLOBALS['digitalogic_test_transient_deletes'][] = $name;
+    $exists = isset($GLOBALS['digitalogic_test_transients'][$name]);
+    unset($GLOBALS['digitalogic_test_transients'][$name]);
+
+    return $exists;
+}
+// phpcs:enable
 
 function wp_cache_delete($key, $group = '') {
     $GLOBALS['digitalogic_test_cache_deletes'][] = array($key, $group);
@@ -1084,6 +1143,7 @@ $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
 
 require_once dirname(__DIR__) . '/includes/class-unit-converter.php';
 require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';
+require_once dirname(__DIR__) . '/includes/class-digitalogic-pricing-input-credential.php'; // phpcs:ignore
 require_once dirname(__DIR__) . '/includes/class-patris-feed.php';
 require_once dirname(__DIR__) . '/includes/class-product-sync-receiver.php';
 require_once dirname(__DIR__) . '/includes/class-import-freight-service.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -648,6 +648,11 @@ class Digitalogic_Test_WPDB {
     public $after_rollback = null;
     public $identifier_query_count = 0;
     public $option_read_counts = array();
+    // phpcs:disable -- Deterministic lifecycle-interleaving hooks for focused tests.
+    public $before_get_lock = null;
+    public $after_option_write = null;
+    public $lock_timeouts = array();
+    // phpcs:enable
     private $transaction_snapshot = null;
     private $meta_ids = array();
     private $next_meta_id = 1;
@@ -663,6 +668,15 @@ class Digitalogic_Test_WPDB {
         $query = is_array($prepared) && isset($prepared['query']) ? $prepared['query'] : (string) $prepared;
         if (strpos($query, 'GET_LOCK') !== false) {
             $this->acquire_count++;
+            // phpcs:disable -- Test-only interleaving hook follows the legacy bootstrap style.
+            $args = is_array($prepared) && isset($prepared['args']) ? $prepared['args'] : array();
+            $this->lock_timeouts[] = isset($args[1]) ? (int) $args[1] : null;
+            $callback = $this->before_get_lock;
+            $this->before_get_lock = null;
+            if (is_callable($callback)) {
+                call_user_func($callback, $this);
+            }
+            // phpcs:enable
             return $this->acquire_result;
         }
 
@@ -769,6 +783,13 @@ class Digitalogic_Test_WPDB {
             }
             $GLOBALS['digitalogic_test_options'][$name] = $this->stored_database_value($data['option_value']);
             $this->insert_id++;
+            // phpcs:disable -- Test-only interleaving hook follows the legacy bootstrap style.
+            $callback = $this->after_option_write;
+            $this->after_option_write = null;
+            if (is_callable($callback)) {
+                call_user_func($callback, $this, $name);
+            }
+            // phpcs:enable
             return 1;
         }
 
@@ -800,6 +821,13 @@ class Digitalogic_Test_WPDB {
                 return 0;
             }
             $GLOBALS['digitalogic_test_options'][$name] = $this->stored_database_value($data['option_value']);
+            // phpcs:disable -- Test-only interleaving hook follows the legacy bootstrap style.
+            $callback = $this->after_option_write;
+            $this->after_option_write = null;
+            if (is_callable($callback)) {
+                call_user_func($callback, $this, $name);
+            }
+            // phpcs:enable
             return 1;
         }
 


### PR DESCRIPTION
## Summary

- add one rotatable, route/method-scoped pricing-input Bearer identity for Patris
- authorize only `GET /digitalogic/v1/integration/catalog` and `POST /digitalogic/v1/pricing-assignments/batch`
- preserve normal `manage_woocommerce` access while removing these routes from the broad integration read filter
- add administrator-only WP-CLI create, rotate, revoke, and metadata-only status commands
- keep cold catalog reads non-mutating by projecting canonical freight defaults in memory
- document `BearerTokenEnv` wiring and deployment canaries without literal credentials

## Security boundary

- accepts only an exact `Authorization: Bearer ...` header; query, cookie, URL-userinfo, Basic-as-machine, legacy push, and product-sync credentials do not authorize it
- stores only a SHA-256 verifier plus nonsecret lifecycle metadata and performs constant-time ID/verifier comparisons
- verifies from authoritative database state so a stale option/object cache cannot preserve a rotated or revoked verifier
- serializes create/rotate/revoke with a site-scoped MariaDB/MySQL advisory lock, optimistic pre-lock fingerprint, row-locked transaction, exact readback, and cache invalidation
- overlapping creates/rotates reveal at most one valid secret; a later non-overlapping rotate still works; revoke wins either overlap order and cannot be undone
- no secret is returned until the durable record passes readback and commit; lock/storage/conflict failures are sanitized and fail closed
- throttles only invalid credentials in token-free client/generation buckets; a correct credential is verified first and clears its bucket, preventing shared-proxy lockout

## Validation

Exact head `e58f629`:

- `PricingInputCredentialTest`: 14 tests, 178 assertions
- `ImportFreightServiceTest`: 50 tests, 537 assertions
- `RestApiPermissionsTest`: 22 tests, 60 assertions
- prior full local suite excluding the known Windows-hanging `WebSocketLifecycleTest`: 130 tests, 1,017 assertions
- Node authentication/navigation tests: 6 passed
- Composer strict validation and locked audit: passed, no advisories
- credential class WordPress PHPCS: 0 errors, 0 warnings
- repository legacy PHPCS remained within its enforced baseline
- PHP syntax, `git diff --check`, and public-tree backup-artifact checks: passed
- all four fresh GitHub jobs passed, including the canonical Linux plugin package
- downloaded package manifest SHA-256 matched; 727 entries, no tests, `.git`, environment files, literal generated credential, or suspicious secret artifacts; credential class/loaders are byte-identical to this head
- production compatibility check: MariaDB 11.8 supports the required advisory lock operations and the WordPress options table is InnoDB

References #60 and #59. Both issues intentionally remain open until deployment and live unauthorized/wrong/correct/rotate canaries are complete.