### PR TITLE
Fix verified PBX login compatibility with WP Zero Spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.1
+
+- Preserve WordPress account-policy authentication filters while exempting only WP Zero Spam's core form honeypot from a signed, browser-bound PBX login consume request.
+
 ## 1.6.0
 
 - Add secure six-digit phone verification by inbound call on `021-66754123`, IVR option `2`, as a Digits-independent login alternative and a way to verify supplemental Iranian mobile or fixed-line contacts.

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.6.0
+ * Version: 1.6.1
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.6.0' );
+define( 'DIGITALOGIC_VERSION', '1.6.1' );
 define( 'DIGITALOGIC_PBX_SCHEMA_VERSION', '3' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));

--- a/docs/PBX_CALL_VERIFICATION.md
+++ b/docs/PBX_CALL_VERIFICATION.md
@@ -75,7 +75,7 @@ The feature gate opens only after all plugin-owned PBX tables verify their requi
 
 ## Deployment order
 
-1. Back up WordPress and deploy plugin version 1.6.0. Activation/update creates and verifies the plugin-owned challenge, contact, consent-audit, replay, event, rate, and job tables. Do not continue if WordPress reports the migration/recovery-schedule gate as incomplete.
+1. Back up WordPress and deploy plugin version 1.6.1. Activation/update creates and verifies the plugin-owned challenge, contact, consent-audit, replay, event, rate, and job tables. Do not continue if WordPress reports the migration/recovery-schedule gate as incomplete.
 2. Install the inbound AGI/dialplan and prompts from `ops/pbx/` using its deployment and rollback documents.
 3. Add independent verification and callout credentials to server-only configuration; configure the AGI with the same decoded HMAC key bytes.
 4. Keep outbound voice settings disabled. Test a mobile and an eight-digit Tehran ANI through the signed callback, then test browser consumption.

--- a/includes/integrations/class-call-verification.php
+++ b/includes/integrations/class-call-verification.php
@@ -631,7 +631,7 @@ final class Digitalogic_Call_Verification {
 				return $user;
 			}
 
