### PR TITLE
Separate deferred product reconciliation from sync retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Bounded product-sync deferred reconciliation state and administrator WP-CLI status/retry commands, separating terminal missing/ambiguous Codes from transient HTTP retries.
 - Canonical nullable global default percentage markup with exact decimal storage, REST/command/admin controls, catalog revisioning, and result-aware delivery events.
 - **WordPress Admin Bar integration** with quicklinks menu
   - Parent menu item with WooCommerce-focused cart icon (dashicons-cart)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Bounded product-sync deferred reconciliation state and administrator WP-CLI status/retry commands, separating terminal missing/ambiguous Codes from transient HTTP retries.
+- Bounded product-sync deferred reconciliation state and administrator WP-CLI status/retry commands, separating terminal missing/ambiguous Codes from transient HTTP/database retries.
 - Canonical nullable global default percentage markup with exact decimal storage, REST/command/admin controls, catalog revisioning, and result-aware delivery events.
 - **WordPress Admin Bar integration** with quicklinks menu
   - Parent menu item with WooCommerce-focused cart icon (dashicons-cart)

--- a/README.md
+++ b/README.md
@@ -183,9 +183,13 @@ shipping. See [Import Freight Integration Contract](docs/IMPORT-FREIGHT-API.md).
 
 The v1 receiver uses a dedicated header-only secret, independently recomputes
 `landed_price_v1`, verifies record/source/occurrence hashes, merges deltas, and
-keeps failed Woo writes in a durable idempotent outbox. Patris Code is canonical
-and deleted Codes are receiver-state tombstones, never WooCommerce deletions.
-See [Patris Product Sync v1](docs/PATRIS-PRODUCT-SYNC-V1.md).
+keeps transient Woo failures in a durable idempotent outbox. Missing and
+ambiguous Codes are bounded terminal reconciliation work, so they do not cause
+Patris HTTP retries. Patris Code is canonical and deleted Codes are
+receiver-state tombstones, never WooCommerce deletions. Inspect nonsecret counts
+with `wp digitalogic product-sync status`; an administrator can retry only
+durable pending/deferred work with `wp digitalogic product-sync reconcile
+--user=<administrator>`. See [Patris Product Sync v1](docs/PATRIS-PRODUCT-SYNC-V1.md).
 
 #### Export
 - `GET /wp-json/digitalogic/v1/export?format=csv` - Export products as CSV

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ The v1 receiver uses a dedicated header-only secret, independently recomputes
 `landed_price_v1`, verifies record/source/occurrence hashes, merges deltas, and
 keeps transient Woo failures in a durable idempotent outbox. Missing and
 ambiguous Codes are bounded terminal reconciliation work, so they do not cause
