### PR TITLE
Record the superseded product-sync bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-07-20
+
+### Added
+- Added exact Patris Export product-sync v1.1 receiver compatibility for product `category_code`, the complete typed category projection, and excluded catalog Codes, including Go-compatible category, source, and event identity verification.
+- Persisted the v1.1 catalog projection in receiver state v4, exposed bounded category/exclusion counts in receiver responses and status output, and mirrored each product's category Code to `_digitalogic_patris_category_code` through the shared WooCommerce writer.
+- Added a Go-generated v1.1 golden fixture and focused compatibility, catalog-transition, tamper, feature-level baseline, and v3-to-v4 migration coverage while retaining the v1.0 golden regression.
+- Added the production-proven pre-save WooCommerce change capture to `product.updated` webhooks, with compact `changed_fields` values and date/scalar normalization.
+
+### Changed
+- Reduced peak memory during transactional receiver readback by comparing the exact stored serialization digest instead of serializing both the expected and read-back state again.
+- Ported the live login loading-state fixes so button text is hidden behind a centered spinner, loading stripes loop cleanly in LTR/RTL, and Persian retry messages no longer claim the form was released.
+
+### Security
+- Require a fresh snapshot when a source changes between the v1.0 and v1.1 contract feature levels, preventing an update from mixing incompatible product record shapes.
+
 ## [1.3.2] - 2026-07-17
 
 ### Changed

--- a/assets/css/branding/admin-branding.css
+++ b/assets/css/branding/admin-branding.css
@@ -1150,16 +1150,17 @@ body.login :is(#wp-submit, .button-primary, .digits-form_submit-btn, .digits-for
     position: relative;
     overflow: hidden !important;
     background-image: linear-gradient(135deg, var(--dg-accent) 0%, var(--dg-accent-strong) 100%) !important;
-    color: #fff !important;
+    color: transparent !important;
     cursor: wait !important;
     animation: none !important;
     opacity: 1 !important;
     isolation: isolate;
+    text-shadow: none !important;
 }
 
 body.login :is(#wp-submit, .button-primary, .digits-form_submit-btn, .digits-form_submit, .digits-form_button, .digits-social-btn).is-loading:disabled {
     background-image: linear-gradient(135deg, var(--dg-accent) 0%, var(--dg-accent-strong) 100%) !important;
-    color: #fff !important;
+    color: transparent !important;
     filter: none !important;
 }
 
@@ -1183,14 +1184,18 @@ html[dir="rtl"] body.login :is(#wp-submit, .button-primary, .digits-form_submit-
 
 body.login :is(#wp-submit, .button-primary, .digits-form_submit-btn, .digits-form_submit, .digits-form_button, .digits-social-btn).is-loading::after {
     content: "";
-    display: inline-block;
+    display: block;
     inline-size: 18px;
     block-size: 18px;
     border: 2px solid rgba(255, 255, 255, 0.42);
     border-block-start-color: #fff;
     border-radius: 999px;
     animation: dg-fuji-spin 0.72s linear infinite;
-    position: relative;
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
+    margin-block-start: -9px;
+    margin-inline-start: -9px;
     z-index: 1;
 }
 
@@ -1215,6 +1220,8 @@ body.login :is(.digits-form_submit-btn, .digits-form_submit, .digits-form_button
 body.login :is(#wp-submit, .button-primary, .digits-form_submit-btn, .digits-form_submit, .digits-form_button, .digits-social-btn).is-loading > * {
     position: relative;
     z-index: 1;
+    opacity: 0 !important;
+    visibility: hidden !important;
 }
 
 body.login form.dg-form-pending {
@@ -2375,21 +2382,21 @@ body.wp-admin .digitalogic-panel-page .button-hero {
 
 @keyframes dg-loading-stripes-ltr {
     from {
-        transform: translateX(-36px);
+        transform: translateX(0);
     }
 
     to {
-        transform: translateX(36px);
+        transform: translateX(56.568542px);
     }
 }
 
 @keyframes dg-loading-stripes-rtl {
     from {
-        transform: translateX(36px);
+        transform: translateX(0);
     }
 
     to {
-        transform: translateX(-36px);
+        transform: translateX(-56.568542px);
     }
 }
 

--- a/assets/js/branding/admin-branding.js
+++ b/assets/js/branding/admin-branding.js
@@ -886,7 +886,7 @@
             clearLoading();
             showLoginFailureMessage(
                 document.querySelector('.dg-digits-login-shell form, .dg-digits-register-shell form'),
-                getLabel('requestTimeout', 'پاسخی از سرور دریافت نشد. اتصال یا افزونه ورود به‌موقع پاسخ نداد؛ فرم آزاد شد، دوباره تلاش کنید.'),
+                getLabel('requestTimeout', 'پاسخی از سرور دریافت نشد. اتصال یا افزونه ورود به‌موقع پاسخ نداد؛ دوباره تلاش کنید.'),
                 'error'
             );
         }, 9000);
@@ -1229,7 +1229,7 @@
             clearLoading();
             showDigitsInlineMessage(
                 form,
-                getLabel('digitsEmptyResponse', 'افزونه ورود پاسخ ناقص فرستاد: درخواست موفق علامت خورد اما داده مرحله بعدی در پاسخ نبود. فرم آزاد شد؛ دوباره تلاش کنید.'),
+                getLabel('digitsEmptyResponse', 'افزونه ورود پاسخ ناقص فرستاد: درخواست موفق علامت خورد اما داده مرحله بعدی در پاسخ نبود. دوباره تلاش کنید.'),
                 'error'
             );
             return;
@@ -1306,8 +1306,8 @@
             showDigitsInlineMessage(
                 form,
                 error && error.name === 'AbortError'
-                    ? getLabel('requestTimeout', 'پاسخی از سرور دریافت نشد. اتصال یا افزونه ورود به‌موقع پاسخ نداد؛ فرم آزاد شد، دوباره تلاش کنید.')
-                    : getLabel('requestError', 'درخواست ورود با خطای شبکه یا سرور روبه‌رو شد. فرم آزاد شد؛ دوباره تلاش کنید.'),
+                    ? getLabel('requestTimeout', 'پاسخی از سرور دریافت نشد. اتصال یا افزونه ورود به‌موقع پاسخ نداد؛ دوباره تلاش کنید.')
+                    : getLabel('requestError', 'درخواست ورود با خطای شبکه یا سرور روبه‌رو شد. دوباره تلاش کنید.'),
                 'error'
             );
         });
@@ -1371,7 +1371,7 @@
                         clearLoading();
                         showLoginFailureMessage(
                             null,
-                            getLabel('digitsMalformedAjax', 'خطای افزونه Digits: پاسخ AJAX مرحله ورود بدون داده معتبر برگشت، بنابراین callback افزونه اجرا نشد تا فرم گیر نکند. فرم آزاد شد؛ دوباره تلاش کنید.'),
+                            getLabel('digitsMalformedAjax', 'خطای افزونه Digits: پاسخ AJAX مرحله ورود بدون داده معتبر برگشت، بنابراین callback افزونه اجرا نشد تا فرم گیر نکند. دوباره تلاش کنید.'),
                             'error'
                         );
                         return;
@@ -1401,7 +1401,7 @@
 
                     showLoginFailureMessage(
                         null,
-                        getLabel('requestError', 'درخواست AJAX ورود شکست خورد. فرم آزاد شد؛ دوباره تلاش کنید.'),
+                        getLabel('requestError', 'درخواست AJAX ورود شکست خورد. دوباره تلاش کنید.'),
                         'error'
                     );
                 };
@@ -2078,7 +2078,7 @@
             if (/Cannot read properties of undefined .*reload/.test(raw) || /reading 'reload'/.test(raw)) {
                 return getLabel(
                     'digitsReloadBug',
-                    'خطای افزونه Digits: پاسخ AJAX مرحله ورود ناقص بود و اسکریپت Digits هنگام خواندن مقدار reload خراب شد. فرم آزاد شد؛ لطفاً دوباره تلاش کنید.'
+                    'خطای افزونه Digits: پاسخ AJAX مرحله ورود ناقص بود و اسکریپت Digits هنگام خواندن مقدار reload خراب شد. لطفاً دوباره تلاش کنید.'
                 );
             }
 
@@ -2086,7 +2086,7 @@
                 return getLabel('runtimeErrorPrefix', 'خطای صفحه: ') + raw + (source ? ' (' + source.split('/').slice(-3).join('/') + ')' : '');
             }
 
