### PR TITLE
Use a neutral Patris product-sync boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Replaced the product-sync payload families with one sparse living contract, including category and exclusion projections and explicit missing-versus-null semantics.
-- Moved the four Patris-facing routes to the unversioned `digitalogic` REST namespace and removed raw-feed and pricing aliases.
+- Moved the four Patris-facing routes to the `digitalogic` REST namespace and removed raw-feed and pricing aliases.
 - Standardized supplier shipping inputs, storage, events, and responses on `shipping_method_id` and `shipping_price_per_kg_cny` without mirrored keys.
 
 ## [1.3.4] - 2026-07-20
@@ -142,7 +142,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] - 2026-07-16
 
 ### Added
-- Dedicated authenticated `digitalogic.product-sync` REST receiver.
+- Dedicated authenticated `patris.product-sync` REST receiver.
 - Strict typed envelope validation, recursive raw-field rejection, receiver-side exact `landed_price` evaluation, Go-compatible record/source/event hash verification, and duplicate-key-safe JSON decoding.
 - Ordered per-source snapshots, timestamp-bound event identities, update merging, bounded replay protection, quarantine preservation, and deletion-only tombstones that never delete WooCommerce products.
 - Dedicated header-only receiver secrets with optional exact source scopes, plus a durable per-product WooCommerce outbox with record-hash CAS recovery.

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Developed for Digitalogic electronic components shop.
 - Refreshed Persian translation catalogs and retained backward-compatible CLI update behavior.
 
 ### 1.2.0
-- Added the authenticated, transformed-only `digitalogic.product-sync` receiver with deterministic integrity and ordering checks.
+- Added the authenticated, transformed-only `patris.product-sync` receiver with deterministic integrity and ordering checks.
 - Added snapshot/delta merging, bounded replay protection, quarantine preservation, and non-destructive Code tombstones.
 - Added exact receiver-side landed-price verification, a durable per-product Woo delivery outbox, and a separate source-scopeable header secret.
 - Reused the exact collision-safe Patris Code resolver and normalized Patris WooCommerce writer.

--- a/docs/PATRIS-PRODUCT-SYNC.md
+++ b/docs/PATRIS-PRODUCT-SYNC.md
@@ -1,6 +1,6 @@
 # Patris Product Sync Living Contract
 
-Digitalogic and Patris Export use one living, versionless contract. Because both ends are deployed together, contract changes replace the current shape instead of adding compatibility branches.
+Digitalogic and Patris Export use one living contract. Because both ends are deployed together, contract changes replace the current shape instead of adding compatibility branches.
 
 ## Endpoints
 
@@ -9,7 +9,7 @@ Digitalogic and Patris Export use one living, versionless contract. Because both
 - `POST /wp-json/digitalogic/integration/pricing-assignments/batch`
 - `GET /wp-json/digitalogic/integration/products/by-code/{code}/pricing`
 
-The product-sync request uses `X-Digitalogic-Product-Sync-Secret`. It may be restricted to exact `{id,dataset}` source pairs.
+The product-sync request uses `X-Patris-Product-Sync-Secret`. It may be restricted to exact `{id,dataset}` source pairs.
 
 Product delivery and pricing-assignment lookups match the case-sensitive
 `_digitalogic_patris_product_code` value only. A WooCommerce SKU is never used
