### PR TITLE
Publish verified source-built WordPress releases

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -67,7 +69,14 @@ jobs:
       - name: Validate tag, plugin version, and changelog
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
-        run: bash scripts/generate-release-notes.sh "$GITHUB_REF_NAME" "$GITHUB_SHA" build/release-notes.md
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Release tag $GITHUB_REF_NAME does not point to code merged into main." >&2
+            exit 1
+          fi
+          bash scripts/generate-release-notes.sh "$GITHUB_REF_NAME" "$GITHUB_SHA" build/release-notes.md
 
   package:
     name: Build verified plugin package
@@ -238,33 +247,57 @@ jobs:
         run: |
           set -euo pipefail
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release edit "$RELEASE_TAG" \
-              --title "Digitalogic WooCommerce Extension ${RELEASE_TAG#v}" \
-              --notes-file "release-package/${RELEASE_NOTES_NAME}" \
-              --repo "$GITHUB_REPOSITORY"
+            existing_dir="$(mktemp -d)"
+            trap 'rm -rf -- "$existing_dir"' EXIT
+            existing_body="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '.body')"
+            if ! grep -Fq "$GITHUB_SHA" <<<"$existing_body"; then
+              echo "Existing release $RELEASE_TAG does not identify source commit $GITHUB_SHA." >&2
+              exit 1
+            fi
+            gh release download "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --dir "$existing_dir" \
+              --pattern "$ARCHIVE_NAME" \
+              --pattern "$STABLE_ARCHIVE_NAME" \
+              --pattern "$CHECKSUM_NAME"
+            for file in "$ARCHIVE_NAME" "$STABLE_ARCHIVE_NAME" "$CHECKSUM_NAME"; do
+              if ! cmp -s "release-package/$file" "$existing_dir/$file"; then
+                echo "Existing immutable release asset differs: $file" >&2
+                exit 1
+              fi
+            done
+            echo "Release $RELEASE_TAG already contains the identical verified assets."
           else
             gh release create "$RELEASE_TAG" \
               --verify-tag \
               --title "Digitalogic WooCommerce Extension ${RELEASE_TAG#v}" \
               --notes-file "release-package/${RELEASE_NOTES_NAME}" \
+              "release-package/${ARCHIVE_NAME}" \
+              "release-package/${STABLE_ARCHIVE_NAME}" \
+              "release-package/${CHECKSUM_NAME}" \
               --repo "$GITHUB_REPOSITORY"
           fi
-          gh release upload "$RELEASE_TAG" \
-            "release-package/${ARCHIVE_NAME}" \
-            "release-package/${STABLE_ARCHIVE_NAME}" \
-            "release-package/${CHECKSUM_NAME}" \
-            --clobber \
-            --repo "$GITHUB_REPOSITORY"
 
       - name: Generate publication summary
         if: always()
         shell: bash
         env:
+          JOB_STATUS: ${{ job.status }}
           RELEASE_TAG: ${{ github.ref_name }}
           ARCHIVE_NAME: ${{ needs.package.outputs.archive_name }}
           STABLE_ARCHIVE_NAME: ${{ needs.package.outputs.stable_archive_name }}
           CHECKSUM_NAME: ${{ needs.package.outputs.checksum_name }}
         run: |
