### PR TITLE
ci: update upload-artifact to v7

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -164,7 +164,7 @@ jobs:
         )
         
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: digitalogic-wp-plugin
         path: |

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -208,7 +208,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.metadata.outputs.artifact_name }}
           path: |


### PR DESCRIPTION
## Summary
- update both CI and release packaging uploads from `actions/upload-artifact@v4` to `@v7`
- remove the Node.js 20 deprecation warning from the remaining artifact-upload steps
- preserve archived multi-file behavior and all existing retention/compression/error settings

## Compatibility
- current inputs remain supported by upload-artifact v7
- default `archive: true` preserves ZIP artifact behavior for download-artifact v8
- workflows run on GitHub-hosted runners newer than the Node.js 24 minimum

## Validation
- reviewed the official v6/v7 migration notes and v7 action inputs
- `git diff --check`
- PR CI exercises the CI artifact upload; after merge, a non-publishing release workflow run will exercise the release package upload