@@ -30,7 +30,7 @@ The envelope contains:
 
 ```json
 {
-  "schema": "digitalogic.product-sync",
+  "schema": "patris.product-sync",
   "event_type": "snapshot",
   "event_id": "sha256:...",
   "local_currency": "IRT",

--- a/docs/SHIPPING-METHOD-API.md
+++ b/docs/SHIPPING-METHOD-API.md
@@ -2,7 +2,7 @@
 
 Supplier shipping methods are pricing inputs and are separate from WooCommerce customer delivery methods. The canonical fields are `shipping_method_id` and `shipping_price_per_kg_cny`; aliases are not accepted or emitted.
 
-Management routes remain under `/wp-json/digitalogic/v1/shipping-methods`. Patris reads the versionless integration routes documented in [PATRIS-PRODUCT-SYNC.md](PATRIS-PRODUCT-SYNC.md).
+Management routes remain under `/wp-json/digitalogic/v1/shipping-methods`. Patris reads the integration routes documented in [PATRIS-PRODUCT-SYNC.md](PATRIS-PRODUCT-SYNC.md).
 
 Built-in defaults are `air_express`, `air_freight`, and `sea_freight`. Product assignments are stored only in `_digitalogic_shipping_method_id`. Catalog, assignment, panel, and webhook writes use the same canonical record without mirrored option or metadata keys.
 

--- a/includes/admin/views/patris-reports.php
+++ b/includes/admin/views/patris-reports.php
@@ -55,7 +55,7 @@ $notice_type = in_array($notice_type, array('success', 'error', 'warning', 'info
             <div class="digitalogic-push-box">
                 <strong><?php echo esc_html__('Product-sync endpoint', 'digitalogic'); ?></strong>
                 <code><?php echo esc_html($product_sync_url); ?></code>
-                <strong><?php echo esc_html__('X-Digitalogic-Product-Sync-Secret', 'digitalogic'); ?></strong>
+                <strong><?php echo esc_html__('X-Patris-Product-Sync-Secret', 'digitalogic'); ?></strong>
                 <code><?php echo esc_html($product_sync_secret); ?></code>
             </div>
         </section>

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -33,7 +33,7 @@ class Digitalogic_REST_API {
      *
      * WooCommerce only recognizes its own wc/* and wc-* namespaces by default.
      * Preserve requests already recognized by WooCommerce and opt in only the
-     * existing Digitalogic API and exact versionless Patris integration routes
+     * existing Digitalogic API and exact Patris integration routes
      * (including subdirectory installs and rest_route query parameters).
      *
      * @param bool $is_request Whether WooCommerce already recognizes the request.
@@ -877,7 +877,7 @@ class Digitalogic_REST_API {
     /**
      * POST /patris/product-sync
      *
-     * Consume the deterministic digitalogic.product-sync envelope. Patris
+     * Consume the deterministic patris.product-sync envelope. Patris
      * identity headers are optional, but when present they must agree with the
      * body so proxies cannot accidentally pair stale metadata with new JSON.
      */

--- a/includes/api/class-webhooks.php
+++ b/includes/api/class-webhooks.php
@@ -14,7 +14,7 @@ class Digitalogic_Webhooks {
 
     // phpcs:disable -- Preserve the established webhook formatting in this file.
     private const PRODUCT_SYNC_EVENT = 'patris.product_sync.applied';
-    private const PRODUCT_SYNC_SCHEMA = 'digitalogic.product-sync';
+    private const PRODUCT_SYNC_SCHEMA = 'patris.product-sync';
     private const MAX_PRODUCT_SYNC_COUNT = 10000;
     private const PRODUCT_SYNC_STATUSES = array(
         'accepted',

--- a/includes/class-patris-feed.php
+++ b/includes/class-patris-feed.php
@@ -370,7 +370,7 @@ class Digitalogic_Patris_Feed {
      */
     public function verify_product_sync_request(WP_REST_Request $request) {
         $expected = $this->get_product_sync_secret();
-        $provided = $request->get_header('x-digitalogic-product-sync-secret');
+        $provided = $request->get_header('x-patris-product-sync-secret');
 
         if (!is_string($provided) || '' === $provided || '' === $expected || !hash_equals($expected, $provided)) {
             return false;

--- a/includes/class-product-sync-receiver.php
+++ b/includes/class-product-sync-receiver.php
@@ -2,7 +2,7 @@
 /**
  * Living, transformed-only Patris product-sync receiver.
  *
- * It accepts the canonical digitalogic.product-sync contract,
+ * It accepts the canonical patris.product-sync contract,
  * verifies its deterministic identities, and maintains an ordered snapshot
  * per Patris source.
  */
@@ -233,7 +233,7 @@ final class Digitalogic_Product_Sync_JSON_Decoder {
 
 class Digitalogic_Product_Sync_Receiver {
     public const STATE_OPTION = 'digitalogic_product_sync_state';
-    public const CONTRACT_NAME = 'digitalogic.product-sync';
+    public const CONTRACT_NAME = 'patris.product-sync';
     public const FORMULA_ID = 'landed_price';
 
     private const LOCK_NAME = 'digitalogic_product_sync';
@@ -840,7 +840,7 @@ class Digitalogic_Product_Sync_Receiver {
             }
         }
         if (self::CONTRACT_NAME !== $payload['schema']) {
-            return $this->error('digitalogic_product_sync_schema_unsupported', 'Only digitalogic.product-sync envelopes are accepted.', 422);
+            return $this->error('digitalogic_product_sync_schema_unsupported', 'Only patris.product-sync envelopes are accepted.', 422);
         }
         if (!in_array($payload['event_type'], array('snapshot', 'update'), true)) {
             return $this->field_error('event_type', 'must be snapshot or update');

--- a/languages/digitalogic-fa_IR.po
+++ b/languages/digitalogic-fa_IR.po
@@ -1304,7 +1304,7 @@ msgid "Product-sync endpoint"
 msgstr ""
 
 #: includes\admin\views\patris-reports.php:58
-msgid "X-Digitalogic-Product-Sync-Secret"
+msgid "X-Patris-Product-Sync-Secret"
 msgstr ""
 
 #: includes\admin\views\patris-reports.php:64

--- a/languages/digitalogic.pot
+++ b/languages/digitalogic.pot
@@ -1360,7 +1360,7 @@ msgid "Product-sync endpoint"
 msgstr ""
 
 #: includes\admin\views\patris-reports.php:58
-msgid "X-Digitalogic-Product-Sync-Secret"
+msgid "X-Patris-Product-Sync-Secret"
 msgstr ""
 
 #: includes\admin\views\patris-reports.php:64

--- a/tests/ProductSyncReceiverTest.php
+++ b/tests/ProductSyncReceiverTest.php
@@ -24,7 +24,7 @@ final class ProductSyncReceiverTest extends TestCase {
         $this->resetSingleton(Digitalogic_Product_Sync_Receiver::class);
     }
 
-    public function test_accepts_versionless_golden_fixture_and_requires_catalog_arrays(): void {
+    public function test_accepts_current_golden_fixture_and_requires_catalog_arrays(): void {
         $path = __DIR__ . '/fixtures/patris-product-sync-golden.json';
         $result = Digitalogic_Product_Sync_Receiver::instance()->receive_json(file_get_contents($path));
 
@@ -126,7 +126,7 @@ final class ProductSyncReceiverTest extends TestCase {
             'revision' => 'sha256:' . hash('sha256', implode("\n", $material)),
         );
         $identity = array(
-            'schema' => 'digitalogic.product-sync',
+            'schema' => 'patris.product-sync',
             'event_type' => 'snapshot',
             'local_currency' => $pricing ? 'IRT' : '',
             'formula_id' => $pricing ? 'landed_price' : '',
@@ -141,7 +141,7 @@ final class ProductSyncReceiverTest extends TestCase {
         sort($identity['categories'], SORT_STRING);
 
         $envelope = array(
-            'schema' => 'digitalogic.product-sync',
+            'schema' => 'patris.product-sync',
             'event_type' => 'snapshot',
             'event_id' => 'sha256:' . hash('sha256', json_encode($identity, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
             'source' => $source,

--- a/tests/ProductSyncRestTest.php
+++ b/tests/ProductSyncRestTest.php
@@ -55,7 +55,7 @@ final class ProductSyncRestTest extends TestCase {
             array(),
             $payload,
             array(
-                'X-Digitalogic-Product-Sync-Secret' => 'receiver-secret',
+                'X-Patris-Product-Sync-Secret' => 'receiver-secret',
                 'X-Patris-Contract' => $payload['schema'],
                 'X-Patris-Event-ID' => $payload['event_id'],
             ),

--- a/tests/ProductSyncWebhookTest.php
+++ b/tests/ProductSyncWebhookTest.php
@@ -18,7 +18,7 @@ final class ProductSyncWebhookTest extends TestCase {
         $this->resetSingleton(Digitalogic_Shipping_Method_Service::class);
     }
 
-    public function test_observer_emits_bounded_versionless_summary(): void {
+    public function test_observer_emits_bounded_current_contract_summary(): void {
         $result = array(
             'status' => 'accepted',
             'retryable' => false,
@@ -27,7 +27,7 @@ final class ProductSyncWebhookTest extends TestCase {
             'woocommerce' => array('attempted' => 2, 'missing' => 2),
         );
         $envelope = array(
-            'schema' => 'digitalogic.product-sync',
+            'schema' => 'patris.product-sync',
             'event_id' => 'sha256:' . str_repeat('a', 64),
             'event_type' => 'snapshot',
             'source' => array('id' => 'patris-export', 'dataset' => 'ALLANBAR'),
@@ -42,7 +42,7 @@ final class ProductSyncWebhookTest extends TestCase {
             array('schema', 'event_id', 'event_type', 'source', 'status', 'retryable', 'pending_products', 'deferred_products', 'woocommerce'),
             array_keys($payload['data'])
         );
-        $this->assertSame('digitalogic.product-sync', $payload['data']['schema']);
+        $this->assertSame('patris.product-sync', $payload['data']['schema']);
     }
 
     private function resetSingleton($class): void {

--- a/tests/fixtures/patris-product-sync-golden.json
+++ b/tests/fixtures/patris-product-sync-golden.json
@@ -1,7 +1,7 @@
 {
-  "schema": "digitalogic.product-sync",
+  "schema": "patris.product-sync",
   "event_type": "snapshot",
-  "event_id": "sha256:2bbb46be3ac8923ab6dab2256cfc419eabbb8d6405b7568169aa2ad0a93d1a63",
+  "event_id": "sha256:0554ef4f5dc36a0380d7d0ae0b1b8f5bbb350d218a6f30fa885f792de73bbe0a",
   "source": {
     "id": "patris-export",
     "dataset": "ALLANBAR",


### PR DESCRIPTION
## Summary

- switch the shared boundary to `patris.product-sync` and `X-Patris-Product-Sync-Secret`
- keep Digitalogic routes, storage, matching, translations, and observer identity local
- remove receiver-specific coupling from documentation, runtime messages, fixtures, and tests
- regenerate deterministic event identity for the current living shape

## Verification

- PHPUnit: 145 tests, 744 assertions; 5 platform skips and 1 existing warning
- PHP syntax and translation catalogs
- Composer strict validation
- PHPCS debt gate below the repository baseline
- deterministic production package and prohibited-reference scans

Closes #100