+          if [[ "$JOB_STATUS" != "success" ]]; then
+            {
+              echo '## Digitalogic WordPress release publication failed'
+              echo
+              echo "- Source commit: \`$GITHUB_SHA\`"
+              echo "- Tag: \`$RELEASE_TAG\`"
+              echo '- Review the failed publication step before retrying. No mutable asset replacement is performed.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           {
             echo '## Published Digitalogic WordPress release'
             echo

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -1,9 +1,14 @@
 name: Package and publish WordPress plugin
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch: {}
+
+concurrency:
+  group: package-release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -59,6 +64,11 @@ jobs:
       - name: Reject public backup artifacts
         run: bash scripts/check-public-tree.sh
 
+      - name: Validate tag, plugin version, and changelog
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: bash scripts/generate-release-notes.sh "$GITHUB_REF_NAME" "$GITHUB_SHA" build/release-notes.md
+
   package:
     name: Build verified plugin package
     needs: verify
@@ -68,6 +78,7 @@ jobs:
       stable_archive_name: ${{ steps.metadata.outputs.stable_archive_name }}
       checksum_name: ${{ steps.metadata.outputs.checksum_name }}
       artifact_name: ${{ steps.metadata.outputs.artifact_name }}
+      release_notes_name: ${{ steps.metadata.outputs.release_notes_name }}
     env:
       COMPOSER_ROOT_VERSION: dev-main
 
@@ -109,7 +120,7 @@ jobs:
         id: metadata
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
         run: |
           set -euo pipefail
           label="${RELEASE_TAG:-${GITHUB_SHA:0:12}}"
@@ -124,6 +135,7 @@ jobs:
             echo "archive_name=digitalogic-wp-${label}.zip"
             echo 'stable_archive_name=digitalogic-wp.zip'
             echo 'checksum_name=SHA256SUMS'
+            echo 'release_notes_name=RELEASE_NOTES.md'
             echo "artifact_name=digitalogic-wp-${label}"
           } >> "$GITHUB_OUTPUT"
 
@@ -145,6 +157,47 @@ jobs:
             cat "${CHECKSUM_NAME}"
           )
 