-			$filtered = apply_filters( 'wp_authenticate_user', $user, '' );
+			$filtered = $this->authenticate_verified_user( $user );
 			if ( is_wp_error( $filtered ) ) {
 				$wpdb->query( 'ROLLBACK' );
 				return $filtered;
@@ -1953,6 +1953,66 @@ final class Digitalogic_Call_Verification {
 
 		$user = get_userdata( $user_ids[0] );
 		return $user instanceof WP_User ? $user : new WP_Error( 'digitalogic_call_account', __( 'No unique account is available for this verified number.', 'digitalogic' ), array( 'status' => 403 ) );
+	}
+
+	/**
+	 * Apply account-policy authentication filters after PBX ownership proof.
+	 *
+	 * WordPress Zero Spam's core-login callback requires a form honeypot or login-page
+	 * intent cookie. Neither exists in this REST flow, whose equivalent anti-automation
+	 * controls are the signed PBX proof, browser binding, CSRF token, rate limits, and
+	 * single-use transaction. Suspend only that form-specific callback for this call;
+	 * every other account/security filter still runs and the callback is always restored.
+	 *
+	 * @param WP_User $user Resolved user.
+	 * @return WP_User|WP_Error
+	 */
+	private function authenticate_verified_user( WP_User $user ) {
+		$removed = $this->suspend_zerospam_login_filter();
+		try {
+			return apply_filters( 'wp_authenticate_user', $user, '' );
+		} finally {
+			foreach ( $removed as $filter ) {
+				add_filter( 'wp_authenticate_user', $filter['callback'], $filter['priority'], $filter['accepted_args'] );
+			}
+		}
+	}
+
+	/**
+	 * Remove only Zero Spam's core form validator from this request's auth-filter pass.
+	 *
+	 * @return array<int,array{callback:callable,priority:int,accepted_args:int}> Removed callbacks.
+	 */
+	private function suspend_zerospam_login_filter(): array {
+		global $wp_filter;
+		$hook = $wp_filter['wp_authenticate_user'] ?? null;
+		if ( ! is_object( $hook ) || ! isset( $hook->callbacks ) || ! is_array( $hook->callbacks ) ) {
+			return array();
+		}
+
+		$removed = array();
+		foreach ( $hook->callbacks as $priority => $callbacks ) {
+			if ( ! is_array( $callbacks ) ) {
+				continue;
+			}
+			foreach ( $callbacks as $registered ) {
+				$callback = is_array( $registered ) ? ( $registered['function'] ?? null ) : null;
+				if ( ! is_array( $callback ) || 2 !== count( $callback ) || ! is_object( $callback[0] )
+					|| 'ZeroSpam\\Modules\\Login\\Login' !== get_class( $callback[0] ) || 'process_form' !== $callback[1] ) {
+					continue;
+				}
+				$numeric_priority = (int) $priority;
+				if ( remove_filter( 'wp_authenticate_user', $callback, $numeric_priority ) ) {
+					$removed[] = array(
+						'callback'      => $callback,
+						'priority'      => $numeric_priority,
+						'accepted_args' => (int) ( $registered['accepted_args'] ?? 2 ),
+					);
+				}
+			}
+		}
+
+		return $removed;
 	}
 
 	/**

--- a/languages/digitalogic-fa_IR.po
+++ b/languages/digitalogic-fa_IR.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Digitalogic WooCommerce Extension 1.6.0\n"
+"Project-Id-Version: Digitalogic WooCommerce Extension 1.6.1\n"
 "Report-Msgid-Bugs-To: https://github.com/atomicdeploy/digitalogic-wp/issues\n"
 "POT-Creation-Date: 2026-07-20 21:54+0330\n"
 "PO-Revision-Date: 2026-07-17 00:00+0000\n"

--- a/languages/digitalogic.pot
+++ b/languages/digitalogic.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Digitalogic 1.6.0\n"
+"Project-Id-Version: Digitalogic 1.6.1\n"
 "Report-Msgid-Bugs-To: https://github.com/atomicdeploy/digitalogic-wp/issues\n"
 "POT-Creation-Date: 2026-07-20 21:54+0330\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/tests/CallVerificationTest.php
+++ b/tests/CallVerificationTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 require_once dirname(__DIR__) . '/includes/integrations/class-pbx-phone.php';
 require_once dirname(__DIR__) . '/includes/integrations/class-call-verification.php';
 require_once dirname(__DIR__) . '/includes/integrations/class-voice-notifications.php';
+require_once __DIR__ . '/fixtures/ZeroSpamLogin.php';
 
 final class CallVerificationTest extends TestCase {
     public function test_public_phone_normalizer_accepts_ir_mobile_and_full_landline_but_not_local_ani(): void {
@@ -184,6 +185,129 @@ final class CallVerificationTest extends TestCase {
 			} else {
 				$GLOBALS['wpdb'] = $oldWpdb;
 			}
+		}
+	}
+
+	public function test_verified_login_suspends_only_zerospam_form_filter_and_restores_it(): void {
+		$oldFilters = $GLOBALS['digitalogic_test_filters'] ?? array();
+		$oldWpFilter = $GLOBALS['wp_filter'] ?? array();
+		$zeroSpam = new \ZeroSpam\Modules\Login\Login();
+		$accountPolicy = new class {
+			public int $calls = 0;
+			public function validate( $user, $password ) {
+				++$this->calls;
+				return $user;
+			}
+		};
+		$unrelatedFormFilter = new class {
+			public int $calls = 0;
+			public function process_form( $user, $password ) {
+				++$this->calls;
+				return $user;
+			}
+		};
+
+		try {
+			remove_all_filters( 'wp_authenticate_user' );
+			add_filter( 'wp_authenticate_user', array( $zeroSpam, 'process_form' ), 10, 2 );
+			add_filter( 'wp_authenticate_user', array( $unrelatedFormFilter, 'process_form' ), 15, 2 );
+			add_filter( 'wp_authenticate_user', array( $accountPolicy, 'validate' ), 20, 2 );
+			$hook = new WP_Hook();
+			$hook->callbacks = array(
+				10 => array(
+					'zerospam' => array(
+						'function'      => array( $zeroSpam, 'process_form' ),
+						'accepted_args' => 2,
+					),
+				),
+				15 => array(
+					'unrelated-form-filter' => array(
+						'function'      => array( $unrelatedFormFilter, 'process_form' ),
+						'accepted_args' => 2,
+					),
+				),
+				20 => array(
+					'account-policy' => array(
+						'function'      => array( $accountPolicy, 'validate' ),
+						'accepted_args' => 2,
+					),
+				),
+			);
+			$GLOBALS['wp_filter']['wp_authenticate_user'] = $hook;
+
+			$authenticate = new ReflectionMethod( Digitalogic_Call_Verification::class, 'authenticate_verified_user' );
+			$user = new WP_User( 52, 'verified-user' );
+			$this->assertSame( $user, $authenticate->invoke( Digitalogic_Call_Verification::instance(), $user ) );
+			$this->assertSame( 0, $zeroSpam->calls );
+			$this->assertSame( 1, $unrelatedFormFilter->calls );
+			$this->assertSame( 1, $accountPolicy->calls );
+
+			$normalLogin = apply_filters( 'wp_authenticate_user', $user, '' );
+			$this->assertTrue( is_wp_error( $normalLogin ) );
+			$this->assertSame( 'failed_zerospam', $normalLogin->get_error_code() );
+			$this->assertSame( 1, $zeroSpam->calls );
+			$this->assertSame( 2, $unrelatedFormFilter->calls );
+			$this->assertSame( 2, $accountPolicy->calls );
+		} finally {
+			$GLOBALS['digitalogic_test_filters'] = $oldFilters;
+			$GLOBALS['wp_filter'] = $oldWpFilter;
+		}
+	}
+
+	public function test_verified_login_propagates_other_policy_failures_and_restores_zerospam_on_throw(): void {
+		$oldFilters = $GLOBALS['digitalogic_test_filters'] ?? array();
+		$oldWpFilter = $GLOBALS['wp_filter'] ?? array();
+		$zeroSpam = new \ZeroSpam\Modules\Login\Login();
+		$authenticate = new ReflectionMethod( Digitalogic_Call_Verification::class, 'authenticate_verified_user' );
+		$user = new WP_User( 53, 'policy-user' );
+		$policyError = new class {
+			public function validate( $user, $password ) {
+				return new WP_Error( 'account_suspended', 'account policy denied access' );
+			}
+		};
+		$throwingPolicy = new class {
+			public function validate( $user, $password ) {
+				throw new RuntimeException( 'injected account policy failure' );
+			}
+		};
+
+		try {
+			remove_all_filters( 'wp_authenticate_user' );
+			add_filter( 'wp_authenticate_user', array( $zeroSpam, 'process_form' ), 10, 2 );
+			add_filter( 'wp_authenticate_user', array( $policyError, 'validate' ), 20, 2 );
+			$hook = new WP_Hook();
+			$hook->callbacks = array(
+				10 => array( 'zerospam' => array( 'function' => array( $zeroSpam, 'process_form' ), 'accepted_args' => 2 ) ),
+				20 => array( 'policy' => array( 'function' => array( $policyError, 'validate' ), 'accepted_args' => 2 ) ),
+			);
+			$GLOBALS['wp_filter']['wp_authenticate_user'] = $hook;
+
+			$result = $authenticate->invoke( Digitalogic_Call_Verification::instance(), $user );
+			$this->assertTrue( is_wp_error( $result ) );
+			$this->assertSame( 'account_suspended', $result->get_error_code() );
+			$this->assertSame( 0, $zeroSpam->calls );
+
+			remove_all_filters( 'wp_authenticate_user' );
+			add_filter( 'wp_authenticate_user', array( $zeroSpam, 'process_form' ), 10, 2 );
+			add_filter( 'wp_authenticate_user', array( $throwingPolicy, 'validate' ), 20, 2 );
+			$hook = new WP_Hook();
+			$hook->callbacks = array(
+				10 => array( 'zerospam' => array( 'function' => array( $zeroSpam, 'process_form' ), 'accepted_args' => 2 ) ),
+				20 => array( 'policy' => array( 'function' => array( $throwingPolicy, 'validate' ), 'accepted_args' => 2 ) ),
+			);
+			$GLOBALS['wp_filter']['wp_authenticate_user'] = $hook;
+
+			try {
+				$authenticate->invoke( Digitalogic_Call_Verification::instance(), $user );
+				$this->fail( 'Expected the account policy exception.' );
+			} catch ( RuntimeException $exception ) {
+				$this->assertSame( 'injected account policy failure', $exception->getMessage() );
+			}
+			$callbacks = array_column( $GLOBALS['digitalogic_test_filters']['wp_authenticate_user'], 'callback' );
+			$this->assertContains( array( $zeroSpam, 'process_form' ), $callbacks );
+		} finally {
+			$GLOBALS['digitalogic_test_filters'] = $oldFilters;
+			$GLOBALS['wp_filter'] = $oldWpFilter;
 		}
 	}
 

--- a/tests/fixtures/ZeroSpamLogin.php
+++ b/tests/fixtures/ZeroSpamLogin.php
@@ -1,0 +1,33 @@
+<?php
+// phpcs:ignoreFile
+
+namespace {
+	if ( ! class_exists( 'WP_Hook' ) ) {
+		class WP_Hook {
+			public array $callbacks = array();
+		}
+	}
+
+	if ( ! class_exists( 'WP_User' ) ) {
+		class WP_User {
+			public int $ID;
+			public string $user_login;
+
+			public function __construct( $id = 1, $user_login = 'test-user' ) {
+				$this->ID         = (int) $id;
+				$this->user_login = (string) $user_login;
+			}
+		}
+	}
+}
+
+namespace ZeroSpam\Modules\Login {
+	final class Login {
+		public int $calls = 0;
+
+		public function process_form( $user, $password ) {
+			++$this->calls;
+			return new \WP_Error( 'failed_zerospam', 'form token missing' );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- ship Digitalogic plugin version 1.6.1
- let a fully verified PBX login consume bypass only WP Zero Spam's core-form honeypot callback
- keep every other `wp_authenticate_user` account/security policy active and propagate its denial
- restore the exact Zero Spam callback, priority, and accepted-argument count in `finally`
- document the compatibility behavior and add regression fixtures

## Why this is narrowly scoped

The wrapper is reached only after the challenge is signed by the PBX, browser-bound, CSRF-bound, unexpired, rate-limited, resolved to exactly one account, and locked for single-use consumption. It matches the exact runtime class `ZeroSpam\Modules\Login\Login` and exact method `process_form`; unrelated callbacks—even one also named `process_form`—continue to run. Normal WordPress, WooCommerce, Digits, and Zero Spam login flows are unchanged.

## Verification

- focused call verification: 23 tests, 192 assertions
- full local PHP suite excluding the two pre-existing Windows-only socket/port cases: 284 tests, 2,108 assertions, 3 environment skips
- JavaScript/UI: 17 passing
- PBX helper: 12 passing
- whole-tree PHP syntax: pass
- PHPCS baseline: 43,212 errors / 3,004 warnings, unchanged and below repository maxima
- Composer locked audit: no advisories
- translation, Action lint, diff whitespace, and PII scans: pass
- production evidence before the patch: signed callback, idempotent retry, and verified polling pass; only consume is rejected by `failed_zerospam`

After Linux CI passes and this PR is merged, production rollout will repeat the complete synthetic challenge → signed callback → retry → consume → exact cleanup smoke with global voice notifications still off.

Fixes #106
