### PR TITLE
release: Digitalogic 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-07-17
+
+### Changed
+- Added grouped Dependabot maintenance for Composer and GitHub Actions so dependency updates remain reviewable and independently testable.
+- Updated the release and CI workflows to current `actions/checkout`, `actions/cache`, `actions/download-artifact`, and `actions/upload-artifact` generations.
+- Updated the WordPress Coding Standards development dependency from 3.3.0 to 3.4.0 without changing the production dependency set.
+
 ## [1.3.1] - 2026-07-17
 
 ### Fixed
@@ -193,7 +200,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added options: `dollar_price`, `yuan_price`, `update_date`
 - Added product meta keys: `_digitalogic_dynamic_pricing`, `_digitalogic_currency_type`, `_digitalogic_base_price`, `_digitalogic_markup`, `_digitalogic_markup_type`
 
-## [Unreleased]
+## Roadmap
 
 ### Planned Features
 - Excel import/export with PhpSpreadsheet library

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.3.1
+ * Version: 1.3.2
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.3.1' );
+define( 'DIGITALOGIC_VERSION', '1.3.2' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('DIGITALOGIC_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Summary

Prepare the source-built Digitalogic WooCommerce Extension 1.3.2 patch release from the current merged main branch.

- document the Dependabot grouping and GitHub Actions upgrades merged in PRs #74-#79
- document the WPCS 3.4.0 development-only update
- keep one active Unreleased section and label the historical planned work as Roadmap
- bump both WordPress-visible version declarations to 1.3.2

## Validation

- php -l digitalogic.php
- composer validate --strict
- composer audit --locked
- JavaScript parse checks with node --check
- git diff --check
- release-note metadata generation for v1.3.2

The PR and release-package workflows will run the authoritative Linux PHPUnit, coding-standard, deterministic package, packaged-PHP, and autoload checks. After merge, tag the exact main commit as v1.3.2 to publish the installable ZIPs and SHA-256 manifest.