-            return getLabel('runtimeError', 'یک خطای صفحه رخ داد اما مرورگر جزئیات آن را گزارش نکرد. فرم آزاد شد؛ دوباره تلاش کنید.');
+            return getLabel('runtimeError', 'یک خطای صفحه رخ داد اما مرورگر جزئیات آن را گزارش نکرد. دوباره تلاش کنید.');
         }
 
         window.addEventListener('error', function (event) {

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.3.2
+ * Version: 1.3.3
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.3.2' );
+define( 'DIGITALOGIC_VERSION', '1.3.3' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('DIGITALOGIC_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/docs/PATRIS-PRODUCT-SYNC-V1.1-VERIFICATION.md
+++ b/docs/PATRIS-PRODUCT-SYNC-V1.1-VERIFICATION.md
@@ -1,0 +1,71 @@
+# Patris Product Sync v1.1 Verification
+
+This note records the sanitized compatibility run used for the v1.3.3 release.
+The production envelope remains outside the repository; no product, category,
+path, credential, event identity, or source identity is included here.
+
+## Command shape
+
+The local envelope was read into the lightweight WordPress/WooCommerce test
+bootstrap and passed, unchanged, to the public JSON receiver:
+
+```powershell
+@'
+<?php
+require 'tests/bootstrap.php';
+$json = file_get_contents('<local-production-envelope.json>');
+$result = Digitalogic_Product_Sync_Receiver::instance()->receive_json($json);
+$state = Digitalogic_Product_Sync_Receiver::instance()->get_state();
+$serialized = maybe_serialize($state);
+// Print aggregate counts, byte sizes, elapsed time, and peak memory only.
+'@ | php -d memory_limit=128M
+```
+
+The receiver therefore used the same strict duplicate-key decoder, exact Go
+record/source/event identity checks, formula validation, transactional option
+writer, state readback, and mocked WooCommerce delivery path as PHPUnit.
+
+## Sanitized result
+
+```json
+{
+  "status": "accepted",
+  "input_bytes": 4698058,
+  "received_products": 3495,
+  "stored_products": 3495,
+  "received_categories": 1779,
+  "stored_categories": 1779,
+  "excluded_codes": 7,
+  "quarantined_codes": 231,
+  "serialized_state_bytes": 5856731,
+  "state_limit_bytes": 16777216,
+  "state_headroom_bytes": 10920485,
+  "state_limit_percent": 34.91,
+  "elapsed_seconds": 0.837,
+  "peak_memory_bytes": 130023424,
+  "php_memory_limit_bytes": 134217728
+}
+```
+
+The 128 MiB PHP ceiling is exactly 134,217,728 bytes, leaving 4,194,304 bytes
+between the observed peak and that isolated CLI ceiling. That is not adequate
+deployment headroom for WordPress, WooCommerce, and other active plugins;
+production should use at least a 256 MiB effective PHP/WordPress memory limit
+and monitor the first full snapshot. The durable receiver state itself uses
+34.91% of its separate 16 MiB cap.
+
+The original readback implementation exceeded the 128 MiB test ceiling by
+serializing both full expected and read-back states again. v1.3.3 hashes the
+already available exact serialized strings instead; the focused state readback
+failure tests still pass.
+
+## Automated coverage
+
+- Product-sync receiver: 34 tests, 304 assertions.
+- All non-socket-platform plugin tests: 191 tests, 1,591 assertions.
+- Twelve portable WebSocket lifecycle tests: 12 tests, 41 assertions.
+
+The remaining WebSocket lifecycle cases require Unix `pcntl_fork`, Unix-domain
+socket pairs, or Unix bind-failure behavior and cannot complete on the Windows
+PHP runner. They are unrelated to this receiver change and should run in the
+Linux CI job before publishing the release artifact.

--- a/docs/PATRIS-PRODUCT-SYNC-V1.md
+++ b/docs/PATRIS-PRODUCT-SYNC-V1.md
@@ -43,12 +43,13 @@ Patris may also send `X-Patris-Contract`, `X-Patris-Contract-Version`, and
 
 ## Envelope
 
-The receiver accepts schema major version 1. The current producer sends:
+The receiver accepts schema major version 1. Patris Export currently sends
+schema version 1.1:
 
 ```json
 {
   "schema": "digitalogic.product-sync",
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "event": "digitalogic.product-sync",
   "event_type": "snapshot",
   "event_id": "sha256:...",
@@ -63,17 +64,34 @@ The receiver accepts schema major version 1. The current producer sends:
   },
   "generated_at": "2026-07-16T08:00:00Z",
   "products": [],
+  "categories": [],
+  "excluded_codes": [],
   "deleted_codes": [],
   "quarantined_codes": [],
   "warnings": []
 }
 ```
 
-Every product is the fixed typed `digitalogic.product-sync` v1 shape emitted by
-Patris Export. `product_code` is always a non-empty JSON string, even when it
-contains only digits. Product output currency is CNY, final prices are
-non-negative integer IRT values or `null`, and the product formula must be
-`landed_price_v1`.
+Every product is the fixed typed `digitalogic.product-sync` shape emitted by
+Patris Export. In v1.1, `category_code` follows `product_code` and is a required
+string; an empty value means the product has no matching structural category.
+`product_code` is always a non-empty JSON string, even when it contains only
+digits. Product output currency is CNY, final prices are non-negative integer
+IRT values or `null`, and the product formula must be `landed_price_v1`.
+
+`categories` is the complete sorted catalog projection, not a delta. Every
+entry has exactly `category_code`, `name`, `parent_code`, positive integer
+`depth`, `warnings`, and `record_hash`. Roots have an empty parent and depth 1;
+children reference another category in the same projection and have parent
+depth plus one. `excluded_codes` is the complete sorted set of structural or
+accounting records which must not become products. Both arrays are omitted by
+the producer when empty.
+
+Legacy v1.0 envelopes remain accepted with their original product shape and
+hash material. They must not contain `category_code`, `categories`, or
+`excluded_codes`. A source changing between the v1.0 and v1.1 feature levels
+must establish a fresh snapshot; a cross-feature update is rejected with
+`digitalogic_product_sync_baseline_required`.
 
 The receiver recursively rejects raw Patris/Paradox keys, including spelling,
 case, and separator variants of `Sharh`, `Sharh1`, `Sharh2`, `FOROSH`,
@@ -83,11 +101,13 @@ case, and separator variants of `Sharh`, `Sharh1`, `Sharh2`, `FOROSH`,
 
 The receiver independently verifies:
 
-- each `record_hash` from the typed product in Go-compatible JSON field order;
+- each product and category `record_hash` from its typed record in
+  Go-compatible JSON field order;
 - every non-null `final_price` by independently evaluating
   `landed_price_v1` as bounded exact decimals, with one half-up round to the
   final IRT integer; incomplete formula inputs require `final_price: null`;
-- `source.revision` from the resulting complete source snapshot; and
+- `source.revision` from the resulting complete product, category, exclusion,
+  and quarantine snapshot; and
 - `event_id` from the schema, source identity, sorted record hashes,
   occurrence timestamp, tombstones, and quarantined Codes.
 
@@ -97,12 +117,16 @@ this field order:
 ```text
 schema, schema_version, event_type, local_currency, formula_id,
 formula_revision, source{id,dataset,revision}, generated_at, products,
+[categories when non-empty], [excluded_codes when non-empty],
 [deleted_codes when non-empty], [quarantined_codes when non-empty]
 ```
 
 `products` is a lexicographically sorted string list whose entries are
-`<product_code>=<record_hash>`. `generated_at` is the exact validated RFC3339
-wire string. Binding it into the identity makes same-content occurrences at
+`<product_code>=<record_hash>`. `categories` uses the same form with the
+category Code. The source revision sorts product entries, entries prefixed by
+`category:`, and entries prefixed by `excluded=` together, then appends sorted
+`quarantined=` entries. `generated_at` is the exact validated RFC3339 wire
+string. Binding it into the identity makes same-content occurrences at
 different timestamps distinct and ensures a newer same-content event advances
 the ordering watermark.
 
@@ -126,6 +150,8 @@ returns `recovered` or `retry_pending`.
 
 - `snapshot` replaces the receiver snapshot for that source.
 - `update` merges complete changed products into the existing snapshot.
+- On every v1.1 snapshot or update, `categories` and `excluded_codes` replace
+  their previous complete projections; they are never merged as deltas.
 - `deleted_codes` is valid on updates, including an update containing only
   tombstones. It removes exact Codes from receiver state only.
 - A tombstone never trashes, drafts, or deletes a WooCommerce product.
@@ -138,6 +164,13 @@ when no exact Patris Code exists; a distinct exact SKU and Patris Code collision
 is ambiguous. Missing or ambiguous identifiers are reported and never resolved
 by fuzzy name matching.
 
+For v1.1 products, the shared WooCommerce writer stores the validated category
+Code in `_digitalogic_patris_category_code`. This compatibility change does
+not create, rename, delete, or assign WooCommerce product terms. Native term
+materialization and taxonomy reconciliation remain separately tracked in
+[issue #81](https://github.com/atomicdeploy/digitalogic-wp/issues/81); deploying
+this receiver must not be represented as completing that work.
+
 Receiver state is written under `digitalogic_product_sync_v1_state`, evicted
 from the option cache, and read back with a digest check before WooCommerce
 writes. Each source has an applied `{record_hash,woocommerce_id}` CAS record, a
@@ -147,10 +180,12 @@ crash-window retries without a duplicate save. Woo lookup/storage/write
 failures, including identifier database query failures, stay pending; exact
 Code not-found and ambiguity move to deferred only after a successful lookup
 and are never guessed. The final delivery state is read back before the result-aware
-`digitalogic_product_sync_v1_applied` domain action. Existing v2 receiver state
-is projected and transactionally persisted as v3 under the same advisory lock.
-Because v2 could not distinguish SQL failure from not-found, its not-found
-entries stay pending until one successful v3 lookup reclassifies them.
+`digitalogic_product_sync_v1_applied` domain action. Existing v2/v3 receiver
+state is projected and transactionally persisted as v4 under the same advisory
+lock. Migrated sources are explicitly marked v1.0 with empty category and
+exclusion projections. Because v2 could not distinguish SQL failure from
+not-found, its not-found entries stay pending until one successful current
+receiver lookup reclassifies them.
 This state is independent of the legacy Patris feed option.
 
 ## Successful response
@@ -165,6 +200,9 @@ This state is independent of the legacy Patris feed option.
     "event_type": "update",
     "received_products": 1,
     "stored_products": 2,
+    "received_categories": 2,
+    "stored_categories": 2,
+    "excluded_codes": 1,
     "deleted_codes": 0,
     "fully_applied": true,
     "retryable": false,
@@ -211,8 +249,9 @@ wp digitalogic product-sync reconcile \
 ```
 
 The status command exposes source/event identities and aggregate counts only;
-it does not print product payloads or credentials. Reconciliation processes
-only pending/deferred records, never already-applied writes, and preserves the
+it includes the schema version and stored product/category/exclusion totals but
+does not print record payloads or credentials. Reconciliation processes only
+pending/deferred records, never already-applied writes, and preserves the
 stored source event ordering watermark.
 
 ## Optional signed observer event
@@ -249,3 +288,8 @@ The synthetic cross-project fixture is 2,760 bytes with SHA-256
 `810bdf4d8fd5e3c2a87750a02f241363f6403736c899a625f615967fea259da5`.
 Its occurrence identity is
 `sha256:25d5afce95dfdcf598c28f9c9639cbd54ed7f2e838a6c285844eee75d972ef06`.
+
+The Go-generated v1.1 catalog fixture is 3,361 bytes with SHA-256
+`8a635fa63cadc2b5021879c32e3ee47ce9d4928806948c154cdeb1b744da61fd`.
+Its occurrence identity is
+`sha256:4230ed302661c27a3b1bac71c60fac6a82c43bfb1ac0a7942137695b00afc2ac`.

--- a/includes/api/class-webhooks.php
+++ b/includes/api/class-webhooks.php
@@ -26,6 +26,13 @@ class Digitalogic_Webhooks {
     // phpcs:enable
     
     private static $instance = null;
+
+    /**
+     * Best-effort WooCommerce product field changes captured before save.
+     *
+     * @var array<int,array<int,array<string,mixed>>>
+     */
+    private $pending_product_changes = array();
     
     public static function instance() {
         if (is_null(self::$instance)) {
@@ -43,6 +50,7 @@ class Digitalogic_Webhooks {
         add_action('profile_update', array($this, 'user_updated'), 10, 3);
 
         // Hook into product updates
+        add_action('woocommerce_before_product_object_save', array($this, 'capture_product_changes'), 10, 1);
         add_action('woocommerce_update_product', array($this, 'product_updated'), 10, 1);
         add_action('woocommerce_new_product', array($this, 'product_created'), 10, 1);
         add_action('before_delete_post', array($this, 'product_deleted'), 10, 2);
@@ -207,6 +215,46 @@ class Digitalogic_Webhooks {
         ));
     }
     
+    // phpcs:disable -- Preserve the production hotfix formatting while the legacy file remains baseline-managed.
+    /**
+     * Capture changed WooCommerce product fields before save.
+     *
+     * @param WC_Product $product Product being saved.
+     */
+    public function capture_product_changes($product) {
+        if (!is_object($product) || !method_exists($product, 'get_id') || !method_exists($product, 'get_changes')) {
+            return;
+        }
+
+        $product_id = (int) $product->get_id();
+        if ($product_id <= 0) {
+            return;
+        }
+
+        $changes = $product->get_changes();
+        if (empty($changes) || !is_array($changes)) {
+            return;
+        }
+
+        $data = method_exists($product, 'get_data') ? $product->get_data() : array();
+        $captured = array();
+        foreach ($changes as $field => $new_value) {
+            if (in_array((string) $field, array('date_modified', 'date_created'), true)) {
+                continue;
+            }
+            $captured[] = array(
+                'field' => (string) $field,
+                'old' => $this->webhook_scalar_value(is_array($data) && array_key_exists($field, $data) ? $data[$field] : null),
+                'new' => $this->webhook_scalar_value($new_value),
+            );
+        }
+
+        if (!empty($captured)) {
+            $this->pending_product_changes[$product_id] = $captured;
+        }
+    }
+    // phpcs:enable
+
     /**
      * Product updated webhook
      */
@@ -215,6 +263,10 @@ class Digitalogic_Webhooks {
         $product = $manager->get_product($product_id);
         
         if ($product) {
+            if (isset($this->pending_product_changes[(int) $product_id])) {
+                $product['changed_fields'] = $this->pending_product_changes[(int) $product_id];
+                unset($this->pending_product_changes[(int) $product_id]);
+            }
             $this->trigger_webhook('product.updated', $product);
         }
     }
@@ -668,6 +720,31 @@ class Digitalogic_Webhooks {
             'request' => $this->request_context(),
         );
     }
+
+    // phpcs:disable -- Preserve the production hotfix formatting while the legacy file remains baseline-managed.
+    /**
+     * Normalize webhook change values into compact nonsecret scalars.
+     *
+     * @param mixed $value Raw value.
+     * @return mixed
+     */
+    private function webhook_scalar_value($value) {
+        if ($value instanceof WC_DateTime || $value instanceof DateTimeInterface) {
+            return $value->date('c');
+        }
+        if (is_scalar($value) || null === $value) {
+            return $value;
+        }
+        if (is_array($value)) {
+            return wp_json_encode($value);
+        }
+        if (is_object($value) && method_exists($value, '__toString')) {
+            return (string) $value;
+        }
+
+        return gettype($value);
+    }
+    // phpcs:enable
 
     /**
      * Current request metadata.

--- a/includes/class-patris-feed.php
+++ b/includes/class-patris-feed.php
@@ -501,6 +501,7 @@ class Digitalogic_Patris_Feed {
         }
 
         $canonical_meta = array(
+            'category_code' => '_digitalogic_patris_category_code',
             'import_freight_method_id' => '_digitalogic_patris_import_freight_method_id',
             'freight_cny_per_kg' => '_digitalogic_patris_freight_cny_per_kg',
             'markup_percent' => '_digitalogic_patris_markup_percent',

--- a/includes/class-product-sync-receiver.php
+++ b/includes/class-product-sync-receiver.php
@@ -237,12 +237,13 @@ class Digitalogic_Product_Sync_Receiver {
     public const CONTRACT_NAME = 'digitalogic.product-sync';
     public const FORMULA_ID = 'landed_price_v1';
 
-    private const STATE_VERSION = 3;
+    private const STATE_VERSION = 4;
     private const LOCK_NAME = 'digitalogic_product_sync_v1';
     private const LOCK_TIMEOUT_SECONDS = 15;
     private const MAX_BODY_BYTES = 8388608;
     private const MAX_STATE_BYTES = 16777216;
     private const MAX_PRODUCTS = 10000;
+    private const MAX_CATEGORIES = 10000;
     private const MAX_SOURCES = 16;
     private const MAX_RECENT_EVENTS = 128;
     private const MAX_RESULT_ERRORS = 100;
@@ -265,12 +266,14 @@ class Digitalogic_Product_Sync_Receiver {
         'source',
         'generated_at',
         'products',
+        'categories',
+        'excluded_codes',
         'deleted_codes',
         'quarantined_codes',
         'warnings',
     );
 
-    private const PRODUCT_FIELDS = array(
+    private const PRODUCT_FIELDS_V1_0 = array(
         'product_code',
         'name',
         'serial',
@@ -294,6 +297,44 @@ class Digitalogic_Product_Sync_Receiver {
         'final_price',
         'formula_version',
         'source_updated_at',
+        'warnings',
+        'record_hash',
+    );
+
+    private const PRODUCT_FIELDS_V1_1 = array(
+        'product_code',
+        'category_code',
+        'name',
+        'serial',
+        'unit',
+        'sale_price_source',
+        'purchase_price_source',
+        'warehouse_stock',
+        'total_stock',
+        'minimum_stock',
+        'foreign_currency',
+        'foreign_price',
+        'weight_grams',
+        'location',
+        'import_freight_method_id',
+        'freight_cny_per_kg',
+        'markup_percent',
+        'irt_per_cny',
+        'pricing_catalog_revision',
+        'pricing_catalog_status',
+        'currency_effective_date',
+        'final_price',
+        'formula_version',
+        'source_updated_at',
+        'warnings',
+        'record_hash',
+    );
+
+    private const CATEGORY_FIELDS = array(
+        'category_code',
+        'name',
+        'parent_code',
+        'depth',
         'warnings',
         'record_hash',
     );
@@ -454,6 +495,8 @@ class Digitalogic_Product_Sync_Receiver {
         $sources = array();
         $totals = array(
             'stored_products' => 0,
+            'stored_categories' => 0,
+            'excluded_codes' => 0,
             'applied_products' => 0,
             'pending_products' => 0,
             'deferred_products' => 0,
@@ -574,6 +617,9 @@ class Digitalogic_Product_Sync_Receiver {
         if (2 === $version) {
             $state = $this->migrate_v2_state($state);
             $migration_required = true;
+        } elseif (3 === $version) {
+            $state = $this->migrate_v3_state($state);
+            $migration_required = true;
         } elseif (self::STATE_VERSION !== $version) {
             return array('version' => self::STATE_VERSION, 'sources' => array());
         }
@@ -582,6 +628,7 @@ class Digitalogic_Product_Sync_Receiver {
             if (!is_array($source_state)) {
                 $source_state = array();
             }
+            $this->normalize_catalog_source_state($source_state);
             $source_state['deferred_products'] = is_array($source_state['deferred_products'] ?? null)
                 ? array_slice($source_state['deferred_products'], 0, self::MAX_DEFERRED_PRODUCTS, true)
                 : array();
@@ -634,6 +681,22 @@ class Digitalogic_Product_Sync_Receiver {
                 409
             );
         }
+        if (
+            'update' === $envelope['event_type']
+            && is_array($existing)
+            && $this->has_catalog_contract($envelope['schema_version'])
+                !== $this->has_catalog_contract((string) ($existing['schema_version'] ?? '1.0'))
+        ) {
+            return $this->error(
+                'digitalogic_product_sync_baseline_required',
+                'A snapshot is required before changing the source contract feature level.',
+                409,
+                array(
+                    'stored_schema_version' => (string) ($existing['schema_version'] ?? '1.0'),
+                    'received_schema_version' => $envelope['schema_version'],
+                )
+            );
+        }
 
         if (is_array($existing)) {
             $comparison = $this->compare_timestamp_order($envelope['generated_at_order'], $existing['generated_at_order'] ?? array());
@@ -669,6 +732,7 @@ class Digitalogic_Product_Sync_Receiver {
         $delivery = $this->build_delivery_state($transition['products'], $transition['changed_products'], $envelope, $existing);
         $source_state = array(
             'source' => $envelope['source'],
+            'schema_version' => $envelope['schema_version'],
             'generated_at' => $envelope['generated_at'],
             'generated_at_order' => $envelope['generated_at_order'],
             'last_event_id' => $envelope['event_id'],
@@ -677,6 +741,8 @@ class Digitalogic_Product_Sync_Receiver {
             'formula_id' => $envelope['formula_id'],
             'formula_revision' => $envelope['formula_revision'],
             'products' => $transition['products'],
+            'categories' => $transition['categories'],
+            'excluded_codes' => $transition['excluded_codes'],
             'quarantined_codes' => $envelope['quarantined_codes'],
             'recent_events' => $recent_events,
             'applied_products' => $delivery['applied_products'],
@@ -710,6 +776,9 @@ class Digitalogic_Product_Sync_Receiver {
             'source' => $envelope['source'],
             'received_products' => count($envelope['products']),
             'stored_products' => count($transition['products']),
+            'received_categories' => count($envelope['categories']),
+            'stored_categories' => count($transition['categories']),
+            'excluded_codes' => count($transition['excluded_codes']),
             'deleted_codes' => $transition['deleted_count'],
             'preserved_quarantined' => $transition['preserved_quarantined'],
             'woocommerce' => $woo,
@@ -739,6 +808,8 @@ class Digitalogic_Product_Sync_Receiver {
             'event_type' => $envelope['event_type'],
             'source' => $envelope['source'],
             'stored_products' => count($source_state['products'] ?? array()),
+            'stored_categories' => count($source_state['categories'] ?? array()),
+            'excluded_codes' => count($source_state['excluded_codes'] ?? array()),
             'woocommerce' => $woo,
             'persistence_verified' => true,
         ), $this->delivery_result_state($source_state));
@@ -806,6 +877,17 @@ class Digitalogic_Product_Sync_Receiver {
         if (!$this->is_supported_major_version($payload['schema_version'])) {
             return $this->error('digitalogic_product_sync_version_unsupported', 'Only product-sync schema major version 1 is supported.', 422);
         }
+        $has_catalog = $this->has_catalog_contract($payload['schema_version']);
+        if (
+            !$has_catalog
+            && (array_key_exists('categories', $payload) || array_key_exists('excluded_codes', $payload))
+        ) {
+            return $this->error(
+                'digitalogic_product_sync_version_field_unsupported',
+                'Categories and excluded Codes require product-sync schema version 1.1 or newer.',
+                422
+            );
+        }
         if (!in_array($payload['event_type'], array('snapshot', 'update'), true)) {
             return $this->field_error('event_type', 'must be snapshot or update');
         }
@@ -853,7 +935,7 @@ class Digitalogic_Product_Sync_Receiver {
         $products = array();
         $seen_codes = array();
         foreach ($payload['products'] as $index => $product) {
-            $validated = $this->validate_product($product, $index);
+            $validated = $this->validate_product($product, $index, $payload['schema_version']);
             if (is_wp_error($validated)) {
                 return $validated;
             }
@@ -865,6 +947,19 @@ class Digitalogic_Product_Sync_Receiver {
             // the validated string as the value whenever the map is projected.
             $seen_codes[$code] = $code;
             $products[] = $validated;
+        }
+
+        $categories = $this->validate_categories($payload['categories'] ?? array());
+        if (is_wp_error($categories)) {
+            return $categories;
+        }
+        $excluded_codes = $this->validate_string_set($payload['excluded_codes'] ?? array(), 'excluded_codes');
+        if (is_wp_error($excluded_codes)) {
+            return $excluded_codes;
+        }
+        $catalog_check = $this->validate_catalog_projection($products, $categories, $excluded_codes);
+        if (is_wp_error($catalog_check)) {
+            return $catalog_check;
         }
 
         $deleted_codes = $this->validate_tombstones($payload['deleted_codes'] ?? array(), $payload['event_type']);
@@ -913,6 +1008,8 @@ class Digitalogic_Product_Sync_Receiver {
             'generated_at' => $payload['generated_at'],
             'generated_at_order' => $generated_at_order,
             'products' => $products,
+            'categories' => $categories,
+            'excluded_codes' => $excluded_codes,
             'deleted_codes' => $deleted_codes,
             'quarantined_codes' => $quarantined_codes,
             'warnings' => $warnings,
@@ -964,13 +1061,14 @@ class Digitalogic_Product_Sync_Receiver {
         return $source;
     }
 
-    private function validate_product($product, $index) {
+    private function validate_product($product, $index, $schema_version) {
         $path = 'products[' . (int) $index . ']';
+        $product_fields = $this->product_fields($schema_version);
         if (!is_array($product) || array_is_list($product)) {
             return $this->field_error($path, 'must be an object');
         }
-        $missing = array_values(array_diff(self::PRODUCT_FIELDS, array_keys($product)));
-        $unknown = array_values(array_diff(array_keys($product), self::PRODUCT_FIELDS));
+        $missing = array_values(array_diff($product_fields, array_keys($product)));
+        $unknown = array_values(array_diff(array_keys($product), $product_fields));
         if (!empty($missing) || !empty($unknown)) {
             return $this->error(
                 'digitalogic_product_sync_product_shape_invalid',
@@ -988,6 +1086,16 @@ class Digitalogic_Product_Sync_Receiver {
         }
         if (strlen($product['product_code']) > self::MAX_CODE_LENGTH) {
             return $this->field_error($path . '.product_code', 'is too long');
+        }
+        if (
+            $this->has_catalog_contract($schema_version)
+            && (
+                !is_string($product['category_code'])
+                || trim($product['category_code']) !== $product['category_code']
+                || strlen($product['category_code']) > self::MAX_CODE_LENGTH
+            )
+        ) {
+            return $this->field_error($path . '.category_code', 'must be a trimmed string within the code limit');
         }
         foreach (self::PRODUCT_STRING_FIELDS as $field) {
             if (!is_string($product[$field])) {
@@ -1041,7 +1149,7 @@ class Digitalogic_Product_Sync_Receiver {
 
         $hash_product = $product;
         $hash_product['warnings'] = $warnings;
-        $expected_hash = $this->record_hash($hash_product);
+        $expected_hash = $this->record_hash($hash_product, $product_fields);
         if (!hash_equals($expected_hash, $product['record_hash'])) {
             return $this->error(
                 'digitalogic_product_sync_record_hash_mismatch',
@@ -1057,7 +1165,7 @@ class Digitalogic_Product_Sync_Receiver {
         }
 
         $stored = array();
-        foreach (self::PRODUCT_FIELDS as $field) {
+        foreach ($product_fields as $field) {
             if ('warehouse_stock' === $field) {
                 $stocks = $product[$field];
                 ksort($stocks, SORT_STRING);
@@ -1075,6 +1183,169 @@ class Digitalogic_Product_Sync_Receiver {
 
         return $stored;
     }
+
+    // phpcs:disable -- Preserve the established receiver formatting while the legacy file remains baseline-managed.
+    private function validate_categories($values) {
+        if (!is_array($values) || !array_is_list($values)) {
+            return $this->field_error('categories', 'must be an array');
+        }
+        if (count($values) > self::MAX_CATEGORIES) {
+            return $this->error('digitalogic_product_sync_category_limit', 'The event contains too many categories.', 413);
+        }
+
+        $categories = array();
+        $seen = array();
+        foreach ($values as $index => $category) {
+            $path = 'categories[' . (int) $index . ']';
+            if (!is_array($category) || array_is_list($category)) {
+                return $this->field_error($path, 'must be an object');
+            }
+            $missing = array_values(array_diff(self::CATEGORY_FIELDS, array_keys($category)));
+            $unknown = array_values(array_diff(array_keys($category), self::CATEGORY_FIELDS));
+            if (!empty($missing) || !empty($unknown)) {
+                return $this->error(
+                    'digitalogic_product_sync_category_shape_invalid',
+                    'A category does not match the typed v1.1 shape.',
+                    422,
+                    array('path' => $path, 'missing' => $missing, 'unknown' => $unknown)
+                );
+            }
+            if (
+                !is_string($category['category_code'])
+                || '' === trim($category['category_code'])
+                || trim($category['category_code']) !== $category['category_code']
+                || strlen($category['category_code']) > self::MAX_CODE_LENGTH
+            ) {
+                return $this->field_error($path . '.category_code', 'must be a non-empty trimmed string within the code limit');
+            }
+            if (isset($seen[$category['category_code']])) {
+                return $this->error(
+                    'digitalogic_product_sync_duplicate_category_code',
+                    'Category codes must be unique inside an event.',
+                    422,
+                    array('category_code' => $category['category_code'])
+                );
+            }
+            if (!is_string($category['name']) || !is_string($category['parent_code'])) {
+                return $this->field_error($path, 'name and parent_code must be strings');
+            }
+            if (
+                trim($category['parent_code']) !== $category['parent_code']
+                || strlen($category['parent_code']) > self::MAX_CODE_LENGTH
+                || $category['parent_code'] === $category['category_code']
+            ) {
+                return $this->field_error($path . '.parent_code', 'must be a distinct trimmed category code or an empty string');
+            }
+            if (!$this->is_nonnegative_integer($category['depth']) || $this->number_compare_zero($category['depth']) <= 0) {
+                return $this->field_error($path . '.depth', 'must be a positive integer');
+            }
+            $warnings = $this->validate_string_set($category['warnings'], $path . '.warnings', false);
+            if (is_wp_error($warnings)) {
+                return $warnings;
+            }
+            if (!is_string($category['record_hash']) || !$this->is_hash($category['record_hash'])) {
+                return $this->field_error($path . '.record_hash', 'must be a sha256 identity');
+            }
+
+            $hash_category = $category;
+            $hash_category['warnings'] = $warnings;
+            $expected_hash = $this->category_record_hash($hash_category);
+            if (!hash_equals($expected_hash, $category['record_hash'])) {
+                return $this->error(
+                    'digitalogic_product_sync_category_hash_mismatch',
+                    'A category record_hash does not match its typed category.',
+                    422,
+                    array('path' => $path . '.record_hash', 'expected' => $expected_hash)
+                );
+            }
+
+            $stored = array(
+                'category_code' => $category['category_code'],
+                'name' => $category['name'],
+                'parent_code' => $category['parent_code'],
+                'depth' => $this->number_to_storage($category['depth']),
+                'warnings' => $warnings,
+                'record_hash' => $category['record_hash'],
+            );
+            $seen[$stored['category_code']] = $stored['category_code'];
+            $categories[] = $stored;
+        }
+
+        usort($categories, static function($left, $right) {
+            return strcmp($left['category_code'], $right['category_code']);
+        });
+        $lookup = array();
+        foreach ($categories as $category) {
+            $lookup[$category['category_code']] = $category;
+        }
+        foreach ($categories as $category) {
+            if ('' === $category['parent_code']) {
+                if (1 !== $category['depth']) {
+                    return $this->field_error(
+                        'categories.' . $category['category_code'] . '.depth',
+                        'must be 1 for a root category'
+                    );
+                }
+                continue;
+            }
+            if (!isset($lookup[$category['parent_code']])) {
+                return $this->field_error(
+                    'categories.' . $category['category_code'] . '.parent_code',
+                    'must reference a category in the same complete projection'
+                );
+            }
+            if ($category['depth'] !== $lookup[$category['parent_code']]['depth'] + 1) {
+                return $this->field_error(
+                    'categories.' . $category['category_code'] . '.depth',
+                    'must be exactly one greater than its parent depth'
+                );
+            }
+        }
+
+        return $categories;
+    }
+
+    private function validate_catalog_projection($products, $categories, $excluded_codes) {
+        $category_lookup = array();
+        foreach ($categories as $category) {
+            $category_lookup[$category['category_code']] = $category['category_code'];
+        }
+        $excluded_lookup = array();
+        foreach ($excluded_codes as $code) {
+            $excluded_lookup[$code] = $code;
+            if (isset($category_lookup[$code])) {
+                return $this->error(
+                    'digitalogic_product_sync_catalog_overlap',
+                    'A Code cannot be both a category and an excluded record.',
+                    422,
+                    array('code' => $code)
+                );
+            }
+        }
+        foreach ($products as $product) {
+            $code = $product['product_code'];
+            if (isset($category_lookup[$code]) || isset($excluded_lookup[$code])) {
+                return $this->error(
+                    'digitalogic_product_sync_catalog_overlap',
+                    'A Code cannot be both a sellable product and a structural catalog record.',
+                    422,
+                    array('code' => $code)
+                );
+            }
+            $category_code = (string) ($product['category_code'] ?? '');
+            if ('' !== $category_code && !isset($category_lookup[$category_code])) {
+                return $this->error(
+                    'digitalogic_product_sync_category_reference_invalid',
+                    'A product category_code must reference the complete category projection.',
+                    422,
+                    array('product_code' => $code, 'category_code' => $category_code)
+                );
+            }
+        }
+
+        return true;
+    }
+    // phpcs:enable
 
     private function validate_tombstones($values, $event_type) {
         if (!is_array($values) || !array_is_list($values)) {
@@ -1142,6 +1413,12 @@ class Digitalogic_Product_Sync_Receiver {
         foreach ($envelope['products'] as $product) {
             $incoming[$product['product_code']] = $product;
         }
+        $categories = array();
+        foreach ($envelope['categories'] as $category) {
+            $categories[$category['category_code']] = $category;
+        }
+        ksort($categories, SORT_STRING);
+        $excluded_codes = $envelope['excluded_codes'];
         $quarantined = array();
         foreach ($envelope['quarantined_codes'] as $quarantined_code) {
             $quarantined[$quarantined_code] = $quarantined_code;
@@ -1184,7 +1461,20 @@ class Digitalogic_Product_Sync_Receiver {
 
         ksort($next, SORT_STRING);
         ksort($revision_products, SORT_STRING);
-        $expected_revision = $this->source_revision($revision_products, $envelope['quarantined_codes']);
+        $catalog_check = $this->validate_catalog_projection(
+            array_values($next),
+            array_values($categories),
+            $excluded_codes
+        );
+        if (is_wp_error($catalog_check)) {
+            return $catalog_check;
+        }
+        $expected_revision = $this->source_revision(
+            $revision_products,
+            $categories,
+            $excluded_codes,
+            $envelope['quarantined_codes']
+        );
         if (!hash_equals($expected_revision, $envelope['source']['revision'])) {
             return $this->error(
                 'digitalogic_product_sync_source_revision_mismatch',
@@ -1196,6 +1486,8 @@ class Digitalogic_Product_Sync_Receiver {
 
         return array(
             'products' => $next,
+            'categories' => $categories,
+            'excluded_codes' => $excluded_codes,
             'changed_products' => array_values($incoming),
             'deleted_count' => 'snapshot' === $envelope['event_type']
                 ? count(array_diff(array_keys($previous), array_merge(array_keys($next), $envelope['quarantined_codes'])))
@@ -1504,7 +1796,7 @@ class Digitalogic_Product_Sync_Receiver {
     }
 
     /**
-     * Project v2 delivery state into v3 without discarding retry metadata.
+     * Project v2 delivery state into the current shape without discarding retry metadata.
      *
      * The migration is persisted by receive() or reconcile() while holding the
      * same advisory lock used for normal event delivery.
@@ -1544,7 +1836,41 @@ class Digitalogic_Product_Sync_Receiver {
         unset($source_state);
         $state['sources'] = $sources;
 
+        return $this->migrate_v3_state($state);
+    }
+
+    /**
+     * Add the v1.1 catalog projection fields to legacy v3 source state.
+     */
+    private function migrate_v3_state($state) {
+        $state['version'] = self::STATE_VERSION;
+        $sources = is_array($state['sources'] ?? null) ? $state['sources'] : array();
+        foreach ($sources as &$source_state) {
+            if (!is_array($source_state)) {
+                $source_state = array();
+            }
+            $this->normalize_catalog_source_state($source_state);
+        }
+        unset($source_state);
+        $state['sources'] = $sources;
+
         return $state;
+    }
+
+    private function normalize_catalog_source_state(&$source_state) {
+        $schema_version = (string) ($source_state['schema_version'] ?? '1.0');
+        $source_state['schema_version'] = $this->is_supported_major_version($schema_version)
+            ? $schema_version
+            : '1.0';
+        $source_state['categories'] = is_array($source_state['categories'] ?? null)
+            ? $source_state['categories']
+            : array();
+        ksort($source_state['categories'], SORT_STRING);
+        $excluded = is_array($source_state['excluded_codes'] ?? null)
+            ? array_values(array_unique(array_filter($source_state['excluded_codes'], 'is_string')))
+            : array();
+        sort($excluded, SORT_STRING);
+        $source_state['excluded_codes'] = $excluded;
     }
 
     private function deferred_summary($deferred) {
@@ -1608,9 +1934,12 @@ class Digitalogic_Product_Sync_Receiver {
                 'dataset' => (string) ($source['dataset'] ?? ''),
                 'revision' => (string) ($source['revision'] ?? ''),
             ),
+            'schema_version' => (string) ($source_state['schema_version'] ?? '1.0'),
             'generated_at' => (string) ($source_state['generated_at'] ?? ''),
             'last_event_id' => (string) ($source_state['last_event_id'] ?? ''),
             'stored_products' => count(is_array($source_state['products'] ?? null) ? $source_state['products'] : array()),
+            'stored_categories' => count(is_array($source_state['categories'] ?? null) ? $source_state['categories'] : array()),
+            'excluded_codes' => count(is_array($source_state['excluded_codes'] ?? null) ? $source_state['excluded_codes'] : array()),
             'applied_products' => count(is_array($source_state['applied_products'] ?? null) ? $source_state['applied_products'] : array()),
             'pending_products' => count(is_array($source_state['pending_products'] ?? null) ? $source_state['pending_products'] : array()),
             'deferred_products' => count(is_array($source_state['deferred_products'] ?? null) ? $source_state['deferred_products'] : array()),
@@ -1641,6 +1970,7 @@ class Digitalogic_Product_Sync_Receiver {
 
             return $this->error('digitalogic_product_sync_state_too_large', 'The combined receiver state is too large.', 413);
         }
+        $expected_digest = hash('sha256', $serialized);
         $row = $wpdb->get_row($wpdb->prepare(
             "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s FOR UPDATE",
             self::STATE_OPTION
@@ -1675,10 +2005,15 @@ class Digitalogic_Product_Sync_Receiver {
             "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
             self::STATE_OPTION
         ), ARRAY_A);
-        $read_back = is_array($read_row) && array_key_exists('option_value', $read_row)
-            ? maybe_unserialize($read_row['option_value'])
+        $read_serialized = is_array($read_row) && is_string($read_row['option_value'] ?? null)
+            ? $read_row['option_value']
             : null;
-        if (!is_array($read_back) || !hash_equals($this->state_digest($state), $this->state_digest($read_back))) {
+        $read_back = is_string($read_serialized) ? maybe_unserialize($read_serialized) : null;
+        if (
+            !is_array($read_back)
+            || !is_string($read_serialized)
+            || !hash_equals($expected_digest, hash('sha256', $read_serialized))
+        ) {
             $wpdb->query('ROLLBACK');
             $this->invalidate_state_cache();
 
@@ -1705,6 +2040,8 @@ class Digitalogic_Product_Sync_Receiver {
             'event_type' => $envelope['event_type'],
             'source' => $envelope['source'],
             'stored_products' => count($existing['products'] ?? array()),
+            'stored_categories' => count($existing['categories'] ?? array()),
+            'excluded_codes' => count($existing['excluded_codes'] ?? array()),
         ), $this->delivery_result_state($existing));
     }
     // phpcs:enable
@@ -1916,9 +2253,10 @@ class Digitalogic_Product_Sync_Receiver {
         return '' === $value ? '0' : $value;
     }
 
-    private function record_hash($product) {
+    // phpcs:disable -- Preserve the established receiver formatting while the legacy file remains baseline-managed.
+    private function record_hash($product, $product_fields) {
         $ordered = array();
-        foreach (self::PRODUCT_FIELDS as $field) {
+        foreach ($product_fields as $field) {
             if ('record_hash' !== $field) {
                 $ordered[$field] = $product[$field];
             }
@@ -1927,10 +2265,27 @@ class Digitalogic_Product_Sync_Receiver {
         return $this->hash_identity($this->encode_go_json($ordered, array('warehouse_stock')));
     }
 
-    private function source_revision($products, $quarantined_codes) {
+    private function category_record_hash($category) {
+        $ordered = array();
+        foreach (self::CATEGORY_FIELDS as $field) {
+            if ('record_hash' !== $field) {
+                $ordered[$field] = $category[$field];
+            }
+        }
+
+        return $this->hash_identity($this->encode_go_json($ordered));
+    }
+
+    private function source_revision($products, $categories, $excluded_codes, $quarantined_codes) {
         $material = array();
         foreach ($products as $product) {
             $material[] = $product['product_code'] . '=' . $product['record_hash'];
+        }
+        foreach ($categories as $category) {
+            $material[] = 'category:' . $category['category_code'] . '=' . $category['record_hash'];
+        }
+        foreach ($excluded_codes as $code) {
+            $material[] = 'excluded=' . $code;
         }
         sort($material, SORT_STRING);
         foreach ($quarantined_codes as $code) {
@@ -1946,6 +2301,11 @@ class Digitalogic_Product_Sync_Receiver {
             $product_hashes[] = $product['product_code'] . '=' . $product['record_hash'];
         }
         sort($product_hashes, SORT_STRING);
+        $category_hashes = array();
+        foreach ($envelope['categories'] as $category) {
+            $category_hashes[] = $category['category_code'] . '=' . $category['record_hash'];
+        }
+        sort($category_hashes, SORT_STRING);
         $identity = array(
             'schema' => $envelope['schema'],
             'schema_version' => $envelope['schema_version'],
@@ -1961,6 +2321,12 @@ class Digitalogic_Product_Sync_Receiver {
             'generated_at' => $envelope['generated_at'],
             'products' => $product_hashes,
         );
+        if (!empty($category_hashes)) {
+            $identity['categories'] = $category_hashes;
+        }
+        if (!empty($envelope['excluded_codes'])) {
+            $identity['excluded_codes'] = $envelope['excluded_codes'];
+        }
         if (!empty($envelope['deleted_codes'])) {
             $identity['deleted_codes'] = $envelope['deleted_codes'];
         }
@@ -1970,6 +2336,7 @@ class Digitalogic_Product_Sync_Receiver {
 
         return $this->hash_identity($this->encode_go_json($identity));
     }
+    // phpcs:enable
 
     /**
      * Encode the validated subset the same way Go encoding/json does.
@@ -2065,6 +2432,23 @@ class Digitalogic_Product_Sync_Receiver {
     private function is_supported_major_version($version) {
         return is_string($version) && 1 === preg_match('/^1(?:\.[0-9]+){1,2}$/', $version);
     }
+
+    // phpcs:disable -- Preserve the established receiver formatting while the legacy file remains baseline-managed.
+    private function has_catalog_contract($version) {
+        if (!$this->is_supported_major_version($version)) {
+            return false;
+        }
+        $parts = explode('.', $version);
+
+        return (int) ($parts[1] ?? 0) >= 1;
+    }
+
+    private function product_fields($schema_version) {
+        return $this->has_catalog_contract($schema_version)
+            ? self::PRODUCT_FIELDS_V1_1
+            : self::PRODUCT_FIELDS_V1_0;
+    }
+    // phpcs:enable
 
     private function is_hash($value) {
         return is_string($value) && 1 === preg_match('/^sha256:[a-f0-9]{64}$/', $value);

--- a/tests/ProductSyncReceiverTest.php
+++ b/tests/ProductSyncReceiverTest.php
@@ -4,10 +4,13 @@ use PHPUnit\Framework\TestCase;
 
 final class ProductSyncReceiverTest extends TestCase {
     private static $golden;
+    private static $goldenV11;
 
     public static function setUpBeforeClass(): void {
         $path = __DIR__ . '/fixtures/patris-product-sync-v1-golden.json';
         self::$golden = json_decode(file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        $path = __DIR__ . '/fixtures/patris-product-sync-v1.1-golden.json';
+        self::$goldenV11 = json_decode(file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
     }
 
     protected function setUp(): void {
@@ -61,6 +64,45 @@ final class ProductSyncReceiverTest extends TestCase {
         $this->assertSame('240', $source['products']['SYNTH-PRICED-001']['weight_grams']);
         $this->assertSame(2009410, $source['products']['SYNTH-PRICED-001']['final_price']);
     }
+
+    // phpcs:disable -- Match the established PHPUnit fixture style in this baseline-managed test file.
+    public function test_accepts_go_generated_v11_catalog_fixture_with_exact_hashes_and_durable_state(): void {
+        $path = __DIR__ . '/fixtures/patris-product-sync-v1.1-golden.json';
+        $this->assertSame(
+            '8a635fa63cadc2b5021879c32e3ee47ce9d4928806948c154cdeb1b744da61fd',
+            hash_file('sha256', $path)
+        );
+        $GLOBALS['digitalogic_test_posts'][699] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_sku' => '101001001'),
+        );
+
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive_json(file_get_contents($path));
+
+        $this->assertNotInstanceOf(WP_Error::class, $result, $result instanceof WP_Error ? $result->get_error_message() : '');
+        $this->assertSame('accepted', $result['status']);
+        $this->assertSame('sha256:4230ed302661c27a3b1bac71c60fac6a82c43bfb1ac0a7942137695b00afc2ac', $result['event_id']);
+        $this->assertSame(2, $result['received_products']);
+        $this->assertSame(2, $result['received_categories']);
+        $this->assertSame(2, $result['stored_categories']);
+        $this->assertSame(1, $result['excluded_codes']);
+        $this->assertSame(1, $result['woocommerce']['updated']);
+        $this->assertSame(1, $result['deferred_products']);
+
+        $source = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('synthetic-fixture', 'synthetic-kala.db');
+        $this->assertSame('1.1', $source['schema_version']);
+        $this->assertSame('101001', $source['products']['101001001']['category_code']);
+        $this->assertSame('101', $source['categories']['101001']['parent_code']);
+        $this->assertSame(array('999010'), $source['excluded_codes']);
+        $this->assertSame('101001', $GLOBALS['digitalogic_test_wc_products'][699]->meta['_digitalogic_patris_category_code']);
+
+        $status = Digitalogic_Product_Sync_Receiver::instance()->get_status();
+        $this->assertSame(2, $status['totals']['stored_categories']);
+        $this->assertSame(1, $status['totals']['excluded_codes']);
+        $this->assertSame('1.1', $status['sources'][0]['schema_version']);
+    }
+    // phpcs:enable
 
     public function test_snapshot_persists_before_event_and_uses_shared_exact_woo_writer(): void {
         $product = $this->product(1);
@@ -144,7 +186,7 @@ final class ProductSyncReceiverTest extends TestCase {
 
         $state = get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array());
         $source_key = array_key_first($state['sources']);
-        $this->assertSame(3, $state['version']);
+        $this->assertSame(4, $state['version']);
         $this->assertSame($code, $state['sources'][$source_key]['products'][$code]['product_code']);
         $this->assertIsString($state['sources'][$source_key]['products'][$code]['product_code']);
         $this->assertSame($code, $state['sources'][$source_key]['pending_products'][$code]['product_code']);
@@ -261,6 +303,84 @@ final class ProductSyncReceiverTest extends TestCase {
         $this->assertArrayHasKey($first['product_code'], $state['products']);
         $this->assertArrayHasKey($second['product_code'], $state['products']);
     }
+
+    // phpcs:disable -- Match the established PHPUnit fixture style in this baseline-managed test file.
+    public function test_v11_update_merges_products_and_replaces_complete_catalog_projection(): void {
+        $first = $this->v11Product(0);
+        $second = $this->v11Product(1);
+        $categories = array($this->v11Category(0), $this->v11Category(1));
+        $snapshot = $this->v11Envelope(
+            'snapshot',
+            array($first),
+            array($first),
+            '2026-07-16T10:00:00Z',
+            $categories,
+            array('999010')
+        );
+        $this->assertSame('accepted', Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot)['status']);
+
+        $categories[1]['name'] = 'Renamed synthetic modules';
+        $categories[1] = $this->rehashCategory($categories[1]);
+        $update = $this->v11Envelope(
+            'update',
+            array($second),
+            array($first, $second),
+            '2026-07-16T10:01:00Z',
+            $categories,
+            array('999991')
+        );
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive($update);
+        $state = Digitalogic_Product_Sync_Receiver::instance()->get_source_state('receiver-tests', 'kala.db');
+
+        $this->assertSame('accepted', $result['status']);
+        $this->assertCount(2, $state['products']);
+        $this->assertSame('Renamed synthetic modules', $state['categories']['101001']['name']);
+        $this->assertSame(array('999991'), $state['excluded_codes']);
+        $this->assertSame($update['source']['revision'], $state['source']['revision']);
+    }
+
+    public function test_v11_rejects_category_hash_tampering_and_dangling_product_category(): void {
+        $tampered = self::$goldenV11;
+        $tampered['categories'][1]['name'] .= ' changed';
+        $hash_error = Digitalogic_Product_Sync_Receiver::instance()->receive($tampered);
+        $this->assertSame('digitalogic_product_sync_category_hash_mismatch', $hash_error->get_error_code());
+
+        $product = $this->v11Product(0);
+        $product['category_code'] = '404';
+        $product = $this->rehashProduct($product);
+        $event = $this->v11Envelope(
+            'snapshot',
+            array($product),
+            array($product),
+            '2026-07-16T10:02:00Z',
+            array($this->v11Category(0), $this->v11Category(1)),
+            array()
+        );
+        $reference_error = Digitalogic_Product_Sync_Receiver::instance()->receive($event);
+        $this->assertSame('digitalogic_product_sync_category_reference_invalid', $reference_error->get_error_code());
+    }
+
+    public function test_contract_feature_level_change_requires_a_fresh_snapshot(): void {
+        $legacy = $this->product(0);
+        $snapshot = $this->envelope('snapshot', array($legacy), array($legacy), '2026-07-16T10:00:00Z');
+        $this->assertSame('accepted', Digitalogic_Product_Sync_Receiver::instance()->receive($snapshot)['status']);
+
+        $product = $this->v11Product(0);
+        $update = $this->v11Envelope(
+            'update',
+            array($product),
+            array($product),
+            '2026-07-16T10:01:00Z',
+            array($this->v11Category(0), $this->v11Category(1)),
+            array('999010')
+        );
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive($update);
+
+        $this->assertSame('digitalogic_product_sync_baseline_required', $result->get_error_code());
+        $this->assertSame('1.0', $result->get_error_data()['stored_schema_version']);
+        $this->assertSame('1.1', $result->get_error_data()['received_schema_version']);
+    }
+    // phpcs:enable
 
     public function test_deletion_only_update_removes_receiver_entry_but_never_woo_product(): void {
         $first = $this->product(0);
@@ -761,7 +881,7 @@ final class ProductSyncReceiverTest extends TestCase {
         update_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, $state, false);
 
         $projected = Digitalogic_Product_Sync_Receiver::instance()->get_state();
-        $this->assertSame(3, $projected['version']);
+        $this->assertSame(4, $projected['version']);
         $this->assertCount(1, $projected['sources'][$source_key]['pending_products']);
         $this->assertCount(0, $projected['sources'][$source_key]['deferred_products']);
         $this->assertSame(2, get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array())['version']);
@@ -772,8 +892,38 @@ final class ProductSyncReceiverTest extends TestCase {
         $this->assertSame(0, $replay['pending_products']);
         $this->assertSame(1, $replay['deferred_products']);
         $this->assertSame(1, $GLOBALS['wpdb']->identifier_query_count);
-        $this->assertSame(3, get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array())['version']);
+        $this->assertSame(4, get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array())['version']);
         $this->assertEmpty($GLOBALS['digitalogic_test_wc_product_saves']);
+    }
+
+    public function test_v3_state_projects_and_persists_empty_v10_catalog_fields(): void {
+        $product = $this->productWithCode(0, 'MIGRATE-V3');
+        $event = $this->envelope('snapshot', array($product), array($product), '2026-07-16T11:17:30Z');
+        $this->assertSame('accepted', Digitalogic_Product_Sync_Receiver::instance()->receive($event)['status']);
+
+        $state = get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array());
+        $source_key = array_key_first($state['sources']);
+        $state['version'] = 3;
+        unset(
+            $state['sources'][$source_key]['schema_version'],
+            $state['sources'][$source_key]['categories'],
+            $state['sources'][$source_key]['excluded_codes']
+        );
+        update_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, $state, false);
+
+        $projected = Digitalogic_Product_Sync_Receiver::instance()->get_state();
+        $this->assertSame(4, $projected['version']);
+        $this->assertSame('1.0', $projected['sources'][$source_key]['schema_version']);
+        $this->assertSame(array(), $projected['sources'][$source_key]['categories']);
+        $this->assertSame(array(), $projected['sources'][$source_key]['excluded_codes']);
+        $this->assertSame(3, get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array())['version']);
+
+        $this->assertSame('replayed', Digitalogic_Product_Sync_Receiver::instance()->receive($event)['status']);
+        $persisted = get_option(Digitalogic_Product_Sync_Receiver::STATE_OPTION, array());
+        $this->assertSame(4, $persisted['version']);
+        $this->assertSame('1.0', $persisted['sources'][$source_key]['schema_version']);
+        $this->assertSame(array(), $persisted['sources'][$source_key]['categories']);
+        $this->assertSame(array(), $persisted['sources'][$source_key]['excluded_codes']);
     }
 
     public function test_deferred_response_details_and_cli_status_are_bounded_and_nonsecret(): void {
@@ -886,14 +1036,20 @@ final class ProductSyncReceiverTest extends TestCase {
     }
 
     // phpcs:disable -- Match the established PHPUnit fixture style in this baseline-managed test file.
+    private function v11Product($index) {
+        return self::$goldenV11['products'][$index];
+    }
+
+    private function v11Category($index) {
+        return self::$goldenV11['categories'][$index];
+    }
+
     private function productWithCode($index, $code) {
         $product = $this->product($index);
         $product['product_code'] = $code;
 
         return $this->rehashProduct($product);
     }
-    // phpcs:enable
-
     private function rehashProduct($product) {
         unset($product['record_hash']);
         ksort($product['warehouse_stock'], SORT_STRING);
@@ -903,6 +1059,16 @@ final class ProductSyncReceiverTest extends TestCase {
         );
 
         return $product;
+    }
+
+    private function rehashCategory($category) {
+        unset($category['record_hash']);
+        $category['record_hash'] = 'sha256:' . hash(
+            'sha256',
+            json_encode($category, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+        );
+
+        return $category;
     }
 
     private function envelope($type, $event_products, $full_products, $generated_at, $deleted = array(), $quarantined = array()) {
@@ -943,13 +1109,63 @@ final class ProductSyncReceiverTest extends TestCase {
         return $envelope;
     }
 
-    private function sourceRevision($products, $quarantined) {
+    private function v11Envelope($type, $event_products, $full_products, $generated_at, $categories, $excluded, $deleted = array(), $quarantined = array()) {
+        usort($event_products, static function($left, $right) {
+            return strcmp($left['product_code'], $right['product_code']);
+        });
+        usort($categories, static function($left, $right) {
+            return strcmp($left['category_code'], $right['category_code']);
+        });
+        usort($deleted, static function($left, $right) {
+            return strcmp($left['product_code'], $right['product_code']);
+        });
+        sort($excluded, SORT_STRING);
+        sort($quarantined, SORT_STRING);
+        $source = array(
+            'id' => 'receiver-tests',
+            'dataset' => 'kala.db',
+            'revision' => $this->sourceRevision($full_products, $quarantined, $categories, $excluded),
+        );
+        $envelope = array(
+            'schema' => 'digitalogic.product-sync',
+            'schema_version' => '1.1',
+            'event' => 'digitalogic.product-sync',
+            'event_type' => $type,
+            'event_id' => '',
+            'local_currency' => 'IRT',
+            'formula_id' => 'landed_price_v1',
+            'formula_revision' => '1.0.0',
+            'formula_version' => 'landed_price_v1',
+            'source' => $source,
+            'generated_at' => $generated_at,
+            'products' => array_values($event_products),
+            'categories' => array_values($categories),
+            'excluded_codes' => array_values($excluded),
+        );
+        if (!empty($deleted)) {
+            $envelope['deleted_codes'] = $deleted;
+        }
+        if (!empty($quarantined)) {
+            $envelope['quarantined_codes'] = $quarantined;
+        }
+        $envelope['event_id'] = $this->eventId($envelope);
+
+        return $envelope;
+    }
+
+    private function sourceRevision($products, $quarantined, $categories = array(), $excluded = array()) {
         $lines = array();
         foreach ($products as $product) {
             if (in_array($product['product_code'], $quarantined, true)) {
                 continue;
             }
             $lines[] = $product['product_code'] . '=' . $product['record_hash'];
+        }
+        foreach ($categories as $category) {
+            $lines[] = 'category:' . $category['category_code'] . '=' . $category['record_hash'];
+        }
+        foreach ($excluded as $code) {
+            $lines[] = 'excluded=' . $code;
         }
         sort($lines, SORT_STRING);
         sort($quarantined, SORT_STRING);
@@ -966,6 +1182,11 @@ final class ProductSyncReceiverTest extends TestCase {
             $hashes[] = $product['product_code'] . '=' . $product['record_hash'];
         }
         sort($hashes, SORT_STRING);
+        $category_hashes = array();
+        foreach ($envelope['categories'] ?? array() as $category) {
+            $category_hashes[] = $category['category_code'] . '=' . $category['record_hash'];
+        }
+        sort($category_hashes, SORT_STRING);
         $identity = array(
             'schema' => $envelope['schema'],
             'schema_version' => $envelope['schema_version'],
@@ -981,6 +1202,12 @@ final class ProductSyncReceiverTest extends TestCase {
             'generated_at' => $envelope['generated_at'],
             'products' => $hashes,
         );
+        if (!empty($category_hashes)) {
+            $identity['categories'] = $category_hashes;
+        }
+        if (!empty($envelope['excluded_codes'])) {
+            $identity['excluded_codes'] = $envelope['excluded_codes'];
+        }
         if (!empty($envelope['deleted_codes'])) {
             $identity['deleted_codes'] = $envelope['deleted_codes'];
         }
@@ -990,4 +1217,5 @@ final class ProductSyncReceiverTest extends TestCase {
 
         return 'sha256:' . hash('sha256', json_encode($identity, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
     }
+    // phpcs:enable
 }

--- a/tests/fixtures/patris-product-sync-v1.1-golden.json
+++ b/tests/fixtures/patris-product-sync-v1.1-golden.json
@@ -1,0 +1,109 @@
+{
+  "schema": "digitalogic.product-sync",
+  "schema_version": "1.1",
+  "event": "digitalogic.product-sync",
+  "event_type": "snapshot",
+  "event_id": "sha256:4230ed302661c27a3b1bac71c60fac6a82c43bfb1ac0a7942137695b00afc2ac",
+  "local_currency": "IRT",
+  "formula_id": "landed_price_v1",
+  "formula_revision": "1.0.0",
+  "formula_version": "landed_price_v1",
+  "source": {
+    "id": "synthetic-fixture",
+    "dataset": "synthetic-kala.db",
+    "revision": "sha256:48748e38b0af76d87bbdf97328efb1f98c43a0e984544a551972238e1e7180bf"
+  },
+  "generated_at": "2026-01-02T03:04:05Z",
+  "products": [
+    {
+      "product_code": "101001001",
+      "category_code": "101001",
+      "name": "Synthetic priced product",
+      "serial": "SYNTH-PN-001",
+      "unit": "unit",
+      "sale_price_source": 100000,
+      "purchase_price_source": 90000,
+      "warehouse_stock": {
+        "1": 3,
+        "2": 2
+      },
+      "total_stock": 5,
+      "minimum_stock": 1,
+      "foreign_currency": "CNY",
+      "foreign_price": 24.5,
+      "weight_grams": 240,
+      "location": "TEST-A",
+      "import_freight_method_id": "synthetic-air",
+      "freight_cny_per_kg": 120,
+      "markup_percent": 30,
+      "irt_per_cny": 29000,
+      "pricing_catalog_revision": "synthetic-catalog-v1",
+      "pricing_catalog_status": "static",
+      "currency_effective_date": "2026-01-01",
+      "final_price": 2009410,
+      "formula_version": "landed_price_v1",
+      "source_updated_at": "2026-01-01T00:00:00Z",
+      "warnings": [],
+      "record_hash": "sha256:25e2672d5b77e1ea5f9749c31757f8fdc933b96d634410eb55bec1f0e6e12fb5"
+    },
+    {
+      "product_code": "101001002",
+      "category_code": "101001",
+      "name": "Synthetic incomplete product",
+      "serial": "SYNTH-PN-002",
+      "unit": "unit",
+      "sale_price_source": null,
+      "purchase_price_source": null,
+      "warehouse_stock": {
+        "1": 0,
+        "2": 0
+      },
+      "total_stock": 0,
+      "minimum_stock": null,
+      "foreign_currency": "CNY",
+      "foreign_price": null,
+      "weight_grams": null,
+      "location": "weight unavailable",
+      "import_freight_method_id": "",
+      "freight_cny_per_kg": null,
+      "markup_percent": null,
+      "irt_per_cny": 29000,
+      "pricing_catalog_revision": "synthetic-catalog-v1",
+      "pricing_catalog_status": "static",
+      "currency_effective_date": "2026-01-01",
+      "final_price": null,
+      "formula_version": "landed_price_v1",
+      "source_updated_at": "",
+      "warnings": [
+        "final_price_unavailable",
+        "foreign_price_missing",
+        "freight_rate_missing",
+        "import_freight_method_missing",
+        "markup_percent_missing",
+        "weight_missing"
+      ],
+      "record_hash": "sha256:e45fd709eba4e43aab7f3eea5a3994950e0d41c271284f0d198e85ef10bd5125"
+    }
+  ],
+  "categories": [
+    {
+      "category_code": "101",
+      "name": "Synthetic components",
+      "parent_code": "",
+      "depth": 1,
+      "warnings": [],
+      "record_hash": "sha256:31241792f095579c78ebbfaa239d4302d6b6bc11555afaa009357a8ecb01ac58"
+    },
+    {
+      "category_code": "101001",
+      "name": "Synthetic modules",
+      "parent_code": "101",
+      "depth": 2,
+      "warnings": [],
+      "record_hash": "sha256:027f01ca991309c98a4dc275388209e7d6d0bf5926663b81edd71ead7d226a23"
+    }
+  ],
+  "excluded_codes": [
+    "999010"
+  ]
+}


### PR DESCRIPTION
Closes #91.

## Historical outcome (superseded)

This merged change temporarily bridged the earlier product-only payload and the later catalog-bearing payload. It verified product/category/source/event identities, persisted categories and exclusions, and proved the receiver against a production-sized snapshot.

That transition bridge is superseded by the owner-approved living standard in #85 and PR #93. The current implementation accepts only the living shape and removes feature-level selectors, alternate payload parsers, and noncurrent route/header shapes. Missing source/reference data omits its key; JSON `null` is reserved for an explicitly supplied upstream null. Producer and consumers are changed and deployed together.

## Historical verification retained for scale evidence

- Product-sync receiver: 34 tests / 304 assertions.
- Affected integration set: 50 tests / 409 assertions.
- Production-sized envelope accepted with exact identities: 3,495 products, 1,779 categories, 7 exclusions, and 231 quarantined Codes.
- Serialized state remained within the receiver cap.

Do not copy this merged commit as the current contract implementation; use PR #93 and the living-standard documentation.
