### PR TITLE
ci: configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+
+updates:
+  # Keep the target branch implicit so these settings also apply to security
+  # updates, which Dependabot always opens against the default branch.
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Tehran"
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
+    versioning-strategy: "increase-if-necessary"
+    labels:
+      - "🧹 type: maintenance"
+      - "🏗️ area: build-ci"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      composer-production-minor-patch:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      composer-development-minor-patch:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:15"
+      timezone: "Asia/Tehran"
+    open-pull-requests-limit: 3
+    rebase-strategy: "auto"
+    labels:
+      - "🧹 type: maintenance"
+      - "🏗️ area: build-ci"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions-minor-patch:
+        applies-to: "version-updates"
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- monitor the root Composer manifest and GitHub Actions workflows every Monday in Asia/Tehran
- group routine minor/patch version updates while leaving major and security updates isolated
- reuse the repository maintenance/build-CI labels, automatic rebasing, and bounded PR limits
- keep the default target branch implicit so the customization also applies to security-update PRs

## Validation
- Dependabot YAML parse and policy assertions
- `composer validate --strict`
- `composer audit --locked`
- `git diff --check`

## Follow-up
After merge, enable and verify Dependabot alerts and automated security updates in the repository settings.