### PR TITLE
Publish committed Patris sync summaries to signed observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Optional signed `patris.product_sync.applied` observer summaries through the existing webhook fan-out, without exposing product payloads or affecting direct sync outcomes.
 - Bounded product-sync deferred reconciliation state and administrator WP-CLI status/retry commands, separating terminal missing/ambiguous Codes from transient HTTP/database retries.
 - Canonical nullable global default percentage markup with exact decimal storage, REST/command/admin controls, catalog revisioning, and result-aware delivery events.
 - **WordPress Admin Bar integration** with quicklinks menu

--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ Webhook events:
 - `product.created` - New product added
 - `product.updated` - Product updated
 - `currency.updated` - Currency rates changed
+- `patris.product_sync.applied` - Safe committed Patris sync summary for optional observers
+
+The Patris observer event uses the same HMAC signature and destination fan-out.
+It contains bounded aggregate counts only. n8n can route it to alerts or audit
+copies, but direct Patris delivery remains authoritative and does not depend on
+a configured webhook destination.
 
 Verify webhook signatures:
 ```php

--- a/docs/PATRIS-PRODUCT-SYNC-V1.md
+++ b/docs/PATRIS-PRODUCT-SYNC-V1.md
@@ -215,6 +215,36 @@ it does not print product payloads or credentials. Reconciliation processes
 only pending/deferred records, never already-applied writes, and preserves the
 stored source event ordering watermark.
 
+## Optional signed observer event
+
+After the receiver state and Woo delivery outbox are committed, the shared
+webhook service emits `patris.product_sync.applied` when at least one standard
+webhook destination is configured. The existing `X-Digitalogic-Signature` HMAC
+and fan-out are reused; there is no n8n-specific transport.
+
+The event's `data` object is an allowlisted projection containing only:
+
+- `schema`, `schema_version`, `event_id`, and `event_type`;
+- non-path `source.id` and `source.dataset`;
+- `status`, `retryable`, `pending_products`, and `deferred_products`; and
+- bounded Woo aggregate counts: `attempted`, `updated`, `already_applied`,
+  `missing`, `ambiguous`, `failed`, and `errors_truncated`.
+
+Products, names, raw fields, error details, request/response bodies, endpoint
+paths, headers, credentials, source revisions, and receiver state are never
+projected. Counts are bounded to the receiver's 10,000-product limit. A path-like
+source identifier fails closed and produces no observer event.
+
+Terminal replays do not emit the committed domain action, so they do not create
+duplicate observer events. A transient attempt may emit `partially_applied`,
+followed by `recovered` when the durable retry succeeds. Observer transport or
+listener failure is isolated from the already-committed receiver response.
+
+An n8n workflow may verify the existing signature and route this event to
+Telegram alerts or an audit copy. It must not treat the observer as a data
+source, acknowledge Patris delivery, or initiate receiver retries. With no
+webhook URL configured, product sync remains a complete standalone deployment.
+
 The synthetic cross-project fixture is 2,760 bytes with SHA-256
 `810bdf4d8fd5e3c2a87750a02f241363f6403736c899a625f615967fea259da5`.
 Its occurrence identity is

--- a/includes/api/class-webhooks.php
+++ b/includes/api/class-webhooks.php
@@ -11,6 +11,19 @@ if (!defined('ABSPATH')) {
 }
 
 class Digitalogic_Webhooks {
+
+    // phpcs:disable -- Preserve the established webhook formatting while the legacy file remains baseline-managed.
+    private const PRODUCT_SYNC_EVENT = 'patris.product_sync.applied';
+    private const PRODUCT_SYNC_SCHEMA = 'digitalogic.product-sync';
+    private const MAX_PRODUCT_SYNC_COUNT = 10000;
+    private const PRODUCT_SYNC_STATUSES = array(
+        'accepted',
+        'already_current',
+        'partially_applied',
+        'recovered',
+        'retry_pending',
+    );
+    // phpcs:enable
     
     private static $instance = null;
     
@@ -44,6 +57,9 @@ class Digitalogic_Webhooks {
         // Hook into currency updates
         add_action('update_option_dollar_price', array($this, 'currency_updated'), 10, 3);
         add_action('update_option_yuan_price', array($this, 'currency_updated'), 10, 3);
+
+        // Committed transformed Patris outcomes are optional observer events.
+        add_action('digitalogic_product_sync_v1_applied', array($this, 'product_sync_applied'), 10, 2);
 
         // Add settings page
         add_action('admin_init', array($this, 'register_settings'));
@@ -288,6 +304,113 @@ class Digitalogic_Webhooks {
         
         $this->trigger_webhook('currency.updated', $data);
     }
+
+    // phpcs:disable -- Preserve the established webhook formatting while the legacy file remains baseline-managed.
+    /**
+     * Publish a committed product-sync outcome through the shared observer.
+     *
+     * The receiver owns delivery truth. This listener deliberately ignores
+     * observer transport results so n8n remains optional and cannot change a
+     * committed receiver response.
+     */
+    public function product_sync_applied($result, $envelope) {
+        try {
+            $summary = $this->product_sync_summary($result, $envelope);
+            if (null === $summary) {
+                return true;
+            }
+
+            $this->trigger_webhook(self::PRODUCT_SYNC_EVENT, $summary);
+        } catch (Throwable) {
+            error_log('[Digitalogic webhooks] Product-sync observer delivery was unavailable.');
+        }
+
+        return true;
+    }
+
+    /**
+     * Project the receiver result onto the bounded public observer contract.
+     */
+    private function product_sync_summary($result, $envelope) {
+        if (!is_array($result) || !is_array($envelope)) {
+            return null;
+        }
+        if (self::PRODUCT_SYNC_SCHEMA !== ($envelope['schema'] ?? null)) {
+            return null;
+        }
+        $schema_version = $envelope['schema_version'] ?? null;
+        if (!is_string($schema_version) || !preg_match('/^1(?:\.[0-9]+){1,2}$/', $schema_version)) {
+            return null;
+        }
+        $event_id = $envelope['event_id'] ?? null;
+        if (!is_string($event_id) || !preg_match('/^sha256:[a-f0-9]{64}$/', $event_id)) {
+            return null;
+        }
+        $event_type = $envelope['event_type'] ?? null;
+        if (!in_array($event_type, array('snapshot', 'update'), true)) {
+            return null;
+        }
+        $status = $result['status'] ?? null;
+        if (!in_array($status, self::PRODUCT_SYNC_STATUSES, true)) {
+            return null;
+        }
+        $source = is_array($envelope['source'] ?? null) ? $envelope['source'] : array();
+        $source_id = $this->safe_product_sync_source($source['id'] ?? null);
+        $dataset = $this->safe_product_sync_source($source['dataset'] ?? null);
+        if (null === $source_id || null === $dataset) {
+            return null;
+        }
+
+        $pending = $this->bounded_product_sync_count($result['pending_products'] ?? null);
+        $deferred = $this->bounded_product_sync_count($result['deferred_products'] ?? null);
+        $retryable = true === ($result['retryable'] ?? false);
+        $partial = in_array($status, array('partially_applied', 'retry_pending'), true);
+        if (($partial && (!$retryable || 0 === $pending)) || (!$partial && ($retryable || 0 !== $pending))) {
+            return null;
+        }
+
+        $woocommerce = is_array($result['woocommerce'] ?? null) ? $result['woocommerce'] : array();
+        $woo_summary = array();
+        foreach (array('attempted', 'updated', 'already_applied', 'missing', 'ambiguous', 'failed', 'errors_truncated') as $field) {
+            $woo_summary[$field] = $this->bounded_product_sync_count($woocommerce[$field] ?? null);
+        }
+
+        return array(
+            'schema' => self::PRODUCT_SYNC_SCHEMA,
+            'schema_version' => $schema_version,
+            'event_id' => $event_id,
+            'event_type' => $event_type,
+            'source' => array(
+                'id' => $source_id,
+                'dataset' => $dataset,
+            ),
+            'status' => $status,
+            'retryable' => $retryable,
+            'pending_products' => $pending,
+            'deferred_products' => $deferred,
+            'woocommerce' => $woo_summary,
+        );
+    }
+
+    private function safe_product_sync_source($value) {
+        if (
+            !is_string($value)
+            || 1 !== preg_match('/\A[A-Za-z0-9][A-Za-z0-9._-]{0,190}\z/D', $value)
+        ) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function bounded_product_sync_count($value) {
+        if (!is_int($value) || $value < 0) {
+            return 0;
+        }
+
+        return min($value, self::MAX_PRODUCT_SYNC_COUNT);
+    }
+    // phpcs:enable
 
     public function import_freight_method_created($method) {
         return $this->trigger_import_freight_method_webhook('import_freight.method.created', $method);

--- a/tests/ProductSyncWebhookTest.php
+++ b/tests/ProductSyncWebhookTest.php
@@ -1,0 +1,243 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable -- Match the established PHPUnit fixture style in this baseline-managed test suite.
+final class ProductSyncWebhookTest extends TestCase {
+    private static $fixture_json;
+    private static $fixture;
+
+    public static function setUpBeforeClass(): void {
+        self::$fixture_json = file_get_contents(__DIR__ . '/fixtures/patris-product-sync-v1-golden.json');
+        self::$fixture = json_decode(self::$fixture_json, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_capabilities'] = array();
+        $GLOBALS['digitalogic_test_filters'] = array();
+        $GLOBALS['digitalogic_test_routes'] = array();
+        $GLOBALS['digitalogic_test_options'] = array();
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_actions'] = array();
+        $GLOBALS['digitalogic_test_action_callbacks'] = array();
+        $GLOBALS['digitalogic_test_posts'] = array();
+        $GLOBALS['digitalogic_test_post_meta_cache'] = array();
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_transaction_failures'] = array();
+        $GLOBALS['digitalogic_test_cache_deletes'] = array();
+        $GLOBALS['digitalogic_test_remote_posts'] = array();
+        $GLOBALS['digitalogic_test_remote_post_results'] = array();
+        $GLOBALS['digitalogic_test_wc_products'] = array();
+        $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array();
+        $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
+        $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
+
+        $this->resetSingleton(Digitalogic_Webhooks::class);
+        $this->resetSingleton(Digitalogic_Product_Sync_Receiver::class);
+        $this->resetSingleton(Digitalogic_Product_Identifier_Resolver::class);
+    }
+
+    public function test_safe_bounded_projection_reuses_shared_signing_transport(): void {
+        $this->configureWebhook();
+        $webhooks = Digitalogic_Webhooks::instance();
+        $unsafe = 'DO-NOT-EXPOSE-RAW-SECRET';
+        $result = array(
+            'status' => 'accepted',
+            'retryable' => false,
+            'pending_products' => 0,
+            'deferred_products' => PHP_INT_MAX,
+            'woocommerce' => array(
+                'attempted' => PHP_INT_MAX,
+                'updated' => -1,
+                'already_applied' => 2,
+                'missing' => 3,
+                'ambiguous' => 4,
+                'failed' => 5,
+                'errors_truncated' => 101,
+                'errors' => array(array('product_code' => $unsafe)),
+            ),
+            'products' => array(array('name' => $unsafe)),
+            'request_body' => $unsafe,
+            'credentials' => $unsafe,
+            'receiver_state' => $unsafe,
+        );
+        $envelope = $this->actionEnvelope();
+        $envelope['products'] = array(array('name' => $unsafe));
+        $envelope['headers'] = array('Authorization' => $unsafe);
+        $envelope['endpoint_path'] = '/private/' . $unsafe;
+
+        $this->assertTrue($webhooks->product_sync_applied($result, $envelope));
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+        $request = $GLOBALS['digitalogic_test_remote_posts'][0];
+        $payload = json_decode($request['args']['body'], true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('patris.product_sync.applied', $payload['event']);
+        $this->assertSame(array(
+            'schema',
+            'schema_version',
+            'event_id',
+            'event_type',
+            'source',
+            'status',
+            'retryable',
+            'pending_products',
+            'deferred_products',
+            'woocommerce',
+        ), array_keys($payload['data']));
+        $this->assertSame('digitalogic.product-sync', $payload['data']['schema']);
+        $this->assertSame('1.0', $payload['data']['schema_version']);
+        $this->assertSame(array('id', 'dataset'), array_keys($payload['data']['source']));
+        $this->assertSame(10000, $payload['data']['deferred_products']);
+        $this->assertSame(10000, $payload['data']['woocommerce']['attempted']);
+        $this->assertSame(0, $payload['data']['woocommerce']['updated']);
+        $this->assertSame(array(
+            'attempted',
+            'updated',
+            'already_applied',
+            'missing',
+            'ambiguous',
+            'failed',
+            'errors_truncated',
+        ), array_keys($payload['data']['woocommerce']));
+        $this->assertStringNotContainsString($unsafe, $request['args']['body']);
+        $this->assertFalse($request['args']['blocking']);
+        $this->assertSame(10, $request['args']['timeout']);
+        $this->assertSame('patris.product_sync.applied', $request['args']['headers']['X-Digitalogic-Event']);
+        $this->assertSame(
+            hash_hmac('sha256', $request['args']['body'], 'observer-test-secret'),
+            $request['args']['headers']['X-Digitalogic-Signature']
+        );
+        $this->assertTrue(Digitalogic_Webhooks::verify_signature(
+            $request['args']['body'],
+            $request['args']['headers']['X-Digitalogic-Signature']
+        ));
+
+        $path_envelope = $this->actionEnvelope();
+        $path_envelope['source']['dataset'] = 'C:\\private\\kala.db';
+        $this->assertTrue($webhooks->product_sync_applied($result, $path_envelope));
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+
+        $query_envelope = $this->actionEnvelope();
+        $query_envelope['source']['dataset'] = 'kala.db?token=' . $unsafe;
+        $this->assertTrue($webhooks->product_sync_applied($result, $query_envelope));
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+    }
+
+    public function test_accepted_deferred_event_is_observed_once_and_terminal_replay_is_suppressed(): void {
+        $this->configureWebhook();
+        Digitalogic_Webhooks::instance();
+
+        $accepted = Digitalogic_Product_Sync_Receiver::instance()->receive_json(self::$fixture_json);
+        $replayed = Digitalogic_Product_Sync_Receiver::instance()->receive_json(self::$fixture_json);
+
+        $this->assertSame('accepted', $accepted['status']);
+        $this->assertSame(2, $accepted['deferred_products']);
+        $this->assertSame('replayed', $replayed['status']);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+        $data = $this->observerPayload(0)['data'];
+        $this->assertSame('accepted', $data['status']);
+        $this->assertFalse($data['retryable']);
+        $this->assertSame(0, $data['pending_products']);
+        $this->assertSame(2, $data['deferred_products']);
+        $this->assertSame(2, $data['woocommerce']['missing']);
+    }
+
+    public function test_transient_retry_emits_partial_then_recovered_without_terminal_duplicate(): void {
+        $this->configureWebhook();
+        Digitalogic_Webhooks::instance();
+        foreach (self::$fixture['products'] as $index => $product) {
+            $GLOBALS['digitalogic_test_posts'][880 + $index] = array(
+                'post_type' => 'product',
+                'post_status' => 'publish',
+                'meta' => array('_digitalogic_patris_product_code' => $product['product_code']),
+            );
+        }
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array(881);
+
+        $partial = Digitalogic_Product_Sync_Receiver::instance()->receive_json(self::$fixture_json);
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array();
+        $recovered = Digitalogic_Product_Sync_Receiver::instance()->receive_json(self::$fixture_json);
+        $replayed = Digitalogic_Product_Sync_Receiver::instance()->receive_json(self::$fixture_json);
+
+        $this->assertSame('partially_applied', $partial['status']);
+        $this->assertSame('recovered', $recovered['status']);
+        $this->assertSame('replayed', $replayed['status']);
+        $this->assertCount(2, $GLOBALS['digitalogic_test_remote_posts']);
+        $this->assertSame('partially_applied', $this->observerPayload(0)['data']['status']);
+        $this->assertTrue($this->observerPayload(0)['data']['retryable']);
+        $this->assertSame(1, $this->observerPayload(0)['data']['pending_products']);
+        $this->assertSame('recovered', $this->observerPayload(1)['data']['status']);
+        $this->assertFalse($this->observerPayload(1)['data']['retryable']);
+        $this->assertSame(0, $this->observerPayload(1)['data']['pending_products']);
+    }
+
+    public function test_no_webhook_configuration_keeps_direct_sync_authoritative(): void {
+        Digitalogic_Webhooks::instance();
+
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive_json(self::$fixture_json);
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertTrue($result['persistence_verified']);
+        $this->assertArrayNotHasKey('delivery_warnings', $result);
+        $this->assertEmpty($GLOBALS['digitalogic_test_remote_posts']);
+    }
+
+    public function test_observer_transport_failure_cannot_change_committed_receiver_outcome(): void {
+        $this->configureWebhook();
+        $GLOBALS['digitalogic_test_remote_post_results'][] = new RuntimeException(
+            'Injected observer transport exception.'
+        );
+        Digitalogic_Webhooks::instance();
+
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive_json(self::$fixture_json);
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertTrue($result['persistence_verified']);
+        $this->assertFalse($result['retryable']);
+        $this->assertArrayNotHasKey('delivery_warnings', $result);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+        $state = Digitalogic_Product_Sync_Receiver::instance()->get_source_state(
+            'synthetic-fixture',
+            'synthetic-kala.db'
+        );
+        $this->assertSame($result['event_id'], $state['last_event_id']);
+    }
+
+    private function configureWebhook(): void {
+        $GLOBALS['digitalogic_test_options']['digitalogic_webhook_urls'] = array(
+            'https://automation.digitalogic.test/webhook/wordpress-events',
+        );
+        $GLOBALS['digitalogic_test_options']['digitalogic_webhook_secret'] = 'observer-test-secret';
+    }
+
+    private function actionEnvelope(): array {
+        return array(
+            'schema' => 'digitalogic.product-sync',
+            'schema_version' => '1.0',
+            'event_id' => 'sha256:' . str_repeat('a', 64),
+            'event_type' => 'snapshot',
+            'source' => array(
+                'id' => 'patris-office',
+                'dataset' => 'kala.db',
+                'revision' => 'sha256:' . str_repeat('b', 64),
+            ),
+            'generated_at' => '2026-07-16T12:00:00Z',
+        );
+    }
+
+    private function observerPayload($index): array {
+        return json_decode(
+            $GLOBALS['digitalogic_test_remote_posts'][$index]['args']['body'],
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+    }
+
+    private function resetSingleton($class): void {
+        $property = new ReflectionProperty($class, 'instance');
+        $property->setValue(null, null);
+    }
+}
+// phpcs:enable


### PR DESCRIPTION
﻿## Summary

- subscribe the existing `Digitalogic_Webhooks` service to committed `digitalogic_product_sync_applied` outcomes
- emit one `patris.product_sync.applied` event through the existing signed webhook fan-out; no n8n-specific transport or second sender
- project an exact allowlist of contract/event/source identities, delivery status, pending/deferred counts, and bounded aggregate Woo counts
- keep no-config deployments standalone, terminal replays suppressed by the receiver domain action, and observer failures isolated from committed receiver responses
- document n8n as an optional alert/audit observer rather than a retry authority or data source

## Safe observer contract

The event data contains only:

- `schema`, `event_id`, `event_type`
- non-path `source.id`, `source.dataset`
- `status`, `retryable`, `pending_products`, `deferred_products`
- `woocommerce.attempted`, `updated`, `already_applied`, `missing`, `ambiguous`, `failed`, `errors_truncated`

Counts are native non-negative integers clamped to the 10,000-product receiver bound. Products, names, raw/error details, request or response bodies, endpoint paths/query strings, headers, credentials, source revisions, and receiver state are excluded. Invalid or path-like source identities fail closed.

## Verification

- focused observer: 5 tests / 50 assertions
- product-sync receiver/REST/observer: 38 tests / 316 assertions
- import-freight webhook regression: 50 tests / 537 assertions
- all non-WebSocket PHPUnit coverage on Windows: 147 tests / 1,231 assertions
- PHP syntax: 54 files
- Node authentication navigation: 6 tests
- PHPCS baseline: 42,660 errors / 2,904 warnings (limits unchanged: 43,221 / 3,016)
- public-tree and `git diff --check` pass

The Windows-only long-running `WebSocketLifecycleTest` process remains unsuitable for the local runner; required GitHub PHP 8.3 CI is authoritative for the complete suite.

Closes #67
