### PR TITLE
Fix Jalali currency effective-date formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.4] - 2026-07-20
+
+### Added
+- Added versioned `[dollar_rate]` and `[yuan_rate]` storefront cards that share the same currency effective-date service used by the WordPress admin and external panel.
+- Added strict regression coverage for legacy YYMMDD storage, ISO dates and date-times, invalid/empty values, Persian and English locales, and the production `260629` case.
+
+### Fixed
+- Prevented legacy YYMMDD currency dates from being interpreted as Unix timestamps and displaying an epoch-era Jalali year such as `۱۳۴۸`.
+- Read the raw `options_update_date` value before ACF/wp-parsidate formatting, return a blank value for invalid dates instead of silently substituting today, and provide deterministic built-in Jalali conversion with Persian digits for `fa*` locales.
+
 ## [1.3.3] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ half-up rounded integers with locale-aware thousands separators. Persian
 (`fa*`) administrator locales also use Persian digits. This formatting is
 presentation-only: stored rates and API values keep their original precision.
 
+Currency effective dates are read from the raw ACF `options_update_date`
+option (falling back to `update_date`) and accept legacy `YYMMDD` or strict ISO
+date values. The admin, external panel, `[dollar_rate]`, and `[yuan_rate]`
+storefront cards all use one formatter: English locales display Gregorian
+dates, while Persian (`fa*`) locales display Jalali dates with Persian digits.
+Invalid or empty stored values display as blank instead of today or an
+epoch-era date. See [Currency effective-date formatting](docs/CURRENCY-DATE-FORMATTING.md).
+
 WooCommerce remains the source of truth for the local currency. `IRT` values
 are Tomans. `IRR` values remain Rials and must be divided by 10 before being
 represented as Tomans; the plugin therefore does not provide a symbol-only

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.3.3
+ * Version: 1.3.4
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.3.3' );
+define( 'DIGITALOGIC_VERSION', '1.3.4' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('DIGITALOGIC_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -108,7 +108,9 @@ final class Digitalogic {
     private function includes() {
         // Core includes
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-number-formatter.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-currency-date-formatter.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-options.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-currency-shortcodes.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-woocommerce-currency-status.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-logger.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-query.php';
@@ -180,6 +182,7 @@ final class Digitalogic {
 
         // Initialize components
         Digitalogic_Options::instance();
+        Digitalogic_Currency_Shortcodes::instance();
         Digitalogic_WooCommerce_Currency_Status::instance();
         Digitalogic_Logger::instance();
         Digitalogic_Product_Manager::instance();

--- a/docs/CURRENCY-DATE-FORMATTING.md
+++ b/docs/CURRENCY-DATE-FORMATTING.md
@@ -1,0 +1,57 @@
+# Currency effective-date formatting
+
+Digitalogic stores the exchange-rate effective date in WordPress options. The
+canonical source is the raw ACF option `options_update_date`; `update_date` is
+used only when the prefixed option does not exist. Reading the option directly
+is intentional: asking ACF for the formatted field can send a six-digit value
+through wp-parsidate as though it were a Unix timestamp.
+
+## Accepted storage formats
+
+- Legacy `YYMMDD`, interpreted as a Gregorian date in the 2000s. For example,
+  `260629` means `2026-06-29`.
+- Strict ISO dates such as `2026-06-29`.
+- Strict ISO date-times such as `2026-06-29T12:30:00+03:30`. The encoded
+  calendar day is the effective date; an offset does not shift it to another
+  day before display.
+- Persian and Arabic-Indic input digits are normalized before validation.
+
+Calendar-invalid dates, invalid ISO times or offsets, non-scalar values, and
+empty values format as an empty string. They never fall back to the current
+date or the Unix epoch.
+
+## Locale behavior
+
+`Digitalogic_Currency_Date_Formatter` is the sole parsing and calendar service.
+English and other non-`fa` locales display Gregorian values. `fa_IR`, `fa_AF`,
+and other `fa*` locales display the Jalali equivalent with Persian digits. The
+numeric `Y`, `y`, `m`, `n`, `d`, and `j` tokens and Persian `F`/`M` month and
+`l`/`D` weekday names are supported; other PHP date-format characters keep
+their standard behavior.
+
+`Digitalogic_Options::get_update_date_formatted()` delegates to this service.
+The WordPress admin, status view, external panel, and storefront currency cards
+all call that options method, keeping their date output aligned.
+
+## Storefront shortcodes
+
+The plugin owns the existing `[dollar_rate]` and `[yuan_rate]` shortcodes. Their
+HTML class names remain `currency-box`, `flag-circle`, `currency-info`, `price`,
+and `date`, preserving the live child-theme styling. The implementation is
+registered on `init` at priority 20 so it supersedes the temporary theme-level
+mitigation during a versioned deployment.
+
+Two filters allow site-specific presentation without forking the formatter:
+
+- `digitalogic_currency_card_date_format` changes the PHP display format.
+- `digitalogic_currency_card_flag_url` changes the flag URL for a currency.
+
+The default flags use the existing site-relative uploads paths
+`/wp-content/uploads/2025/10/us.svg` and `cn.svg`, so non-production hostnames do
+not make requests back to the production domain.
+
+After deploying this release and verifying both shortcodes, remove the old
+`digitalogic_format_currency_update_date`, `show_dollar_price`, and
+`show_yuan_price` definitions from the child theme to eliminate duplicate
+unversioned code. The plugin callback already remains authoritative until that
+cleanup is performed.

--- a/includes/class-digitalogic-currency-date-formatter.php
+++ b/includes/class-digitalogic-currency-date-formatter.php
@@ -1,0 +1,445 @@
+<?php
+/**
+ * Currency effective-date parsing and display.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Provides the canonical parser and locale-aware formatter for currency dates.
+ */
+final class Digitalogic_Currency_Date_Formatter {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Digitalogic_Currency_Date_Formatter|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return Digitalogic_Currency_Date_Formatter
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Read the unformatted effective date, preferring ACF's option storage.
+	 *
+	 * Reading the raw option avoids ACF/wp-parsidate turning a legacy YYMMDD
+	 * value into a Unix timestamp before this formatter can validate it.
+	 *
+	 * @return string
+	 */
+	public function get_raw_update_date() {
+		$value = get_option( 'options_update_date', false );
+
+		if ( false === $value ) {
+			$value = get_option( 'update_date', '' );
+		}
+
+		return $this->scalar_string( $value );
+	}
+
+	/**
+	 * Parse a stored currency date into a site-timezone date at noon.
+	 *
+	 * Accepted values are legacy YYMMDD dates (interpreted as 20YY) and
+	 * strict ISO 8601 dates or date-times. Invalid values never fall back to
+	 * the current date or the Unix epoch.
+	 *
+	 * @param mixed $value Raw stored value.
+	 * @return DateTimeImmutable|null
+	 */
+	public function parse( $value ) {
+		$value = $this->normalize_digits( trim( $this->scalar_string( $value ) ) );
+
+		if ( '' === $value ) {
+			return null;
+		}
+
+		if ( preg_match( '/\A([0-9]{2})([0-9]{2})([0-9]{2})\z/D', $value, $matches ) ) {
+			return $this->date_from_parts(
+				2000 + (int) $matches[1],
+				(int) $matches[2],
+				(int) $matches[3]
+			);
+		}
+
+		$iso_pattern = '/\A([0-9]{4})-([0-9]{2})-([0-9]{2})(?:(?:T| )(?:[01][0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9](?:\.[0-9]{1,6})?)?(?:Z|[+-](?:(?:0[0-9]|1[0-3]):?[0-5][0-9]|14:?00))?)?\z/D';
+
+		if ( preg_match( $iso_pattern, $value, $matches ) ) {
+			return $this->date_from_parts(
+				(int) $matches[1],
+				(int) $matches[2],
+				(int) $matches[3]
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Format a stored currency date for a locale.
+	 *
+	 * @param mixed       $value  Raw stored value.
+	 * @param string      $format PHP date format.
+	 * @param string|null $locale Optional locale override.
+	 * @return string
+	 */
+	public function format( $value, $format = 'Y/m/d', $locale = null ) {
+		$date = $this->parse( $value );
+
+		if ( null === $date ) {
+			return '';
+		}
+
+		return $this->format_date_object( $date, $format, $locale );
+	}
+
+	/**
+	 * Format a date object or Unix timestamp through the same locale renderer.
+	 *
+	 * Six-digit strings and ISO inputs are first treated as currency effective
+	 * dates so the historical YYMMDD value can never become an epoch-era date.
+	 *
+	 * @param mixed       $value  DateTimeInterface, Unix timestamp, or date string.
+	 * @param string      $format PHP date format.
+	 * @param string|null $locale Optional locale override.
+	 * @return string
+	 */
+	public function format_timestamp( $value, $format = 'Y/m/d', $locale = null ) {
+		$effective_date = $this->parse( $value );
+
+		if ( null !== $effective_date ) {
+			return $this->format_date_object( $effective_date, $format, $locale );
+		}
+
+		$normalized_value = $this->normalize_digits( trim( $this->scalar_string( $value ) ) );
+
+		// A malformed value that looks like one of the supported storage formats
+		// is invalid, not a Unix timestamp or a lenient DateTime input.
+		if ( preg_match( '/\A(?:[0-9]{6}|[0-9]{4}-[0-9]{2}-[0-9]{2})/', $normalized_value ) ) {
+			return '';
+		}
+
+		if ( $value instanceof DateTimeInterface ) {
+			$date = DateTimeImmutable::createFromInterface( $value )->setTimezone( $this->site_timezone() );
+		} elseif ( is_int( $value ) || is_float( $value ) || ( is_string( $value ) && is_numeric( $value ) ) ) {
+			if ( ! is_finite( (float) $value ) ) {
+				return '';
+			}
+
+			$date = ( new DateTimeImmutable( '@' . (string) (int) $value ) )->setTimezone( $this->site_timezone() );
+		} else {
+			$value = trim( $this->scalar_string( $value ) );
+
+			if ( '' === $value ) {
+				return '';
+			}
+
+			try {
+				$date = new DateTimeImmutable( $value, $this->site_timezone() );
+			} catch ( Exception $exception ) {
+				return '';
+			}
+		}
+
+		return $this->format_date_object( $date, $format, $locale );
+	}
+
+	/**
+	 * Format an immutable date for the requested locale.
+	 *
+	 * @param DateTimeImmutable $date   Date to render.
+	 * @param string            $format PHP date format.
+	 * @param string|null       $locale Optional locale override.
+	 * @return string
+	 */
+	private function format_date_object( DateTimeImmutable $date, $format, $locale ) {
+		$format = is_string( $format ) && '' !== $format ? $format : 'Y/m/d';
+		$locale = $this->resolve_locale( $locale );
+
+		if ( 0 === stripos( str_replace( '-', '_', $locale ), 'fa' ) ) {
+			return $this->format_jalali( $date, $format );
+		}
+
+		return $date->format( $format );
+	}
+
+	/**
+	 * Resolve the active WordPress locale.
+	 *
+	 * @param string|null $locale Optional locale override.
+	 * @return string
+	 */
+	private function resolve_locale( $locale ) {
+		if ( is_string( $locale ) && '' !== trim( $locale ) ) {
+			return trim( $locale );
+		}
+
+		if ( function_exists( 'determine_locale' ) ) {
+			$locale = determine_locale();
+		} elseif ( function_exists( 'get_locale' ) ) {
+			$locale = get_locale();
+		}
+
+		return is_string( $locale ) && '' !== $locale ? $locale : 'en_US';
+	}
+
+	/**
+	 * Create a validated date at noon in the WordPress timezone.
+	 *
+	 * @param int $year  Gregorian year.
+	 * @param int $month Gregorian month.
+	 * @param int $day   Gregorian day.
+	 * @return DateTimeImmutable|null
+	 */
+	private function date_from_parts( $year, $month, $day ) {
+		if ( ! checkdate( $month, $day, $year ) ) {
+			return null;
+		}
+
+		$date = DateTimeImmutable::createFromFormat(
+			'!Y-m-d H:i:s',
+			sprintf( '%04d-%02d-%02d 12:00:00', $year, $month, $day ),
+			$this->site_timezone()
+		);
+
+		return false === $date ? null : $date;
+	}
+
+	/**
+	 * Get the configured WordPress timezone, with a safe UTC fallback.
+	 *
+	 * @return DateTimeZone
+	 */
+	private function site_timezone() {
+		if ( function_exists( 'wp_timezone' ) ) {
+			$timezone = wp_timezone();
+
+			if ( $timezone instanceof DateTimeZone ) {
+				return $timezone;
+			}
+		}
+
+		return new DateTimeZone( 'UTC' );
+	}
+
+	/**
+	 * Format a Gregorian date in the Jalali calendar with Persian digits.
+	 *
+	 * @param DateTimeImmutable $date   Gregorian date.
+	 * @param string            $format PHP-compatible date format.
+	 * @return string
+	 */
+	private function format_jalali( DateTimeImmutable $date, $format ) {
+		list( $year, $month, $day ) = $this->gregorian_to_jalali(
+			(int) $date->format( 'Y' ),
+			(int) $date->format( 'n' ),
+			(int) $date->format( 'j' )
+		);
+
+		$months   = array(
+			'فروردین',
+			'اردیبهشت',
+			'خرداد',
+			'تیر',
+			'مرداد',
+			'شهریور',
+			'مهر',
+			'آبان',
+			'آذر',
+			'دی',
+			'بهمن',
+			'اسفند',
+		);
+		$weekdays = array(
+			'یکشنبه',
+			'دوشنبه',
+			'سه‌شنبه',
+			'چهارشنبه',
+			'پنجشنبه',
+			'جمعه',
+			'شنبه',
+		);
+		$tokens   = array(
+			'Y' => sprintf( '%04d', $year ),
+			'y' => sprintf( '%02d', $year % 100 ),
+			'm' => sprintf( '%02d', $month ),
+			'n' => (string) $month,
+			'd' => sprintf( '%02d', $day ),
+			'j' => (string) $day,
+			'F' => $months[ $month - 1 ],
+			'M' => $months[ $month - 1 ],
+			'l' => $weekdays[ (int) $date->format( 'w' ) ],
+			'D' => $weekdays[ (int) $date->format( 'w' ) ],
+		);
+
+		$output  = '';
+		$escaped = false;
+		$length  = strlen( $format );
+
+		for ( $index = 0; $index < $length; $index++ ) {
+			$character = $format[ $index ];
+
+			if ( $escaped ) {
+				$output .= $character;
+				$escaped = false;
+				continue;
+			}
+
+			if ( '\\' === $character ) {
+				$escaped = true;
+				continue;
+			}
+
+			$output .= isset( $tokens[ $character ] )
+				? $tokens[ $character ]
+				: $date->format( $character );
+		}
+
+		if ( $escaped ) {
+			$output .= '\\';
+		}
+
+		return $this->to_persian_digits( $output );
+	}
+
+	/**
+	 * Convert Gregorian year/month/day values to their Jalali equivalents.
+	 *
+	 * @param int $gregorian_year  Gregorian year.
+	 * @param int $gregorian_month Gregorian month.
+	 * @param int $gregorian_day   Gregorian day.
+	 * @return int[] Jalali year, month, and day.
+	 */
+	private function gregorian_to_jalali( $gregorian_year, $gregorian_month, $gregorian_day ) {
+		$gregorian_month_days = array( 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 );
+
+		if ( $gregorian_year > 1600 ) {
+			$jalali_year     = 979;
+			$gregorian_year -= 1600;
+		} else {
+			$jalali_year     = 0;
+			$gregorian_year -= 621;
+		}
+
+		$adjusted_year = $gregorian_month > 2 ? $gregorian_year + 1 : $gregorian_year;
+		$days          = ( 365 * $gregorian_year )
+			+ intdiv( $adjusted_year + 3, 4 )
+			- intdiv( $adjusted_year + 99, 100 )
+			+ intdiv( $adjusted_year + 399, 400 )
+			- 80
+			+ $gregorian_day
+			+ $gregorian_month_days[ $gregorian_month - 1 ];
+
+		$jalali_year += 33 * intdiv( $days, 12053 );
+		$days         = $days % 12053;
+		$jalali_year += 4 * intdiv( $days, 1461 );
+		$days         = $days % 1461;
+
+		if ( $days > 365 ) {
+			$jalali_year += intdiv( $days - 1, 365 );
+			--$days;
+			$days = $days % 365;
+		}
+
+		if ( $days < 186 ) {
+			$jalali_month = 1 + intdiv( $days, 31 );
+			$jalali_day   = 1 + ( $days % 31 );
+		} else {
+			$jalali_month = 7 + intdiv( $days - 186, 30 );
+			$jalali_day   = 1 + ( ( $days - 186 ) % 30 );
+		}
+
+		return array( $jalali_year, $jalali_month, $jalali_day );
+	}
+
+	/**
+	 * Normalize Persian and Arabic-Indic numerals to ASCII.
+	 *
+	 * @param string $value Input value.
+	 * @return string
+	 */
+	private function normalize_digits( $value ) {
+		return strtr(
+			$value,
+			array(
+				'۰' => '0',
+				'۱' => '1',
+				'۲' => '2',
+				'۳' => '3',
+				'۴' => '4',
+				'۵' => '5',
+				'۶' => '6',
+				'۷' => '7',
+				'۸' => '8',
+				'۹' => '9',
+				'٠' => '0',
+				'١' => '1',
+				'٢' => '2',
+				'٣' => '3',
+				'٤' => '4',
+				'٥' => '5',
+				'٦' => '6',
+				'٧' => '7',
+				'٨' => '8',
+				'٩' => '9',
+			)
+		);
+	}
+
+	/**
+	 * Convert ASCII digits in display output to Persian digits.
+	 *
+	 * @param string $value Display value.
+	 * @return string
+	 */
+	private function to_persian_digits( $value ) {
+		return strtr(
+			$value,
+			array(
+				'0' => '۰',
+				'1' => '۱',
+				'2' => '۲',
+				'3' => '۳',
+				'4' => '۴',
+				'5' => '۵',
+				'6' => '۶',
+				'7' => '۷',
+				'8' => '۸',
+				'9' => '۹',
+			)
+		);
+	}
+
+	/**
+	 * Safely normalize scalar option values to strings.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string
+	 */
+	private function scalar_string( $value ) {
+		if ( is_string( $value ) || is_int( $value ) || is_float( $value ) ) {
+			return (string) $value;
+		}
+
+		if ( is_object( $value ) && method_exists( $value, '__toString' ) ) {
+			return (string) $value;
+		}
+
+		return '';
+	}
+}

--- a/includes/class-digitalogic-currency-shortcodes.php
+++ b/includes/class-digitalogic-currency-shortcodes.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Storefront currency shortcodes.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Owns the versioned USD/CNY storefront cards.
+ */
+final class Digitalogic_Currency_Shortcodes {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Digitalogic_Currency_Shortcodes|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Currency options service.
+	 *
+	 * @var Digitalogic_Options
+	 */
+	private $options;
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return Digitalogic_Currency_Shortcodes
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self( Digitalogic_Options::instance() );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Construct the shortcode registrar.
+	 *
+	 * @param Digitalogic_Options $options Currency options service.
+	 */
+	private function __construct( Digitalogic_Options $options ) {
+		$this->options = $options;
+
+		// Run after child-theme file-level registrations so the versioned plugin
+		// implementation remains authoritative during the migration from theme code.
+		add_action( 'init', array( $this, 'register' ), 20 );
+	}
+
+	/**
+	 * Register the public currency-card shortcodes.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_shortcode( 'dollar_rate', array( $this, 'render_dollar_rate' ) );
+		add_shortcode( 'yuan_rate', array( $this, 'render_yuan_rate' ) );
+	}
+
+	/**
+	 * Render the USD exchange-rate card.
+	 *
+	 * @return string
+	 */
+	public function render_dollar_rate() {
+		return $this->render_card( 'USD', $this->options->get_dollar_price(), '$', 'us.svg' );
+	}
+
+	/**
+	 * Render the CNY exchange-rate card.
+	 *
+	 * @return string
+	 */
+	public function render_yuan_rate() {
+		return $this->render_card( 'CNY', $this->options->get_yuan_price(), '¥', 'cn.svg' );
+	}
+
+	/**
+	 * Render one currency card with the canonical effective-date formatter.
+	 *
+	 * @param string $currency Currency code.
+	 * @param float  $rate     Exchange rate.
+	 * @param string $symbol   Display symbol.
+	 * @param string $flag     Flag filename in the site's uploads directory.
+	 * @return string
+	 */
+	private function render_card( $currency, $rate, $symbol, $flag ) {
+		$date_format = apply_filters( 'digitalogic_currency_card_date_format', 'Y/m/d', $currency );
+		$date        = $this->options->get_update_date_formatted( $date_format );
+		$flag_url    = content_url( '/uploads/2025/10/' . $flag );
+		$flag_url    = apply_filters( 'digitalogic_currency_card_flag_url', $flag_url, $currency );
+
+		return sprintf(
+			'<div class="currency-box"><div class="flag-circle"><img src="%1$s" alt="%2$s" width="24" height="24"></div><div class="currency-info"><div dir="ltr" class="price">%3$s %4$s</div><div dir="ltr" class="date">%5$s</div></div></div>',
+			esc_url( $flag_url ),
+			esc_attr( $currency ),
+			esc_html( number_format( (float) $rate ) ),
+			esc_html( $symbol ),
+			esc_html( $date )
+		);
+	}
+}

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -232,61 +232,29 @@ class Digitalogic_Options {
     }
     
     /**
-     * Get last update date
-     * Works with or without ACF - tries multiple storage locations
-     * 
-     * @return string YYMMDD format
+     * Get the raw last-update date.
+     *
+     * The prefixed ACF option must be read directly. Asking ACF for the field
+     * can send a legacy YYMMDD value through wp-parsidate as a Unix timestamp.
+     *
+     * @return string Legacy YYMMDD or ISO date value.
      */
     public function get_update_date() {
-        // Try ACF storage first if ACF is available (options_ prefix)
-        if ($this->acf_available) {
-            $value = get_option('options_update_date', false);
-            if ($value !== false) {
-                return $value;
-            }
-        }
-        
-        // Fallback to direct option (works without ACF)
-        return get_option('update_date', date('ymd'));
-    }
-    
-    /**
-     * Parse the stored YYMMDD date format to Y-m-d string
-     * 
-     * @param string $date_raw Date in YYMMDD format
-     * @return string Date in Y-m-d format
-     */
-    private function parse_update_date($date_raw) {
-        // Convert YYMMDD to a full date string
-        // Assuming 20XX century for YY
-        if (strlen($date_raw) === 6) {
-            $year = '20' . substr($date_raw, 0, 2);
-            $month = substr($date_raw, 2, 2);
-            $day = substr($date_raw, 4, 2);
-            return $year . '-' . $month . '-' . $day;
-        } else {
-            // Fallback to today's date if format is wrong
-            return date('Y-m-d');
-        }
+        return Digitalogic_Currency_Date_Formatter::instance()->get_raw_update_date();
     }
     
     /**
      * Get formatted update date for display
-     * Supports Persian dates via parsidate plugin if available
+     * Uses the same strict locale-aware formatter as storefront currency cards.
      * 
      * @param string $format Date format (default: 'Y/m/d')
      * @return string Formatted date
      */
     public function get_update_date_formatted($format = 'Y/m/d') {
-        $update_date_raw = $this->get_update_date();
-        $date_string = $this->parse_update_date($update_date_raw);
-        
-        // Check if Persian (Jalali) date conversion is available
-        if (function_exists('parsidate') && get_locale() === 'fa_IR') {
-            return parsidate($format, strtotime($date_string));
-        } else {
-            return date_i18n($format, strtotime($date_string));
-        }
+        return Digitalogic_Currency_Date_Formatter::instance()->format(
+            $this->get_update_date(),
+            $format
+        );
     }
     
     /**
@@ -295,16 +263,14 @@ class Digitalogic_Options {
      * @return string Relative time string
      */
     public function get_update_date_relative() {
-        $update_date_raw = $this->get_update_date();
-        $date_string = $this->parse_update_date($update_date_raw);
-        
-        $update_timestamp = strtotime($date_string);
-        $today = strtotime(date('Y-m-d'));
-        
-        // Calculate difference in days
-        $seconds_per_day = 86400; // 24 * 60 * 60
-        $diff_seconds = $today - $update_timestamp;
-        $diff_days = (int) floor($diff_seconds / $seconds_per_day);
+        $date = Digitalogic_Currency_Date_Formatter::instance()->parse($this->get_update_date());
+
+        if (null === $date) {
+            return '';
+        }
+
+        $today = new DateTimeImmutable('today', $date->getTimezone());
+        $diff_days = (int) $date->setTime(0, 0)->diff($today)->format('%r%a');
         
         // Handle future dates (negative difference)
         if ($diff_days < 0) {
@@ -329,17 +295,7 @@ class Digitalogic_Options {
      * @return string Formatted date
      */
     public static function format_date($timestamp, $format = 'Y/m/d') {
-        // Convert string to timestamp if needed
-        if (!is_numeric($timestamp)) {
-            $timestamp = strtotime($timestamp);
-        }
-        
-        // Check if Persian (Jalali) date conversion is available
-        if (function_exists('parsidate') && get_locale() === 'fa_IR') {
-            return parsidate($format, $timestamp);
-        } else {
-            return date_i18n($format, $timestamp);
-        }
+        return Digitalogic_Currency_Date_Formatter::instance()->format_timestamp($timestamp, $format);
     }
     
     /**
@@ -384,11 +340,10 @@ add_filter('pre_option_yuan_price', function($pre_option, $option, $default) {
     return $options->get_yuan_price();
 }, 10, 3);
 
-// Redirect get_option('update_date') to use our plugin methods
+// Prefer raw ACF storage without calling back into get_option('update_date').
 add_filter('pre_option_update_date', function($pre_option, $option, $default) {
-    // Use our plugin method which handles ACF storage properly
-    $options = Digitalogic_Options::instance();
-    return $options->get_update_date();
+    $acf_value = get_option('options_update_date', false);
+    return false !== $acf_value ? $acf_value : $pre_option;
 }, 10, 3);
 
 /**

--- a/tests/CurrencyDateFormatterTest.php
+++ b/tests/CurrencyDateFormatterTest.php
@@ -1,0 +1,99 @@
+<?php
+// phpcs:ignoreFile
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CurrencyDateFormatterTest extends TestCase {
+    private Digitalogic_Currency_Date_Formatter $formatter;
+
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_options'] = array();
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_locale'] = 'en_US';
+        $this->formatter = Digitalogic_Currency_Date_Formatter::instance();
+    }
+
+    public function test_legacy_yymmdd_is_a_real_calendar_date_instead_of_a_unix_timestamp(): void {
+        $date = $this->formatter->parse('260629');
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $date);
+        $this->assertSame('2026-06-29 12:00:00 Asia/Tehran', $date->format('Y-m-d H:i:s e'));
+        $this->assertSame('2026/06/29', $this->formatter->format('260629', 'Y/m/d', 'en_US'));
+        $this->assertSame('۱۴۰۵/۰۴/۰۸', $this->formatter->format('260629', 'Y/m/d', 'fa_IR'));
+    }
+
+    public function test_iso_dates_and_datetimes_preserve_the_encoded_calendar_day(): void {
+        $values = array(
+            '2026-06-29',
+            '2026-06-29T23:59+03:30',
+            '2026-06-29T23:59:59.123456Z',
+            '2026-06-29 00:00:00-0330',
+        );
+
+        foreach ($values as $value) {
+            $this->assertSame('2026/06/29', $this->formatter->format($value, 'Y/m/d', 'en_US'), $value);
+            $this->assertSame('۱۴۰۵/۰۴/۰۸', $this->formatter->format($value, 'Y/m/d', 'fa_IR'), $value);
+        }
+    }
+
+    public function test_persian_and_arabic_indic_input_digits_are_normalized(): void {
+        $this->assertSame('۱۴۰۵/۰۴/۰۸', $this->formatter->format('۲۶۰۶۲۹', 'Y/m/d', 'fa_IR'));
+        $this->assertSame('2026/06/29', $this->formatter->format('٢٠٢٦-٠٦-٢٩', 'Y/m/d', 'en_US'));
+    }
+
+    public function test_jalali_conversion_is_correct_at_the_new_year_boundary(): void {
+        $this->assertSame('۱۴۰۵/۰۱/۰۱', $this->formatter->format('2026-03-21', 'Y/m/d', 'fa_IR'));
+        $this->assertSame('۱ فروردین ۱۴۰۵', $this->formatter->format('2026-03-21', 'j F Y', 'fa_AF'));
+    }
+
+    #[DataProvider('invalidDateProvider')]
+    public function test_invalid_and_empty_values_are_blank_without_today_or_epoch_fallback(mixed $value): void {
+        $this->assertNull($this->formatter->parse($value));
+        $this->assertSame('', $this->formatter->format($value, 'Y/m/d', 'en_US'));
+        $this->assertSame('', $this->formatter->format($value, 'Y/m/d', 'fa_IR'));
+    }
+
+    public static function invalidDateProvider(): array {
+        return array(
+            'empty' => array(''),
+            'whitespace' => array('   '),
+            'null' => array(null),
+            'boolean' => array(false),
+            'array' => array(array('260629')),
+            'bad legacy month' => array('261329'),
+            'bad legacy leap day' => array('250229'),
+            'bad ISO day' => array('2026-06-31'),
+            'bad ISO time' => array('2026-06-29T24:00:00Z'),
+            'bad ISO offset' => array('2026-06-29T12:00:00+14:01'),
+            'trailing data' => array('2026-06-29 garbage'),
+            'epoch-like junk' => array('not-a-date'),
+        );
+    }
+
+    public function test_raw_option_reader_always_prefers_unformatted_acf_storage(): void {
+        $GLOBALS['digitalogic_test_options'] = array(
+            'options_update_date' => '260629',
+            'update_date' => '1999-01-01',
+        );
+
+        $this->assertSame('260629', $this->formatter->get_raw_update_date());
+
+        $GLOBALS['digitalogic_test_options']['options_update_date'] = '';
+        $this->assertSame('', $this->formatter->get_raw_update_date());
+
+        unset($GLOBALS['digitalogic_test_options']['options_update_date']);
+        $this->assertSame('1999-01-01', $this->formatter->get_raw_update_date());
+    }
+
+    public function test_legacy_static_formatter_routes_six_digit_values_through_the_safe_parser(): void {
+        $GLOBALS['digitalogic_test_locale'] = 'fa_IR';
+
+        $this->assertSame('۱۴۰۵/۰۴/۰۸', $this->formatter->format_timestamp('260629'));
+        $this->assertSame('', $this->formatter->format_timestamp('260230'));
+        $this->assertSame('', $this->formatter->format_timestamp(260230));
+        $this->assertSame('', $this->formatter->format_timestamp('2026-02-30'));
+        $this->assertSame('', $this->formatter->format_timestamp(''));
+        $this->assertSame('', $this->formatter->format_timestamp('definitely-invalid'));
+    }
+}

--- a/tests/CurrencyDateIntegrationTest.php
+++ b/tests/CurrencyDateIntegrationTest.php
@@ -1,0 +1,87 @@
+<?php
+// phpcs:ignoreFile
+
+use PHPUnit\Framework\TestCase;
+
+final class CurrencyDateIntegrationTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['digitalogic_test_options'] = array(
+            'options_dollar_price' => 71500,
+            'options_yuan_price' => 9875,
+            'options_update_date' => '260629',
+        );
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_locale'] = 'en_US';
+        $GLOBALS['digitalogic_test_shortcodes'] = array();
+    }
+
+    public function test_storefront_shortcodes_register_the_production_callbacks(): void {
+        $shortcodes = Digitalogic_Currency_Shortcodes::instance();
+        $shortcodes->register();
+
+        $this->assertArrayHasKey('dollar_rate', $GLOBALS['digitalogic_test_shortcodes']);
+        $this->assertArrayHasKey('yuan_rate', $GLOBALS['digitalogic_test_shortcodes']);
+        $this->assertSame(array($shortcodes, 'render_dollar_rate'), $GLOBALS['digitalogic_test_shortcodes']['dollar_rate']);
+        $this->assertSame(array($shortcodes, 'render_yuan_rate'), $GLOBALS['digitalogic_test_shortcodes']['yuan_rate']);
+    }
+
+    public function test_storefront_and_options_service_share_the_english_formatter(): void {
+        $options = Digitalogic_Options::instance();
+        $date = $options->get_update_date_formatted();
+        $dollar = Digitalogic_Currency_Shortcodes::instance()->render_dollar_rate();
+        $yuan = Digitalogic_Currency_Shortcodes::instance()->render_yuan_rate();
+
+        $this->assertSame('2026/06/29', $date);
+        $this->assertStringContainsString('<div dir="ltr" class="price">71,500 $</div>', $dollar);
+        $this->assertStringContainsString('<div dir="ltr" class="price">9,875 ¥</div>', $yuan);
+        $this->assertStringContainsString('<div dir="ltr" class="date">' . $date . '</div>', $dollar);
+        $this->assertStringContainsString('<div dir="ltr" class="date">' . $date . '</div>', $yuan);
+    }
+
+    public function test_storefront_and_options_service_share_the_persian_jalali_formatter(): void {
+        $GLOBALS['digitalogic_test_locale'] = 'fa_IR';
+
+        $date = Digitalogic_Options::instance()->get_update_date_formatted();
+        $output = Digitalogic_Currency_Shortcodes::instance()->render_yuan_rate();
+
+        $this->assertSame('۱۴۰۵/۰۴/۰۸', $date);
+        $this->assertStringContainsString('<div dir="ltr" class="date">۱۴۰۵/۰۴/۰۸</div>', $output);
+        $this->assertStringNotContainsString('۱۳۴۸', $output);
+    }
+
+    public function test_invalid_stored_date_renders_an_empty_safe_date_in_both_layers(): void {
+        $GLOBALS['digitalogic_test_options']['options_update_date'] = '260230';
+
+        $this->assertSame('', Digitalogic_Options::instance()->get_update_date_formatted());
+        $this->assertStringContainsString(
+            '<div dir="ltr" class="date"></div>',
+            Digitalogic_Currency_Shortcodes::instance()->render_dollar_rate()
+        );
+    }
+
+    public function test_currency_cards_keep_live_markup_and_use_site_relative_flag_assets(): void {
+        $output = Digitalogic_Currency_Shortcodes::instance()->render_dollar_rate();
+
+        $this->assertStringContainsString('class="currency-box"', $output);
+        $this->assertStringContainsString('class="flag-circle"', $output);
+        $this->assertStringContainsString('class="currency-info"', $output);
+        $this->assertStringContainsString('https://digitalogic.test/wp-content/uploads/2025/10/us.svg', $output);
+        $this->assertStringContainsString('alt="USD" width="24" height="24"', $output);
+    }
+
+    public function test_admin_panel_and_storefront_all_route_through_the_options_formatter(): void {
+        $admin = file_get_contents(dirname(__DIR__) . '/includes/admin/class-admin.php');
+        $status = file_get_contents(dirname(__DIR__) . '/includes/admin/views/status.php');
+        $panel = file_get_contents(dirname(__DIR__) . '/includes/panel/class-panel.php');
+        $options = file_get_contents(dirname(__DIR__) . '/includes/class-options.php');
+        $shortcodes = file_get_contents(dirname(__DIR__) . '/includes/class-digitalogic-currency-shortcodes.php');
+
+        $this->assertSame(2, substr_count($admin, 'get_update_date_formatted()'));
+        $this->assertSame(1, substr_count($status, 'get_update_date_formatted()'));
+        $this->assertSame(2, substr_count($panel, 'get_update_date_formatted()'));
+        $this->assertStringContainsString('Digitalogic_Currency_Date_Formatter::instance()->format(', $options);
+        $this->assertStringContainsString('$this->options->get_update_date_formatted( $date_format )', $shortcodes);
+        $this->assertStringNotContainsString('parsidate', $shortcodes);
+        $this->assertStringNotContainsString('strtotime', $shortcodes);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,6 +41,8 @@ $GLOBALS['digitalogic_test_primed_post_ids'] = array();
 $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
 $GLOBALS['digitalogic_test_transients'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_transient_deletes'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_locale'] = 'en_US';
+$GLOBALS['digitalogic_test_shortcodes'] = array();
 // phpcs:enable Generic.Formatting.MultipleStatementAlignment
 
 class WP_Error {
@@ -185,6 +187,12 @@ function add_action($hook_name, $callback, $priority = 10, $accepted_args = 1) {
         'priority' => $priority,
         'accepted_args' => $accepted_args,
     );
+
+    return true;
+}
+
+function add_shortcode($tag, $callback) {
+    $GLOBALS['digitalogic_test_shortcodes'][$tag] = $callback;
 
     return true;
 }
@@ -627,6 +635,18 @@ function esc_url_raw($value) {
     return trim((string) $value);
 }
 
+function esc_url($value) {
+    return trim((string) $value);
+}
+
+function esc_attr($value) {
+    return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+function esc_html($value) {
+    return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
 function wp_http_validate_url($value) {
     return filter_var($value, FILTER_VALIDATE_URL) !== false;
 }
@@ -641,6 +661,22 @@ function get_bloginfo($field = '') {
 
 function home_url($path = '') {
     return 'https://digitalogic.test' . $path;
+}
+
+function content_url($path = '') {
+    return 'https://digitalogic.test/wp-content' . $path;
+}
+
+function determine_locale() {
+    return $GLOBALS['digitalogic_test_locale'];
+}
+
+function get_locale() {
+    return $GLOBALS['digitalogic_test_locale'];
+}
+
+function wp_timezone() {
+    return new DateTimeZone('Asia/Tehran');
 }
 
 function wp_remote_post($url, $args = array()) {
@@ -1057,7 +1093,11 @@ class Digitalogic_Options {
     }
 
     public function get_update_date() {
-        return (string) get_option('options_update_date', get_option('update_date', ''));
+        return Digitalogic_Currency_Date_Formatter::instance()->get_raw_update_date();
+    }
+
+    public function get_update_date_formatted($format = 'Y/m/d') {
+        return Digitalogic_Currency_Date_Formatter::instance()->format($this->get_update_date(), $format);
     }
 }
 
@@ -1569,6 +1609,8 @@ class WP_CLI {
 
 $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
 
+require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-date-formatter.php';
+require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-shortcodes.php';
 require_once dirname(__DIR__) . '/includes/class-unit-converter.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-woocommerce-currency-status.php';
 require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';


### PR DESCRIPTION
## Summary

- add a canonical currency effective-date parser/formatter shared by storefront, admin, and panel surfaces
- support validated legacy `YYMMDD` and strict ISO date/date-time values
- render Gregorian dates in English locales and Jalali dates with Persian digits in `fa*` locales
- move the existing `[dollar_rate]` and `[yuan_rate]` currency cards into versioned plugin code
- return a blank date for invalid or empty storage instead of silently using today or the Unix epoch
- release the durable fix as plugin version 1.3.4 with documentation, changelog, and regression tests

## Root cause

The production child-theme shortcodes could receive the six-digit raw option value through ACF/wp-parsidate as though it were a Unix timestamp. A value such as `260629` therefore resolved near the epoch and displayed Jalali year `۱۳۴۸` instead of the actual effective date `۱۴۰۵/۰۴/۰۸`.

The plugin also had separate parsing paths, accepted malformed dates by falling back to today, and depended on an unversioned theme-only mitigation.

## Impact

The raw `options_update_date` value is now validated before localization. Storefront cards and management views use one deterministic formatter, and Persian rendering no longer depends on a production-only child-theme function. Existing currency-card DOM classes and flag paths remain compatible with current styling.

This PR does not deploy or modify production.

## Verification

- currency-date regression suite: 24 tests, 87 assertions
- non-WebSocket suite: 215 tests, 1,678 assertions
- portable WebSocket suite: 12 tests, 41 assertions
- PHP syntax: 70 files
- Composer validation and security audit: clean
- new production files: WordPress PHPCS clean
- repository PHPCS baseline: 42,730 errors and 2,912 warnings, both below configured limits
- deterministic production package: 651 PHP files, SHA-256 `ce7aa7aed8dcd1de91c30299b4f2bf43ae03a17685090bc9ba385e76319aef1b`

Closes #89