-Patris HTTP retries. Patris Code is canonical and deleted Codes are
+Patris HTTP retries. Database prepare/query failures remain transient and can
+never be reported as missing. Patris Code is canonical and deleted Codes are
 receiver-state tombstones, never WooCommerce deletions. Inspect nonsecret counts
 with `wp digitalogic product-sync status`; an administrator can retry only
 durable pending/deferred work with `wp digitalogic product-sync reconcile

--- a/docs/PATRIS-PRODUCT-SYNC-V1.md
+++ b/docs/PATRIS-PRODUCT-SYNC-V1.md
@@ -140,11 +140,14 @@ by fuzzy name matching.
 
 Receiver state is written under `digitalogic_product_sync_v1_state`, evicted
 from the option cache, and read back with a digest check before WooCommerce
-writes. Each source has a durable per-product pending outbox plus an applied
-`{record_hash,woocommerce_id}` CAS record. A successful persisted Woo record
-hash acknowledges crash-window retries without a duplicate save. Missing,
-ambiguous, and failed writes stay pending. The final outbox state is read back
-before the result-aware `digitalogic_product_sync_v1_applied` domain action.
+writes. Each source has an applied `{record_hash,woocommerce_id}` CAS record, a
+transient `pending_products` outbox, and a terminal `deferred_products`
+reconciliation set. A successful persisted Woo record hash acknowledges
+crash-window retries without a duplicate save. Woo lookup/storage/write
+failures stay pending; exact Code not-found and ambiguity move to deferred and
+are never guessed. The final delivery state is read back before the result-aware
+`digitalogic_product_sync_v1_applied` domain action. Existing v2 receiver state
+is projected and transactionally persisted as v3 under the same advisory lock.
 This state is independent of the legacy Patris feed option.
 
 ## Successful response
@@ -163,6 +166,13 @@ This state is independent of the legacy Patris feed option.
     "fully_applied": true,
     "retryable": false,
     "pending_products": 0,
+    "deferred_products": 0,
+    "deferred_reconciliation": {
+      "missing": 0,
+      "ambiguous": 0,
+      "details": [],
+      "details_truncated": 0
+    },
     "persistence_verified": true,
     "woocommerce": {
       "updated": 1,
@@ -178,10 +188,29 @@ This state is independent of the legacy Patris feed option.
 Validation errors use HTTP 400 or 422. Ordering conflicts use 409. A busy
 advisory lock or unavailable lock service returns retryable HTTP 503.
 
-When any WooCommerce target is missing, ambiguous, or fails to save, the HTTP
-request remains a verified receiver commit but `data.status` is
-`partially_applied`, `retryable` is true, and `pending_products` is non-zero.
-Send the identical event again after correcting the product or write failure.
+Only transient WooCommerce lookup/storage/write failures make `data.status`
+`partially_applied`, `retryable` true, and `pending_products` non-zero. Send the
+identical event again after correcting a transient failure.
+
+Missing and ambiguous Codes are terminal reconciliation work. A commit with
+only those rows is `accepted` (or `already_current`/`replayed`), has
+`retryable:false` and `pending_products:0`, and reports `deferred_products` as
+an unquoted JSON integer in the range 0..2,147,483,647 plus at most 100 typed
+detail rows. An identical replay is idempotent and does not re-query those
+Codes. Deferred Codes are retried by the next distinct source event or
+explicitly by an administrator:
+
+```shell
+wp digitalogic product-sync status
+wp digitalogic product-sync reconcile --user=<administrator>
+wp digitalogic product-sync reconcile \
+  --source-id=patris-office --dataset=kala.db --user=<administrator>
+```
+
+The status command exposes source/event identities and aggregate counts only;
+it does not print product payloads or credentials. Reconciliation processes
+only pending/deferred records, never already-applied writes, and preserves the
+stored source event ordering watermark.
 
 The synthetic cross-project fixture is 2,760 bytes with SHA-256
 `810bdf4d8fd5e3c2a87750a02f241363f6403736c899a625f615967fea259da5`.

--- a/docs/PATRIS-PRODUCT-SYNC-V1.md
+++ b/docs/PATRIS-PRODUCT-SYNC-V1.md
@@ -144,10 +144,13 @@ writes. Each source has an applied `{record_hash,woocommerce_id}` CAS record, a
 transient `pending_products` outbox, and a terminal `deferred_products`
 reconciliation set. A successful persisted Woo record hash acknowledges
 crash-window retries without a duplicate save. Woo lookup/storage/write
-failures stay pending; exact Code not-found and ambiguity move to deferred and
-are never guessed. The final delivery state is read back before the result-aware
+failures, including identifier database query failures, stay pending; exact
+Code not-found and ambiguity move to deferred only after a successful lookup
+and are never guessed. The final delivery state is read back before the result-aware
 `digitalogic_product_sync_v1_applied` domain action. Existing v2 receiver state
 is projected and transactionally persisted as v3 under the same advisory lock.
+Because v2 could not distinguish SQL failure from not-found, its not-found
+entries stay pending until one successful v3 lookup reclassifies them.
 This state is independent of the legacy Patris feed option.
 
 ## Successful response

--- a/includes/class-product-identifier-resolver.php
+++ b/includes/class-product-identifier-resolver.php
@@ -98,6 +98,9 @@ final class Digitalogic_Product_Identifier_Resolver {
             "(BINARY {$current_sku} = BINARY %s OR BINARY {$current_patris} = BINARY %s)",
             array($code, $code)
         );
+        if (is_wp_error($rows)) {
+            return $rows;
+        }
 
         $sku_matches = array();
         $patris_matches = array();
@@ -138,6 +141,9 @@ final class Digitalogic_Product_Identifier_Resolver {
 
     private function resolve_woocommerce_id($woocommerce_id) {
         $rows = $this->query_rows('woocommerce_id', 'p.ID = %d', array((int) $woocommerce_id));
+        if (is_wp_error($rows)) {
+            return $rows;
+        }
         if (empty($rows)) {
             return $this->not_found('No product or variation has that exact WooCommerce ID.');
         }
@@ -156,6 +162,9 @@ final class Digitalogic_Product_Identifier_Resolver {
             "BINARY {$current_value} = BINARY %s",
             array($meta_key, $value)
         );
+        if (is_wp_error($rows)) {
+            return $rows;
+        }
 
         // Defend exactness again in PHP in case a database collation or test
         // adapter returns a broader row set than the BINARY predicate.
@@ -177,6 +186,9 @@ final class Digitalogic_Product_Identifier_Resolver {
      */
     private function query_rows($marker, $predicate, $args) {
         global $wpdb;
+        if (!is_object($wpdb) || !method_exists($wpdb, 'prepare') || !method_exists($wpdb, 'get_results')) {
+            return $this->query_failed();
+        }
         $posts = isset($wpdb->posts) ? $wpdb->posts : $wpdb->prefix . 'posts';
         $postmeta = isset($wpdb->postmeta) ? $wpdb->postmeta : $wpdb->prefix . 'postmeta';
         $query = "/* digitalogic_identifier:{$marker} */
@@ -197,7 +209,21 @@ final class Digitalogic_Product_Identifier_Resolver {
                 AND {$predicate}
             ORDER BY p.ID ASC";
 
-        return $wpdb->get_results($wpdb->prepare($query, ...$args), ARRAY_A);
+        try {
+            $prepared = $wpdb->prepare($query, ...$args);
+            if (false === $prepared || null === $prepared || '' === $prepared) {
+                return $this->query_failed();
+            }
+            $rows = $wpdb->get_results($prepared, ARRAY_A);
+        } catch (Throwable) {
+            return $this->query_failed();
+        }
+
+        if (!is_array($rows) || '' !== trim((string) ($wpdb->last_error ?? ''))) {
+            return $this->query_failed();
+        }
+
+        return $rows;
     }
 
     private function one_or_ambiguous($rows, $resolved_by, $value) {
@@ -273,6 +299,17 @@ final class Digitalogic_Product_Identifier_Resolver {
             'digitalogic_product_identifier_not_found',
             __($message, 'digitalogic'),
             array('status' => 404)
+        );
+    }
+
+    private function query_failed() {
+        return new WP_Error(
+            'digitalogic_product_identifier_query_failed',
+            __('The product identifier lookup could not be completed.', 'digitalogic'),
+            array(
+                'status' => 503,
+                'retryable' => true,
+            )
         );
     }
 }

--- a/includes/class-product-sync-receiver.php
+++ b/includes/class-product-sync-receiver.php
@@ -1430,6 +1430,14 @@ class Digitalogic_Product_Sync_Receiver {
         return null;
     }
 
+    private function v2_terminal_resolution_reason($error_code) {
+        // v2 collapsed SQL lookup failures into not_found, so only a proven
+        // multi-row ambiguity can be migrated without first querying again.
+        return 'digitalogic_product_identifier_ambiguous' === $error_code
+            ? 'ambiguous'
+            : null;
+    }
+
     /**
      * Project v2 delivery state into v3 without discarding retry metadata.
      *
@@ -1449,7 +1457,7 @@ class Digitalogic_Product_Sync_Receiver {
             $deferred = array();
             foreach ($pending as $code => $entry) {
                 $reason = is_array($entry)
-                    ? $this->terminal_resolution_reason((string) ($entry['last_error'] ?? ''))
+                    ? $this->v2_terminal_resolution_reason((string) ($entry['last_error'] ?? ''))
                     : null;
                 if (null === $reason) {
                     continue;

--- a/includes/class-product-sync-receiver.php
+++ b/includes/class-product-sync-receiver.php
@@ -237,7 +237,7 @@ class Digitalogic_Product_Sync_Receiver {
     public const CONTRACT_NAME = 'digitalogic.product-sync';
     public const FORMULA_ID = 'landed_price_v1';
 
-    private const STATE_VERSION = 2;
+    private const STATE_VERSION = 3;
     private const LOCK_NAME = 'digitalogic_product_sync_v1';
     private const LOCK_TIMEOUT_SECONDS = 15;
     private const MAX_BODY_BYTES = 8388608;
@@ -246,6 +246,7 @@ class Digitalogic_Product_Sync_Receiver {
     private const MAX_SOURCES = 16;
     private const MAX_RECENT_EVENTS = 128;
     private const MAX_RESULT_ERRORS = 100;
+    private const MAX_DEFERRED_PRODUCTS = self::MAX_PRODUCTS;
     private const MAX_CODE_LENGTH = 191;
     private const MAX_FORMULA_INTEGER_DIGITS = 15;
     private const MAX_FORMULA_SCALE = 12;
@@ -431,17 +432,161 @@ class Digitalogic_Product_Sync_Receiver {
         }
     }
 
+    // phpcs:disable -- Preserve the established receiver formatting while the legacy file remains baseline-managed.
     /**
      * Return the stored state for diagnostics and tests.
      *
      * @return array
      */
     public function get_state() {
+        $migration_required = false;
+
+        return $this->load_state($migration_required);
+    }
+
+    /**
+     * Return a bounded, nonsecret operational summary.
+     *
+     * @return array
+     */
+    public function get_status() {
+        $state = $this->get_state();
+        $sources = array();
+        $totals = array(
+            'stored_products' => 0,
+            'applied_products' => 0,
+            'pending_products' => 0,
+            'deferred_products' => 0,
+        );
+        ksort($state['sources'], SORT_STRING);
+
+        foreach ($state['sources'] as $source_state) {
+            if (!is_array($source_state)) {
+                continue;
+            }
+            $summary = $this->source_status($source_state);
+            $sources[] = $summary;
+            foreach ($totals as $field => $_unused) {
+                $totals[$field] += $summary[$field];
+            }
+        }
+
+        return array(
+            'state_version' => self::STATE_VERSION,
+            'source_count' => count($sources),
+            'totals' => $totals,
+            'sources' => $sources,
+        );
+    }
+
+    /**
+     * Retry only durable delivery work, without changing source ordering.
+     *
+     * Applied records are never replayed. Deferred reconciliation and any
+     * transient pending writes are attempted under the receiver lock.
+     *
+     * @param string|null $source_id Optional exact source id.
+     * @param string|null $dataset Optional exact source dataset.
+     * @return array|WP_Error
+     */
+    public function reconcile($source_id = null, $dataset = null) {
+        if ((null === $source_id) !== (null === $dataset)) {
+            return $this->error(
+                'digitalogic_product_sync_reconcile_scope_invalid',
+                'Source id and dataset must be provided together.',
+                400
+            );
+        }
+
+        $locked = $this->acquire_lock();
+        if (is_wp_error($locked)) {
+            return $locked;
+        }
+
+        try {
+            $migration_required = false;
+            $state = $this->load_state($migration_required);
+            $selected = array();
+            if (null !== $source_id) {
+                $source_key = $this->source_key((string) $source_id, (string) $dataset);
+                if (!isset($state['sources'][$source_key]) || !is_array($state['sources'][$source_key])) {
+                    return $this->error(
+                        'digitalogic_product_sync_source_not_found',
+                        'The requested product-sync source was not found.',
+                        404
+                    );
+                }
+                $selected[] = $source_key;
+            } else {
+                $selected = array_keys($state['sources']);
+                sort($selected, SORT_STRING);
+            }
+
+            $before = $this->state_digest($state);
+            $sources = array();
+            $pending_total = 0;
+            $deferred_total = 0;
+            foreach ($selected as $source_key) {
+                $woo = $this->drain_delivery_products($state['sources'][$source_key], true, true);
+                $source_result = $this->source_status($state['sources'][$source_key]);
+                $source_result['woocommerce'] = $woo;
+                $sources[] = $source_result;
+                $pending_total += $source_result['pending_products'];
+                $deferred_total += $source_result['deferred_products'];
+            }
+
+            if ($migration_required || !hash_equals($before, $this->state_digest($state))) {
+                $stored = $this->persist_and_read_back($state);
+                if (is_wp_error($stored)) {
+                    return $stored;
+                }
+            }
+
+            return array(
+                'status' => $pending_total > 0 ? 'partially_applied' : 'reconciled',
+                'retryable' => $pending_total > 0,
+                'pending_products' => $pending_total,
+                'deferred_products' => $deferred_total,
+                'source_count' => count($sources),
+                'sources' => $sources,
+                'source_order_unchanged' => true,
+                'persistence_verified' => true,
+            );
+        } catch (Throwable $exception) {
+            return $this->error(
+                'digitalogic_product_sync_reconcile_failed',
+                'Deferred product reconciliation failed.',
+                500,
+                array('exception' => get_class($exception))
+            );
+        } finally {
+            $this->release_lock();
+        }
+    }
+
+    private function load_state(&$migration_required) {
         $state = get_option(self::STATE_OPTION, array());
-        if (!is_array($state) || (int) ($state['version'] ?? 0) !== self::STATE_VERSION) {
+        $migration_required = false;
+        if (!is_array($state)) {
+            return array('version' => self::STATE_VERSION, 'sources' => array());
+        }
+        $version = (int) ($state['version'] ?? 0);
+        if (2 === $version) {
+            $state = $this->migrate_v2_state($state);
+            $migration_required = true;
+        } elseif (self::STATE_VERSION !== $version) {
             return array('version' => self::STATE_VERSION, 'sources' => array());
         }
         $state['sources'] = isset($state['sources']) && is_array($state['sources']) ? $state['sources'] : array();
+        foreach ($state['sources'] as &$source_state) {
+            if (!is_array($source_state)) {
+                $source_state = array();
+            }
+            $source_state['deferred_products'] = is_array($source_state['deferred_products'] ?? null)
+                ? array_slice($source_state['deferred_products'], 0, self::MAX_DEFERRED_PRODUCTS, true)
+                : array();
+        }
+        unset($source_state);
 
         return $state;
     }
@@ -454,9 +599,18 @@ class Digitalogic_Product_Sync_Receiver {
             ? $state['sources'][$key]
             : array();
     }
+    // phpcs:enable
 
+    // phpcs:disable -- Preserve the established receiver formatting while the legacy file remains baseline-managed.
     private function receive_locked($envelope) {
-        $state = $this->get_state();
+        $migration_required = false;
+        $state = $this->load_state($migration_required);
+        if ($migration_required) {
+            $migrated = $this->persist_and_read_back($state);
+            if (is_wp_error($migrated)) {
+                return $migrated;
+            }
+        }
         $source_key = $this->source_key($envelope['source']['id'], $envelope['source']['dataset']);
         $existing = isset($state['sources'][$source_key]) && is_array($state['sources'][$source_key])
             ? $state['sources'][$source_key]
@@ -527,6 +681,7 @@ class Digitalogic_Product_Sync_Receiver {
             'recent_events' => $recent_events,
             'applied_products' => $delivery['applied_products'],
             'pending_products' => $delivery['pending_products'],
+            'deferred_products' => $delivery['deferred_products'],
             'received_at' => current_time('mysql'),
         );
         $state['sources'][$source_key] = $source_state;
@@ -537,7 +692,7 @@ class Digitalogic_Product_Sync_Receiver {
         }
 
         $before_delivery = $this->state_digest($source_state);
-        $woo = $this->drain_pending_products($source_state);
+        $woo = $this->drain_delivery_products($source_state, true, true);
         $state['sources'][$source_key] = $source_state;
         if (!hash_equals($before_delivery, $this->state_digest($source_state))) {
             $delivery_stored = $this->persist_and_read_back($state);
@@ -547,9 +702,8 @@ class Digitalogic_Product_Sync_Receiver {
         }
 
         $fully_applied = empty($source_state['pending_products']);
-        $status = $fully_applied ? ($same_revision ? 'already_current' : 'accepted') : 'partially_applied';
-        $result = array(
-            'status' => $status,
+        $result = array_merge(array(
+            'status' => $fully_applied ? ($same_revision ? 'already_current' : 'accepted') : 'partially_applied',
             'replayed' => false,
             'event_id' => $envelope['event_id'],
             'event_type' => $envelope['event_type'],
@@ -559,11 +713,8 @@ class Digitalogic_Product_Sync_Receiver {
             'deleted_codes' => $transition['deleted_count'],
             'preserved_quarantined' => $transition['preserved_quarantined'],
             'woocommerce' => $woo,
-            'fully_applied' => $fully_applied,
-            'retryable' => !$fully_applied,
-            'pending_products' => count($source_state['pending_products']),
             'persistence_verified' => true,
-        );
+        ), $this->delivery_result_state($source_state));
 
         return $this->emit_result($result, $envelope);
     }
@@ -571,7 +722,7 @@ class Digitalogic_Product_Sync_Receiver {
     private function retry_pending_locked($state, $source_key, $envelope, $existing) {
         $source_state = $existing;
         $before_delivery = $this->state_digest($source_state);
-        $woo = $this->drain_pending_products($source_state);
+        $woo = $this->drain_delivery_products($source_state, true, false);
         $state['sources'][$source_key] = $source_state;
         if (!hash_equals($before_delivery, $this->state_digest($source_state))) {
             $stored = $this->persist_and_read_back($state);
@@ -581,7 +732,7 @@ class Digitalogic_Product_Sync_Receiver {
         }
 
         $fully_applied = empty($source_state['pending_products']);
-        $result = array(
+        $result = array_merge(array(
             'status' => $fully_applied ? 'recovered' : 'retry_pending',
             'replayed' => true,
             'event_id' => $envelope['event_id'],
@@ -589,14 +740,12 @@ class Digitalogic_Product_Sync_Receiver {
             'source' => $envelope['source'],
             'stored_products' => count($source_state['products'] ?? array()),
             'woocommerce' => $woo,
-            'fully_applied' => $fully_applied,
-            'retryable' => !$fully_applied,
-            'pending_products' => count($source_state['pending_products']),
             'persistence_verified' => true,
-        );
+        ), $this->delivery_result_state($source_state));
 
         return $this->emit_result($result, $envelope);
     }
+    // phpcs:enable
 
     private function emit_result($result, $envelope) {
         try {
@@ -1038,25 +1187,19 @@ class Digitalogic_Product_Sync_Receiver {
         );
     }
 
+    // phpcs:disable -- Preserve the established receiver formatting while the legacy file remains baseline-managed.
     private function build_delivery_state($products, $changed_products, $envelope, $existing) {
         $applied = is_array($existing['applied_products'] ?? null) ? $existing['applied_products'] : array();
         $pending = is_array($existing['pending_products'] ?? null) ? $existing['pending_products'] : array();
+        $deferred = is_array($existing['deferred_products'] ?? null) ? $existing['deferred_products'] : array();
 
         foreach ($applied as $code => $entry) {
             if (!isset($products[$code]) || !is_array($entry) || !isset($entry['record_hash'], $entry['woocommerce_id'])) {
                 unset($applied[$code]);
             }
         }
-        foreach ($pending as $code => $entry) {
-            if (
-                !isset($products[$code])
-                || !is_array($entry)
-                || !isset($entry['record_hash'])
-                || !hash_equals((string) $products[$code]['record_hash'], (string) $entry['record_hash'])
-            ) {
-                unset($pending[$code]);
-            }
-        }
+        $pending = $this->prune_delivery_set($products, $pending);
+        $deferred = $this->prune_delivery_set($products, $deferred);
 
         foreach ($changed_products as $product) {
             $code = $product['product_code'];
@@ -1064,26 +1207,43 @@ class Digitalogic_Product_Sync_Receiver {
             $applied_entry = is_array($applied[$code] ?? null) ? $applied[$code] : array();
             if (isset($applied_entry['record_hash']) && hash_equals((string) $applied_entry['record_hash'], $record_hash)) {
                 unset($pending[$code]);
+                unset($deferred[$code]);
                 continue;
             }
 
             $pending_entry = is_array($pending[$code] ?? null) ? $pending[$code] : array();
-            if (!isset($pending_entry['record_hash']) || !hash_equals((string) $pending_entry['record_hash'], $record_hash)) {
+            $deferred_entry = is_array($deferred[$code] ?? null) ? $deferred[$code] : array();
+            $existing_entry = !empty($pending_entry) ? $pending_entry : $deferred_entry;
+            if (!isset($existing_entry['record_hash']) || !hash_equals((string) $existing_entry['record_hash'], $record_hash)) {
                 $pending_entry = array(
                     'record_hash' => $record_hash,
                     'queued_event_id' => $envelope['event_id'],
                     'attempts' => 0,
                 );
+                $pending[$code] = $pending_entry;
+                unset($deferred[$code]);
             }
-            $pending[$code] = $pending_entry;
         }
 
         ksort($applied, SORT_STRING);
         ksort($pending, SORT_STRING);
-        return array('applied_products' => $applied, 'pending_products' => $pending);
+        ksort($deferred, SORT_STRING);
+        return array(
+            'applied_products' => $applied,
+            'pending_products' => $pending,
+            'deferred_products' => array_slice($deferred, 0, self::MAX_DEFERRED_PRODUCTS, true),
+        );
     }
 
-    private function drain_pending_products(&$source_state) {
+    /**
+     * Drain selected durable delivery sets and classify outcomes once.
+     *
+     * @param array $source_state Source state, updated in place.
+     * @param bool  $include_pending Retry transient work.
+     * @param bool  $include_deferred Retry terminal reconciliation work.
+     * @return array
+     */
+    private function drain_delivery_products(&$source_state, $include_pending, $include_deferred) {
         $result = array(
             'attempted' => 0,
             'updated' => 0,
@@ -1096,38 +1256,54 @@ class Digitalogic_Product_Sync_Receiver {
         );
         $products = is_array($source_state['products'] ?? null) ? $source_state['products'] : array();
         $pending = is_array($source_state['pending_products'] ?? null) ? $source_state['pending_products'] : array();
+        $deferred = is_array($source_state['deferred_products'] ?? null) ? $source_state['deferred_products'] : array();
         $applied = is_array($source_state['applied_products'] ?? null) ? $source_state['applied_products'] : array();
-        ksort($pending, SORT_STRING);
+        $work = array();
+        if ($include_deferred) {
+            $work = $deferred;
+        }
+        if ($include_pending) {
+            $work = array_replace($work, $pending);
+        }
+        ksort($work, SORT_STRING);
 
-        foreach ($pending as $code => &$pending_entry) {
-            if (!isset($products[$code]) || !is_array($pending_entry)) {
+        foreach ($work as $code => $delivery_entry) {
+            if (!$this->valid_delivery_entry($products, $code, $delivery_entry)) {
                 unset($pending[$code]);
+                unset($deferred[$code]);
                 continue;
             }
             $product_data = $products[$code];
-            $record_hash = (string) ($pending_entry['record_hash'] ?? '');
-            if (!hash_equals((string) $product_data['record_hash'], $record_hash)) {
-                unset($pending[$code]);
-                continue;
-            }
+            $record_hash = (string) $delivery_entry['record_hash'];
 
             $result['attempted']++;
             $resolved = Digitalogic_Product_Identifier_Resolver::instance()->resolve(array(
                 'code' => $code,
             ));
             if (is_wp_error($resolved)) {
-                if ('digitalogic_product_identifier_not_found' === $resolved->get_error_code()) {
+                $error_code = $resolved->get_error_code();
+                $deferred_reason = $this->terminal_resolution_reason($error_code);
+                if ('missing' === $deferred_reason) {
                     $result['missing']++;
-                } elseif ('digitalogic_product_identifier_ambiguous' === $resolved->get_error_code()) {
+                } elseif ('ambiguous' === $deferred_reason) {
                     $result['ambiguous']++;
                 } else {
                     $result['failed']++;
                 }
-                $this->mark_pending_failure($pending_entry, $resolved->get_error_code());
+                $this->mark_delivery_failure($delivery_entry, $error_code);
+                if (null !== $deferred_reason) {
+                    $delivery_entry['reason'] = $deferred_reason;
+                    $deferred[$code] = $delivery_entry;
+                    unset($pending[$code]);
+                } else {
+                    unset($delivery_entry['reason']);
+                    $pending[$code] = $delivery_entry;
+                    unset($deferred[$code]);
+                }
                 $this->append_woo_error($result, array(
                     'product_code' => $code,
-                    'code' => $resolved->get_error_code(),
-                    'retryable' => true,
+                    'code' => $error_code,
+                    'retryable' => null === $deferred_reason,
                 ));
                 continue;
             }
@@ -1140,6 +1316,7 @@ class Digitalogic_Product_Sync_Receiver {
                 && (string) $applied_entry['woocommerce_id'] === (string) $woocommerce_id
             ) {
                 unset($pending[$code]);
+                unset($deferred[$code]);
                 $result['already_applied']++;
                 continue;
             }
@@ -1151,6 +1328,7 @@ class Digitalogic_Product_Sync_Receiver {
                     'woocommerce_id' => (string) $woocommerce_id,
                 );
                 unset($pending[$code]);
+                unset($deferred[$code]);
                 $result['already_applied']++;
                 continue;
             }
@@ -1158,7 +1336,10 @@ class Digitalogic_Product_Sync_Receiver {
             $product = wc_get_product($woocommerce_id);
             if (!$product) {
                 $result['failed']++;
-                $this->mark_pending_failure($pending_entry, 'digitalogic_product_sync_woocommerce_product_unavailable');
+                $this->mark_delivery_failure($delivery_entry, 'digitalogic_product_sync_woocommerce_product_unavailable');
+                unset($delivery_entry['reason']);
+                $pending[$code] = $delivery_entry;
+                unset($deferred[$code]);
                 $this->append_woo_error($result, array(
                     'product_code' => $code,
                     'code' => 'digitalogic_product_sync_woocommerce_product_unavailable',
@@ -1178,10 +1359,14 @@ class Digitalogic_Product_Sync_Receiver {
                     'woocommerce_id' => (string) $woocommerce_id,
                 );
                 unset($pending[$code]);
+                unset($deferred[$code]);
                 $result['updated']++;
             } catch (Throwable $exception) {
                 $result['failed']++;
-                $this->mark_pending_failure($pending_entry, 'digitalogic_product_sync_woocommerce_write_failed');
+                $this->mark_delivery_failure($delivery_entry, 'digitalogic_product_sync_woocommerce_write_failed');
+                unset($delivery_entry['reason']);
+                $pending[$code] = $delivery_entry;
+                unset($deferred[$code]);
                 $this->append_woo_error($result, array(
                     'product_code' => $code,
                     'code' => 'digitalogic_product_sync_woocommerce_write_failed',
@@ -1189,21 +1374,41 @@ class Digitalogic_Product_Sync_Receiver {
                 ));
             }
         }
-        unset($pending_entry);
 
         ksort($pending, SORT_STRING);
+        ksort($deferred, SORT_STRING);
         ksort($applied, SORT_STRING);
         $source_state['pending_products'] = $pending;
+        $source_state['deferred_products'] = array_slice($deferred, 0, self::MAX_DEFERRED_PRODUCTS, true);
         $source_state['applied_products'] = $applied;
         $result['pending'] = count($pending);
+        $result['deferred'] = count($source_state['deferred_products']);
 
         return $result;
     }
 
-    private function mark_pending_failure(&$pending_entry, $code) {
-        $pending_entry['attempts'] = max(0, (int) ($pending_entry['attempts'] ?? 0)) + 1;
-        $pending_entry['last_error'] = (string) $code;
-        $pending_entry['last_attempt_at'] = current_time('mysql');
+    private function valid_delivery_entry($products, $code, $entry) {
+        return isset($products[$code])
+            && is_array($entry)
+            && isset($entry['record_hash'])
+            && hash_equals((string) $products[$code]['record_hash'], (string) $entry['record_hash']);
+    }
+
+    private function prune_delivery_set($products, $delivery_set) {
+        foreach ($delivery_set as $code => $entry) {
+            if (!$this->valid_delivery_entry($products, $code, $entry)) {
+                unset($delivery_set[$code]);
+            }
+        }
+
+        return $delivery_set;
+    }
+
+    private function mark_delivery_failure(&$delivery_entry, $code) {
+        $attempts = max(0, (int) ($delivery_entry['attempts'] ?? 0));
+        $delivery_entry['attempts'] = $attempts < PHP_INT_MAX ? $attempts + 1 : PHP_INT_MAX;
+        $delivery_entry['last_error'] = (string) $code;
+        $delivery_entry['last_attempt_at'] = current_time('mysql');
     }
 
     private function append_woo_error(&$result, $error) {
@@ -1213,6 +1418,129 @@ class Digitalogic_Product_Sync_Receiver {
             $result['errors_truncated']++;
         }
     }
+
+    private function terminal_resolution_reason($error_code) {
+        if ('digitalogic_product_identifier_not_found' === $error_code) {
+            return 'missing';
+        }
+        if ('digitalogic_product_identifier_ambiguous' === $error_code) {
+            return 'ambiguous';
+        }
+
+        return null;
+    }
+
+    /**
+     * Project v2 delivery state into v3 without discarding retry metadata.
+     *
+     * The migration is persisted by receive() or reconcile() while holding the
+     * same advisory lock used for normal event delivery.
+     */
+    private function migrate_v2_state($state) {
+        $state['version'] = self::STATE_VERSION;
+        $sources = is_array($state['sources'] ?? null) ? $state['sources'] : array();
+        foreach ($sources as &$source_state) {
+            if (!is_array($source_state)) {
+                $source_state = array();
+            }
+            $pending = is_array($source_state['pending_products'] ?? null)
+                ? $source_state['pending_products']
+                : array();
+            $deferred = array();
+            foreach ($pending as $code => $entry) {
+                $reason = is_array($entry)
+                    ? $this->terminal_resolution_reason((string) ($entry['last_error'] ?? ''))
+                    : null;
+                if (null === $reason) {
+                    continue;
+                }
+                $entry['reason'] = $reason;
+                $deferred[$code] = $entry;
+                unset($pending[$code]);
+            }
+            ksort($pending, SORT_STRING);
+            ksort($deferred, SORT_STRING);
+            $source_state['pending_products'] = $pending;
+            $source_state['deferred_products'] = array_slice(
+                $deferred,
+                0,
+                self::MAX_DEFERRED_PRODUCTS,
+                true
+            );
+        }
+        unset($source_state);
+        $state['sources'] = $sources;
+
+        return $state;
+    }
+
+    private function deferred_summary($deferred) {
+        $deferred = is_array($deferred) ? $deferred : array();
+        ksort($deferred, SORT_STRING);
+        $summary = array(
+            'missing' => 0,
+            'ambiguous' => 0,
+            'details' => array(),
+            'details_truncated' => 0,
+        );
+        foreach ($deferred as $code => $entry) {
+            $reason = is_array($entry) ? (string) ($entry['reason'] ?? '') : '';
+            if ('ambiguous' === $reason) {
+                $summary['ambiguous']++;
+            } else {
+                $reason = 'missing';
+                $summary['missing']++;
+            }
+            if (count($summary['details']) < self::MAX_RESULT_ERRORS) {
+                $summary['details'][] = array(
+                    'product_code' => (string) $code,
+                    'reason' => $reason,
+                    'code' => is_array($entry) ? (string) ($entry['last_error'] ?? '') : '',
+                );
+            } else {
+                $summary['details_truncated']++;
+            }
+        }
+
+        return $summary;
+    }
+
+    private function delivery_result_state($source_state) {
+        $pending = is_array($source_state['pending_products'] ?? null)
+            ? $source_state['pending_products']
+            : array();
+        $deferred = is_array($source_state['deferred_products'] ?? null)
+            ? $source_state['deferred_products']
+            : array();
+        $fully_applied = empty($pending);
+
+        return array(
+            'fully_applied' => $fully_applied,
+            'retryable' => !$fully_applied,
+            'pending_products' => count($pending),
+            'deferred_products' => count($deferred),
+            'deferred_reconciliation' => $this->deferred_summary($deferred),
+        );
+    }
+
+    private function source_status($source_state) {
+        $source = is_array($source_state['source'] ?? null) ? $source_state['source'] : array();
+
+        return array(
+            'source' => array(
+                'id' => (string) ($source['id'] ?? ''),
+                'dataset' => (string) ($source['dataset'] ?? ''),
+                'revision' => (string) ($source['revision'] ?? ''),
+            ),
+            'generated_at' => (string) ($source_state['generated_at'] ?? ''),
+            'last_event_id' => (string) ($source_state['last_event_id'] ?? ''),
+            'stored_products' => count(is_array($source_state['products'] ?? null) ? $source_state['products'] : array()),
+            'applied_products' => count(is_array($source_state['applied_products'] ?? null) ? $source_state['applied_products'] : array()),
+            'pending_products' => count(is_array($source_state['pending_products'] ?? null) ? $source_state['pending_products'] : array()),
+            'deferred_products' => count(is_array($source_state['deferred_products'] ?? null) ? $source_state['deferred_products'] : array()),
+        );
+    }
+    // phpcs:enable
 
     private function persist_and_read_back($state) {
         global $wpdb;
@@ -1292,19 +1620,18 @@ class Digitalogic_Product_Sync_Receiver {
         return $read_back;
     }
 
+    // phpcs:disable -- Preserve the established receiver formatting while the legacy file remains baseline-managed.
     private function replay_result($envelope, $existing) {
-        return array(
+        return array_merge(array(
             'status' => 'replayed',
             'replayed' => true,
             'event_id' => $envelope['event_id'],
             'event_type' => $envelope['event_type'],
             'source' => $envelope['source'],
             'stored_products' => count($existing['products'] ?? array()),
-            'fully_applied' => true,
-            'retryable' => false,
-            'pending_products' => 0,
-        );
+        ), $this->delivery_result_state($existing));
     }
+    // phpcs:enable
 
     /**
      * Independently evaluate landed_price_v1 using bounded decimal strings.

--- a/includes/cli/class-cli-commands.php
+++ b/includes/cli/class-cli-commands.php
@@ -618,7 +618,7 @@ class Digitalogic_CLI_Commands {
 	 * @return void
 	 */
 	public function pricing_input_credential_create() {
-		if ( ! $this->require_pricing_credential_admin() ) {
+		if ( ! $this->require_administrator() ) {
 			return;
 		}
 
@@ -639,7 +639,7 @@ class Digitalogic_CLI_Commands {
 	 * @return void
 	 */
 	public function pricing_input_credential_rotate() {
-		if ( ! $this->require_pricing_credential_admin() ) {
+		if ( ! $this->require_administrator() ) {
 			return;
 		}
 
@@ -660,7 +660,7 @@ class Digitalogic_CLI_Commands {
 	 * @return void
 	 */
 	public function pricing_input_credential_revoke() {
-		if ( ! $this->require_pricing_credential_admin() ) {
+		if ( ! $this->require_administrator() ) {
 			return;
 		}
 
@@ -685,7 +685,7 @@ class Digitalogic_CLI_Commands {
 	 * @return void
 	 */
 	public function pricing_input_credential_status() {
-		if ( ! $this->require_pricing_credential_admin() ) {
+		if ( ! $this->require_administrator() ) {
 			return;
 		}
 
@@ -704,11 +704,71 @@ class Digitalogic_CLI_Commands {
 	}
 
 	/**
-	 * Require an explicit administrator user for credential lifecycle commands.
+	 * Show nonsecret product-sync delivery and reconciliation counts.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp digitalogic product-sync status
+	 *
+	 * @when after_wp_load
+	 *
+	 * @return void
+	 */
+	public function product_sync_status() {
+		WP_CLI::line(
+			wp_json_encode(
+				Digitalogic_Product_Sync_Receiver::instance()->get_status(),
+				JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+			)
+		);
+	}
+
+	/**
+	 * Retry deferred and transient product-sync work without changing ordering.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--source-id=<id>]
+	 * : Exact source id. Must be paired with --dataset.
+	 *
+	 * [--dataset=<dataset>]
+	 * : Exact source dataset. Must be paired with --source-id.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp digitalogic product-sync reconcile --user=<administrator>
+	 *     wp digitalogic product-sync reconcile --source-id=patris-office --dataset=kala.db --user=<administrator>
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args Positional arguments (unused).
+	 * @param array $assoc_args Named command arguments.
+	 * @return void
+	 */
+	public function product_sync_reconcile( $args, $assoc_args ) {
+		if ( ! $this->require_administrator() ) {
+			return;
+		}
+
+		$source_id = isset( $assoc_args['source-id'] ) ? (string) $assoc_args['source-id'] : null;
+		$dataset   = isset( $assoc_args['dataset'] ) ? (string) $assoc_args['dataset'] : null;
+		$result    = Digitalogic_Product_Sync_Receiver::instance()->reconcile( $source_id, $dataset );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		WP_CLI::line(
+			wp_json_encode( $result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES )
+		);
+	}
+
+	/**
+	 * Require an explicit administrator user for mutating operational commands.
 	 *
 	 * @return bool
 	 */
-	private function require_pricing_credential_admin() {
+	private function require_administrator() {
 		if ( current_user_can( 'manage_options' ) ) {
 			return true;
 		}
@@ -770,4 +830,12 @@ WP_CLI::add_command(
 WP_CLI::add_command(
 	'digitalogic pricing-input-credential status',
 	array( 'Digitalogic_CLI_Commands', 'pricing_input_credential_status' )
+);
+WP_CLI::add_command(
+	'digitalogic product-sync status',
+	array( 'Digitalogic_CLI_Commands', 'product_sync_status' )
+);
+WP_CLI::add_command(
+	'digitalogic product-sync reconcile',
+	array( 'Digitalogic_CLI_Commands', 'product_sync_reconcile' )
 );

--- a/tests/ProductIdentifierResolverTest.php
+++ b/tests/ProductIdentifierResolverTest.php
@@ -123,4 +123,27 @@ final class ProductIdentifierResolverTest extends TestCase {
         $not_product = $this->resolver->resolve(array('woocommerce_id' => '700', 'sku' => 'SKU-601'));
         $this->assertSame('digitalogic_product_identifier_not_found', $not_product->get_error_code());
     }
+
+    // phpcs:disable -- Match the established PHPUnit fixture style in this baseline-managed test file.
+    public function test_database_failures_propagate_from_every_resolution_path_as_retryable(): void {
+        $GLOBALS['wpdb']->identifier_query_failure = true;
+        $code = $this->resolver->resolve(array('code' => 'MISSING-CODE'));
+        $this->assertSame('digitalogic_product_identifier_query_failed', $code->get_error_code());
+        $this->assertSame(503, $code->get_error_data()['status']);
+        $this->assertTrue($code->get_error_data()['retryable']);
+        $this->assertArrayNotHasKey('database_error', $code->get_error_data());
+
+        $GLOBALS['wpdb']->identifier_query_failure = false;
+        $GLOBALS['wpdb']->identifier_query_last_error = 'Injected SQL details that must not escape.';
+        $meta = $this->resolver->resolve(array('sku' => 'MISSING-SKU'));
+        $this->assertSame('digitalogic_product_identifier_query_failed', $meta->get_error_code());
+        $this->assertStringNotContainsString('Injected SQL', $meta->get_error_message());
+
+        $GLOBALS['wpdb']->identifier_query_last_error = '';
+        $GLOBALS['wpdb']->identifier_prepare_failure = true;
+        $woocommerce_id = $this->resolver->resolve(array('woocommerce_id' => '601'));
+        $this->assertSame('digitalogic_product_identifier_query_failed', $woocommerce_id->get_error_code());
+        $this->assertSame(503, $woocommerce_id->get_error_data()['status']);
+    }
+    // phpcs:enable
 }

--- a/tests/ProductSyncReceiverTest.php
+++ b/tests/ProductSyncReceiverTest.php
@@ -614,7 +614,33 @@ final class ProductSyncReceiverTest extends TestCase {
         $this->assertSame(1, $recovered['deferred_products']);
     }
 
-    public function test_v2_state_migrates_terminal_resolution_failures_without_a_retry(): void {
+    public function test_identifier_query_failure_stays_pending_until_an_identical_retry_can_resolve(): void {
+        $product = $this->productWithCode(0, 'QUERY-FAILURE');
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:16:45Z');
+        $GLOBALS['wpdb']->identifier_query_failure = true;
+
+        $failed = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('partially_applied', $failed['status']);
+        $this->assertTrue($failed['retryable']);
+        $this->assertSame(1, $failed['pending_products']);
+        $this->assertSame(0, $failed['deferred_products']);
+        $this->assertSame(1, $failed['woocommerce']['failed']);
+        $this->assertSame(
+            'digitalogic_product_identifier_query_failed',
+            $failed['woocommerce']['errors'][0]['code']
+        );
+        $this->assertTrue($failed['woocommerce']['errors'][0]['retryable']);
+
+        $GLOBALS['wpdb']->identifier_query_failure = false;
+        $recovered = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('recovered', $recovered['status']);
+        $this->assertFalse($recovered['retryable']);
+        $this->assertSame(0, $recovered['pending_products']);
+        $this->assertSame(1, $recovered['deferred_products']);
+        $this->assertSame(1, $recovered['woocommerce']['missing']);
+    }
+
+    public function test_v2_not_found_state_is_requeried_before_it_can_be_deferred(): void {
         $product = $this->productWithCode(0, 'MIGRATE-MISSING');
         $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:17:00Z');
         $this->assertSame('accepted', Digitalogic_Product_Sync_Receiver::instance()->receive($event)['status']);
@@ -629,14 +655,16 @@ final class ProductSyncReceiverTest extends TestCase {
 
         $projected = Digitalogic_Product_Sync_Receiver::instance()->get_state();
         $this->assertSame(3, $projected['version']);
-        $this->assertCount(0, $projected['sources'][$source_key]['pending_products']);
-        $this->assertCount(1, $projected['sources'][$source_key]['deferred_products']);
+        $this->assertCount(1, $projected['sources'][$source_key]['pending_products']);
+        $this->assertCount(0, $projected['sources'][$source_key]['deferred_products']);
         $this->assertSame(2, get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array())['version']);
 
+        $GLOBALS['wpdb']->identifier_query_count = 0;
         $replay = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
-        $this->assertSame('replayed', $replay['status']);
+        $this->assertSame('recovered', $replay['status']);
         $this->assertSame(0, $replay['pending_products']);
         $this->assertSame(1, $replay['deferred_products']);
+        $this->assertSame(1, $GLOBALS['wpdb']->identifier_query_count);
         $this->assertSame(3, get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array())['version']);
         $this->assertEmpty($GLOBALS['digitalogic_test_wc_product_saves']);
     }

--- a/tests/ProductSyncReceiverTest.php
+++ b/tests/ProductSyncReceiverTest.php
@@ -40,11 +40,13 @@ final class ProductSyncReceiverTest extends TestCase {
         $result = Digitalogic_Product_Sync_Receiver::instance()->receive_json(file_get_contents($path));
 
         $this->assertNotInstanceOf(WP_Error::class, $result, $result instanceof WP_Error ? $result->get_error_message() : '');
-        $this->assertSame('partially_applied', $result['status']);
+        $this->assertSame('accepted', $result['status']);
         $this->assertSame('sha256:25d5afce95dfdcf598c28f9c9639cbd54ed7f2e838a6c285844eee75d972ef06', $result['event_id']);
-        $this->assertFalse($result['fully_applied']);
-        $this->assertTrue($result['retryable']);
-        $this->assertSame(2, $result['pending_products']);
+        $this->assertTrue($result['fully_applied']);
+        $this->assertFalse($result['retryable']);
+        $this->assertSame(0, $result['pending_products']);
+        $this->assertSame(2, $result['deferred_products']);
+        $this->assertSame(2, $result['deferred_reconciliation']['missing']);
         $this->assertSame(2, $result['stored_products']);
         $this->assertSame(2, $result['woocommerce']['missing']);
         $this->assertCount(2, $result['woocommerce']['errors']);
@@ -144,13 +146,13 @@ final class ProductSyncReceiverTest extends TestCase {
         $first = $this->product(0);
         $second = $this->product(1);
         $snapshot = $this->envelope('snapshot', array($first), array($first), '2026-07-16T10:00:00Z');
-        $this->assertSame('partially_applied', Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot)['status']);
+        $this->assertSame('accepted', Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot)['status']);
 
         $update = $this->envelope('update', array($second), array($first, $second), '2026-07-16T10:01:00Z');
         $result = Digitalogic_Product_Sync_Receiver::instance()->receive($update);
         $state = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
 
-        $this->assertSame('partially_applied', $result['status']);
+        $this->assertSame('accepted', $result['status']);
         $this->assertCount(2, $state['products']);
         $this->assertArrayHasKey($first['product_code'], $state['products']);
         $this->assertArrayHasKey($second['product_code'], $state['products']);
@@ -174,7 +176,7 @@ final class ProductSyncReceiverTest extends TestCase {
         $result = Digitalogic_Product_Sync_Receiver::instance()->receive($delete);
         $state = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
 
-        $this->assertSame('partially_applied', $result['status']);
+        $this->assertSame('accepted', $result['status']);
         $this->assertSame(0, $result['received_products']);
         $this->assertSame(1, $result['deleted_codes']);
         $this->assertArrayNotHasKey($first['product_code'], $state['products']);
@@ -408,21 +410,34 @@ final class ProductSyncReceiverTest extends TestCase {
         $this->assertSame(array(711, 712), $GLOBALS['digitalogic_test_wc_product_saves']);
     }
 
-    public function test_missing_product_added_later_is_recovered_by_identical_replay(): void {
+    public function test_missing_product_is_terminal_until_explicit_reconciliation(): void {
         $product = $this->product(0);
         $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:12:00Z');
         $first = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
-        $this->assertSame('partially_applied', $first['status']);
+        $this->assertSame('accepted', $first['status']);
         $this->assertSame(1, $first['woocommerce']['missing']);
+        $this->assertFalse($first['retryable']);
+        $this->assertSame(0, $first['pending_products']);
+        $this->assertSame(1, $first['deferred_products']);
 
         $GLOBALS['digitalogic_test_posts'][713] = array(
             'post_type' => 'product',
             'post_status' => 'publish',
             'meta' => array('_sku' => $product['product_code']),
         );
-        $recovered = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
-        $this->assertSame('recovered', $recovered['status']);
-        $this->assertSame(1, $recovered['woocommerce']['updated']);
+        $replay = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('replayed', $replay['status']);
+        $this->assertSame(1, $replay['deferred_products']);
+        $this->assertEmpty($GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $before = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
+        $recovered = Digitalogic_Product_Sync_Receiver::instance()->reconcile('receiver-tests', 'kala.db');
+        $after = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
+        $this->assertSame('reconciled', $recovered['status']);
+        $this->assertSame(1, $recovered['sources'][0]['woocommerce']['updated']);
+        $this->assertSame(0, $recovered['deferred_products']);
+        $this->assertSame($before['last_event_id'], $after['last_event_id']);
+        $this->assertSame($before['generated_at'], $after['generated_at']);
         $this->assertSame(array(713), $GLOBALS['digitalogic_test_wc_product_saves']);
     }
 
@@ -453,7 +468,7 @@ final class ProductSyncReceiverTest extends TestCase {
         $this->assertSame(array(714), $GLOBALS['digitalogic_test_wc_product_saves']);
     }
 
-    public function test_patris_code_is_canonical_and_cross_namespace_collision_remains_pending(): void {
+    public function test_patris_code_is_canonical_and_cross_namespace_collision_is_deferred(): void {
         $product = $this->product(0);
         $code = $product['product_code'];
         $GLOBALS['digitalogic_test_posts'][720] = array(
@@ -472,15 +487,221 @@ final class ProductSyncReceiverTest extends TestCase {
 
         $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:14:00Z');
         $first = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
-        $this->assertSame('partially_applied', $first['status']);
+        $this->assertSame('accepted', $first['status']);
         $this->assertSame(1, $first['woocommerce']['ambiguous']);
+        $this->assertSame(0, $first['pending_products']);
+        $this->assertSame(1, $first['deferred_products']);
+        $this->assertSame('ambiguous', $first['deferred_reconciliation']['details'][0]['reason']);
         $this->assertEmpty($GLOBALS['digitalogic_test_wc_product_saves']);
 
         $GLOBALS['digitalogic_test_posts'][720]['meta']['_sku'] = 'OTHER-SKU';
-        $recovered = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
-        $this->assertSame('recovered', $recovered['status']);
+        $replayed = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('replayed', $replayed['status']);
+        $recovered = Digitalogic_Product_Sync_Receiver::instance()->reconcile('receiver-tests', 'kala.db');
+        $this->assertSame('reconciled', $recovered['status']);
         $this->assertSame(array(721), $GLOBALS['digitalogic_test_wc_product_saves']);
     }
+
+    // phpcs:disable -- Match the established PHPUnit fixture style in this baseline-managed test file.
+    public function test_mixed_snapshot_retries_only_transient_work_and_new_event_reconciles_deferred(): void {
+        $matched = $this->productWithCode(0, 'MIX-A-MATCHED');
+        $missing = $this->productWithCode(0, 'MIX-B-MISSING');
+        $ambiguous = $this->productWithCode(0, 'MIX-C-AMBIGUOUS');
+        $transient = $this->productWithCode(0, 'MIX-D-TRANSIENT');
+        $products = array($matched, $missing, $ambiguous, $transient);
+
+        $GLOBALS['digitalogic_test_posts'][730] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $matched['product_code']),
+        );
+        $GLOBALS['digitalogic_test_posts'][731] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_sku' => $ambiguous['product_code']),
+        );
+        $GLOBALS['digitalogic_test_posts'][732] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $ambiguous['product_code']),
+        );
+        $GLOBALS['digitalogic_test_posts'][733] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $transient['product_code']),
+        );
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array(733);
+
+        $snapshot = $this->envelope('snapshot', $products, $products, '2026-07-16T11:15:00Z');
+        $first = Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot);
+
+        $this->assertSame('partially_applied', $first['status']);
+        $this->assertTrue($first['retryable']);
+        $this->assertSame(1, $first['pending_products']);
+        $this->assertSame(2, $first['deferred_products']);
+        $this->assertIsInt($first['deferred_products']);
+        $this->assertLessThanOrEqual(2147483647, $first['deferred_products']);
+        $this->assertSame(
+            $first['deferred_products'],
+            $first['deferred_reconciliation']['missing'] + $first['deferred_reconciliation']['ambiguous']
+        );
+        $this->assertSame(1, $first['woocommerce']['updated']);
+        $this->assertSame(1, $first['woocommerce']['missing']);
+        $this->assertSame(1, $first['woocommerce']['ambiguous']);
+        $this->assertSame(1, $first['woocommerce']['failed']);
+        $this->assertSame(array(730), $GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array();
+        $retry = Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot);
+        $this->assertSame('recovered', $retry['status']);
+        $this->assertFalse($retry['retryable']);
+        $this->assertSame(0, $retry['pending_products']);
+        $this->assertSame(2, $retry['deferred_products']);
+        $this->assertSame(1, $retry['woocommerce']['attempted']);
+        $this->assertSame(array(730, 733), $GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $replay = Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot);
+        $this->assertSame('replayed', $replay['status']);
+        $this->assertSame(2, $replay['deferred_products']);
+        $this->assertSame(array(730, 733), $GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $GLOBALS['digitalogic_test_posts'][734] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_sku' => $missing['product_code']),
+        );
+        $GLOBALS['digitalogic_test_posts'][731]['meta']['_sku'] = 'COLLISION-RESOLVED';
+        $later = $this->envelope('update', array(), $products, '2026-07-16T11:16:00Z');
+        $reconciled = Digitalogic_Product_Sync_Receiver::instance()->receive($later);
+
+        $this->assertSame('already_current', $reconciled['status']);
+        $this->assertFalse($reconciled['retryable']);
+        $this->assertSame(0, $reconciled['pending_products']);
+        $this->assertSame(0, $reconciled['deferred_products']);
+        $this->assertSame(2, $reconciled['woocommerce']['attempted']);
+        $this->assertSame(2, $reconciled['woocommerce']['updated']);
+        $this->assertSame(array(730, 733, 734, 732), $GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_deferred_state_readback_failure_rolls_back_to_retryable_outbox(): void {
+        $product = $this->productWithCode(0, 'DEFERRED-READBACK');
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:16:30Z');
+        $writes = 0;
+        $callback = null;
+        $callback = static function($database, $option_name) use (&$callback, &$writes): void {
+            $writes++;
+            if (1 === $writes) {
+                $database->after_option_write = $callback;
+                return;
+            }
+            $GLOBALS['digitalogic_test_options'][$option_name]['tampered_after_write'] = true;
+        };
+        $GLOBALS['wpdb']->after_option_write = $callback;
+
+        $failed = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertInstanceOf(WP_Error::class, $failed);
+        $this->assertSame('digitalogic_product_sync_readback_failed', $failed->get_error_code());
+        $this->assertContains('ROLLBACK', $GLOBALS['wpdb']->queries);
+
+        $rolled_back = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
+        $this->assertCount(1, $rolled_back['pending_products']);
+        $this->assertCount(0, $rolled_back['deferred_products']);
+
+        $recovered = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('recovered', $recovered['status']);
+        $this->assertFalse($recovered['retryable']);
+        $this->assertSame(0, $recovered['pending_products']);
+        $this->assertSame(1, $recovered['deferred_products']);
+    }
+
+    public function test_v2_state_migrates_terminal_resolution_failures_without_a_retry(): void {
+        $product = $this->productWithCode(0, 'MIGRATE-MISSING');
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:17:00Z');
+        $this->assertSame('accepted', Digitalogic_Product_Sync_Receiver::instance()->receive($event)['status']);
+
+        $state = get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array());
+        $source_key = array_key_first($state['sources']);
+        $state['version'] = 2;
+        $entry = $state['sources'][$source_key]['deferred_products'][$product['product_code']];
+        unset($entry['reason'], $state['sources'][$source_key]['deferred_products']);
+        $state['sources'][$source_key]['pending_products'][$product['product_code']] = $entry;
+        update_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, $state, false);
+
+        $projected = Digitalogic_Product_Sync_Receiver::instance()->get_state();
+        $this->assertSame(3, $projected['version']);
+        $this->assertCount(0, $projected['sources'][$source_key]['pending_products']);
+        $this->assertCount(1, $projected['sources'][$source_key]['deferred_products']);
+        $this->assertSame(2, get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array())['version']);
+
+        $replay = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('replayed', $replay['status']);
+        $this->assertSame(0, $replay['pending_products']);
+        $this->assertSame(1, $replay['deferred_products']);
+        $this->assertSame(3, get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array())['version']);
+        $this->assertEmpty($GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_deferred_response_details_and_cli_status_are_bounded_and_nonsecret(): void {
+        $products = array();
+        for ($index = 0; $index < 101; $index++) {
+            $products[] = $this->productWithCode(0, sprintf('BOUND-%03d', $index));
+        }
+        $event = $this->envelope('snapshot', $products, $products, '2026-07-16T11:18:00Z');
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $status = Digitalogic_Product_Sync_Receiver::instance()->get_status();
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame(101, $result['deferred_products']);
+        $this->assertIsInt($result['deferred_products']);
+        $this->assertLessThanOrEqual(2147483647, $result['deferred_products']);
+        $this->assertCount(100, $result['deferred_reconciliation']['details']);
+        $this->assertSame(1, $result['deferred_reconciliation']['details_truncated']);
+        $this->assertSame(
+            $result['deferred_products'],
+            count($result['deferred_reconciliation']['details'])
+                + $result['deferred_reconciliation']['details_truncated']
+        );
+        $this->assertSame(101, $status['totals']['deferred_products']);
+        $this->assertSame(101, $status['sources'][0]['stored_products']);
+        $this->assertArrayNotHasKey('products', $status['sources'][0]);
+
+        WP_CLI::$logs = array();
+        (new Digitalogic_CLI_Commands())->product_sync_status();
+        $output = implode("\n", WP_CLI::$logs);
+        $this->assertStringContainsString('"deferred_products":101', $output);
+        $this->assertStringNotContainsString('BOUND-000', $output);
+        $this->assertArrayHasKey('digitalogic product-sync status', WP_CLI::$commands);
+        $this->assertArrayHasKey('digitalogic product-sync reconcile', WP_CLI::$commands);
+    }
+
+    public function test_reconciliation_cli_requires_admin_and_retries_only_durable_work(): void {
+        $product = $this->productWithCode(0, 'CLI-MISSING');
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:19:00Z');
+        Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $GLOBALS['digitalogic_test_posts'][735] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => $product['product_code']),
+        );
+        WP_CLI::$errors = array();
+        WP_CLI::$logs = array();
+        $command = new Digitalogic_CLI_Commands();
+
+        $command->product_sync_reconcile(array(), array());
+        $this->assertNotEmpty(WP_CLI::$errors);
+        $this->assertEmpty($GLOBALS['digitalogic_test_wc_product_saves']);
+
+        $GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+        WP_CLI::$errors = array();
+        $command->product_sync_reconcile(array(), array(
+            'source-id' => 'receiver-tests',
+            'dataset' => 'kala.db',
+        ));
+        $this->assertEmpty(WP_CLI::$errors);
+        $this->assertSame(array(735), $GLOBALS['digitalogic_test_wc_product_saves']);
+        $this->assertStringContainsString('"status":"reconciled"', implode("\n", WP_CLI::$logs));
+    }
+    // phpcs:enable
 
     public function test_newer_same_content_occurrence_advances_watermark_before_older_change(): void {
         $first = $this->product(0);
@@ -528,6 +749,15 @@ final class ProductSyncReceiverTest extends TestCase {
     private function product($index) {
         return self::$golden['products'][$index];
     }
+
+    // phpcs:disable -- Match the established PHPUnit fixture style in this baseline-managed test file.
+    private function productWithCode($index, $code) {
+        $product = $this->product($index);
+        $product['product_code'] = $code;
+
+        return $this->rehashProduct($product);
+    }
+    // phpcs:enable
 
     private function rehashProduct($product) {
         unset($product['record_hash']);

--- a/tests/ProductSyncRestTest.php
+++ b/tests/ProductSyncRestTest.php
@@ -152,22 +152,26 @@ final class ProductSyncRestTest extends TestCase {
         $this->assertSame('digitalogic_product_sync_currency_unsupported', $response->get_data()['code']);
     }
 
-    public function test_partial_and_identical_retry_responses_are_intentionally_http_200(): void {
+    public function test_deferred_and_identical_replay_responses_are_terminal_http_200(): void {
         $body = file_get_contents(__DIR__ . '/fixtures/patris-product-sync-v1-golden.json');
         $payload = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
         $headers = array('X-Digitalogic-Product-Sync-Secret' => 'receiver-secret');
         $request = new WP_REST_Request(array(), $payload, $headers, $body);
 
-        $partial = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
-        $this->assertSame(200, $partial->get_status());
-        $this->assertSame('partially_applied', $partial->get_data()['data']['status']);
-        $this->assertTrue($partial->get_data()['data']['retryable']);
+        $accepted = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
+        $this->assertSame(200, $accepted->get_status());
+        $this->assertSame('accepted', $accepted->get_data()['data']['status']);
+        $this->assertFalse($accepted->get_data()['data']['retryable']);
+        $this->assertSame(0, $accepted->get_data()['data']['pending_products']);
+        $this->assertSame(2, $accepted->get_data()['data']['deferred_products']);
+        $this->assertIsInt($accepted->get_data()['data']['deferred_products']);
 
         $retry = Digitalogic_REST_API::instance()->receive_patris_product_sync($request);
         $this->assertSame(200, $retry->get_status());
-        $this->assertSame('retry_pending', $retry->get_data()['data']['status']);
+        $this->assertSame('replayed', $retry->get_data()['data']['status']);
         $this->assertTrue($retry->get_data()['data']['replayed']);
-        $this->assertTrue($retry->get_data()['data']['retryable']);
+        $this->assertFalse($retry->get_data()['data']['retryable']);
+        $this->assertSame(2, $retry->get_data()['data']['deferred_products']);
     }
 
     private function emptySnapshot() {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -647,6 +647,10 @@ class Digitalogic_Test_WPDB {
     public $mysql_string_roundtrip = false;
     public $after_rollback = null;
     public $identifier_query_count = 0;
+    public $identifier_prepare_failure = false;
+    public $identifier_query_failure = false;
+    public $identifier_query_last_error = '';
+    public $last_error = '';
     public $option_read_counts = array();
     // phpcs:disable -- Deterministic lifecycle-interleaving hooks for focused tests.
     public $before_get_lock = null;
@@ -658,6 +662,11 @@ class Digitalogic_Test_WPDB {
     private $next_meta_id = 1;
 
     public function prepare($query, ...$args) {
+        if ($this->identifier_prepare_failure && strpos((string) $query, 'digitalogic_identifier:') !== false) {
+            $this->last_error = 'Injected identifier prepare failure.';
+            return false;
+        }
+
         return array(
             'query' => $query,
             'args' => $args,
@@ -727,6 +736,17 @@ class Digitalogic_Test_WPDB {
         }
 
         $this->identifier_query_count++;
+        if ($this->identifier_query_failure) {
+            $this->last_error = '' !== $this->identifier_query_last_error
+                ? $this->identifier_query_last_error
+                : 'Injected identifier query failure.';
+            return null;
+        }
+        if ('' !== $this->identifier_query_last_error) {
+            $this->last_error = $this->identifier_query_last_error;
+            return array();
+        }
+        $this->last_error = '';
         $rows = array();
         foreach ($GLOBALS['digitalogic_test_posts'] as $post_id => $post) {
             if (!in_array($post['post_type'], array('product', 'product_variation'), true)) {


### PR DESCRIPTION
## Summary

- split product-sync delivery state into applied, transient `pending_products`, and terminal `deferred_products`
- return terminal accepted/already-current/replayed/recovered responses when only exact-Code missing or ambiguity remains
- retry deferred rows on a later distinct event or explicit administrator reconciliation without replaying applied writes or changing the source watermark
- migrate v2 receiver state to bounded v3 state under the existing advisory lock and transaction/readback path
- add nonsecret `wp digitalogic product-sync status` and administrator-only `product-sync reconcile` commands
- document and test the paired Patris response contract from atomicdeploy/patris-export#147

## Wire contract

`data.deferred_products` is an unquoted JSON integer bounded by the 10,000-product receiver limit (therefore within `0..2,147,483,647`). `deferred_reconciliation` contains bounded missing/ambiguous counts and at most 100 typed details. Terminal responses require `retryable:false` and `pending_products:0`; only transient Woo lookup/storage/write failures remain retryable.

## Verification

- Product-sync receiver/REST: 32 tests, 253 assertions
- All non-WebSocket PHPUnit coverage on Windows: 140 tests, 1,160 assertions
- PHP syntax: 53 files
- REST permissions: included in the passing suite (22 tests, 60 assertions in the focused run)
- Pricing credential regression: 14 tests, 178 assertions
- Node authentication navigation: 6 tests
- PHPCS debt gate: 42,541 errors / 2,897 warnings (maxima 43,221 / 3,016; limits unchanged)
- `composer validate --strict --no-check-publish`
- `composer audit --locked` (no advisories; local package metadata fell back to cache after a Packagist timeout)
- public-tree artifact check and `git diff --check`

The Windows-only long-running `WebSocketLifecycleTest` process did not terminate locally; this branch does not change the WebSocket implementation, and the required GitHub PHP 8.3 CI run remains authoritative for the complete suite.

Closes #64