+      - name: Generate curated release notes
+        shell: bash
+        env:
+          RELEASE_NOTES_NAME: ${{ steps.metadata.outputs.release_notes_name }}
+          RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'auto' }}
+        run: bash scripts/generate-release-notes.sh "$RELEASE_TAG" "$GITHUB_SHA" "build/${RELEASE_NOTES_NAME}"
+
+      - name: Generate package summary
+        if: always()
+        shell: bash
+        env:
+          ARCHIVE_NAME: ${{ steps.metadata.outputs.archive_name }}
+          STABLE_ARCHIVE_NAME: ${{ steps.metadata.outputs.stable_archive_name }}
+          CHECKSUM_NAME: ${{ steps.metadata.outputs.checksum_name }}
+        run: |
+          {
+            echo '## Digitalogic WordPress release package'
+            echo
+            echo "- Source commit: \`${GITHUB_SHA}\`"
+            echo "- Source ref: \`${GITHUB_REF_NAME}\`"
+            echo "- Versioned package: \`${ARCHIVE_NAME}\`"
+            echo "- Stable install package: \`${STABLE_ARCHIVE_NAME}\`"
+            echo "- Job status: \`${{ job.status }}\`"
+            echo
+            echo '### SHA-256 manifest'
+            echo
+            echo '```text'
+            if [[ -f "build/${CHECKSUM_NAME}" ]]; then
+              cat "build/${CHECKSUM_NAME}"
+            else
+              echo 'Package checksum manifest was not produced.'
+            fi
+            echo '```'
+            echo
+            echo 'Install the stable ZIP through WordPress Admin, or run:'
+            echo
+            echo '```bash'
+            echo "wp plugin install ${STABLE_ARCHIVE_NAME} --force --activate"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
@@ -153,13 +206,14 @@ jobs:
             build/${{ steps.metadata.outputs.archive_name }}
             build/${{ steps.metadata.outputs.stable_archive_name }}
             build/${{ steps.metadata.outputs.checksum_name }}
+            build/${{ steps.metadata.outputs.release_notes_name }}
           if-no-files-found: error
           compression-level: 0
           retention-days: 30
 
   publish_release:
-    name: Publish GitHub release asset
-    if: github.event_name == 'release'
+    name: Publish verified GitHub release
+    if: startsWith(github.ref, 'refs/tags/')
     needs: package
     runs-on: ubuntu-latest
     permissions:
@@ -172,19 +226,52 @@ jobs:
           name: ${{ needs.package.outputs.artifact_name }}
           path: release-package
 
-      - name: Upload package to GitHub release
+      - name: Create release and upload verified assets
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
           ARCHIVE_NAME: ${{ needs.package.outputs.archive_name }}
           STABLE_ARCHIVE_NAME: ${{ needs.package.outputs.stable_archive_name }}
           CHECKSUM_NAME: ${{ needs.package.outputs.checksum_name }}
+          RELEASE_NOTES_NAME: ${{ needs.package.outputs.release_notes_name }}
         run: |
           set -euo pipefail
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" \
+              --title "Digitalogic WooCommerce Extension ${RELEASE_TAG#v}" \
+              --notes-file "release-package/${RELEASE_NOTES_NAME}" \
+              --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$RELEASE_TAG" \
+              --verify-tag \
+              --title "Digitalogic WooCommerce Extension ${RELEASE_TAG#v}" \
+              --notes-file "release-package/${RELEASE_NOTES_NAME}" \
+              --repo "$GITHUB_REPOSITORY"
+          fi
           gh release upload "$RELEASE_TAG" \
             "release-package/${ARCHIVE_NAME}" \
             "release-package/${STABLE_ARCHIVE_NAME}" \
             "release-package/${CHECKSUM_NAME}" \
             --clobber \
             --repo "$GITHUB_REPOSITORY"
+
+      - name: Generate publication summary
+        if: always()
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          ARCHIVE_NAME: ${{ needs.package.outputs.archive_name }}
+          STABLE_ARCHIVE_NAME: ${{ needs.package.outputs.stable_archive_name }}
+          CHECKSUM_NAME: ${{ needs.package.outputs.checksum_name }}
+        run: |
+          {
+            echo '## Published Digitalogic WordPress release'
+            echo
+            echo "- Release: [\`${RELEASE_TAG}\`](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG})"
+            echo "- Source commit: \`${GITHUB_SHA}\`"
+            echo "- Installable ZIP: [\`${STABLE_ARCHIVE_NAME}\`](https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${STABLE_ARCHIVE_NAME})"
+            echo "- Immutable ZIP: [\`${ARCHIVE_NAME}\`](https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${ARCHIVE_NAME})"
+            echo "- Checksums: [\`${CHECKSUM_NAME}\`](https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${CHECKSUM_NAME})"
+            echo "- Job status: \`${{ job.status }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -18,7 +18,7 @@ constant_version="$(sed -nE "s/.*define\([[:space:]]*'DIGITALOGIC_VERSION',[[:sp
 if [[ "$tag" == "auto" ]]; then
     tag="v${header_version}"
 fi
-if [[ ! "$tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?)$ ]]; then
+if [[ ! "$tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
     printf 'Release tag must use vX.Y.Z syntax: %s\n' "$tag" >&2
     exit 2
 fi
@@ -64,7 +64,7 @@ Both ZIP files have a single \`digitalogic-wp/\` plugin root and include product
 
 ## Verify the download
 
-Download \`SHA256SUMS\` beside the ZIP files, then run \`sha256sum -c SHA256SUMS\`. On Windows, compare \`Get-FileHash .\\digitalogic-wp.zip -Algorithm SHA256\` with the matching line in \`SHA256SUMS\`.
+Download \`SHA256SUMS\` beside the ZIP files. To verify only the stable installer, run \`grep ' digitalogic-wp.zip$' SHA256SUMS | sha256sum -c -\`. To verify the complete release set, download both ZIPs and run \`sha256sum -c SHA256SUMS\`. On Windows, compare \`Get-FileHash .\\digitalogic-wp.zip -Algorithm SHA256\` with the matching line in \`SHA256SUMS\`.
 
 ## Changelog
 

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (($# != 3)); then
+    printf 'Usage: %s <vX.Y.Z-tag> <source-commit> <output.md>\n' "$0" >&2
+    exit 2
+fi
+
+tag="$1"
+source_commit="$2"
+output="$3"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd -- "$script_dir/.." && pwd)"
+
+header_version="$(sed -nE 's/^[[:space:]]*\*[[:space:]]+Version:[[:space:]]*([^[:space:]]+).*/\1/p' "$root/digitalogic.php" | head -n 1)"
+constant_version="$(sed -nE "s/.*define\([[:space:]]*'DIGITALOGIC_VERSION',[[:space:]]*'([^']+)'[[:space:]]*\).*/\1/p" "$root/digitalogic.php" | head -n 1)"
+
+if [[ "$tag" == "auto" ]]; then
+    tag="v${header_version}"
+fi
+if [[ ! "$tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?)$ ]]; then
+    printf 'Release tag must use vX.Y.Z syntax: %s\n' "$tag" >&2
+    exit 2
+fi
+version="${BASH_REMATCH[1]}"
+
+if [[ "$version" != "$header_version" || "$version" != "$constant_version" ]]; then
+    printf 'Tag %s does not match plugin versions (header=%s, constant=%s).\n' \
+        "$tag" "${header_version:-missing}" "${constant_version:-missing}" >&2
+    exit 1
+fi
+
+changelog="$(awk -v wanted="$version" '
+    $0 == "## [" wanted "]" || index($0, "## [" wanted "] - ") == 1 {
+        found = 1
+        next
+    }
+    found && /^## \[/ { exit }
+    found { print }
+    END { if (!found) exit 1 }
+' "$root/CHANGELOG.md")" || {
+    printf 'CHANGELOG.md has no section for %s.\n' "$version" >&2
+    exit 1
+}
+
+if [[ -z "${changelog//[[:space:]]/}" ]]; then
+    printf 'CHANGELOG.md section for %s is empty.\n' "$version" >&2
+    exit 1
+fi
+
+mkdir -p -- "$(dirname -- "$output")"
+cat > "$output" <<EOF
+# Digitalogic WooCommerce Extension ${version}
+
+This release is an installable, production-only WordPress plugin package built and verified directly from source commit [\`${source_commit}\`](https://github.com/atomicdeploy/digitalogic-wp/commit/${source_commit}). It provides the Digitalogic product, pricing, currency, inventory, shipping/import-freight, Patris integration, REST, webhook, polling, and administrative panel capabilities documented in the repository.
+
+## Download and install
+
+- **WordPress admin:** download \`digitalogic-wp.zip\`, then use **Plugins -> Add New Plugin -> Upload Plugin**.
+- **WP-CLI:** run \`wp plugin install digitalogic-wp.zip --force --activate\`.
+- **Versioned deployment:** \`digitalogic-wp-${tag}.zip\` contains the same verified bytes under an immutable release-specific name.
+
+Both ZIP files have a single \`digitalogic-wp/\` plugin root and include production Composer dependencies. Development dependencies, tests, repository metadata, backup files, and editor artifacts are excluded.
+
+## Verify the download
+
+Download \`SHA256SUMS\` beside the ZIP files, then run \`sha256sum -c SHA256SUMS\`. On Windows, compare \`Get-FileHash .\\digitalogic-wp.zip -Algorithm SHA256\` with the matching line in \`SHA256SUMS\`.
+
+## Changelog
+
+${changelog}
+
+## Source and build provenance
+
+- Tag: \`${tag}\`
+- Source commit: \`${source_commit}\`
+- Builder: GitHub Actions from the tagged source tree
+- Verification: Composer validation/audit, PHP and JavaScript syntax, PHPUnit, WordPress coding-standard baseline, public-tree policy, production dependency checks, package layout checks, packaged PHP linting, autoload smoke tests, and deterministic double-build comparison
+- GitHub's automatically generated source archives remain available in the **Assets** section alongside the installable plugin ZIPs.
+EOF
+
+printf 'Generated release notes for %s at %s\n' "$tag" "$output"


### PR DESCRIPTION
## Summary
- publish durable GitHub Releases from version tags instead of requiring a pre-existing release
- enforce tag, plugin header, runtime constant, and changelog version consistency before publication
- generate complete release notes with install and checksum instructions
- attach deterministic versioned/stable plugin ZIPs plus SHA256SUMS
- add package and publication summaries to GitHub Actions

## Validation
- bash syntax and release-note generation
- positive v1.3.1 and negative mismatched-tag checks
- PHP and JavaScript syntax checks
- git diff --check

After merge, pushing v1.3.1 will build, verify, and publish the first installable release.