### PR TITLE
Fix panel authorization and add branded error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a persisted, optional sticky first product column that follows the first visible/reordered column in RTL and LTR while keeping the selection control frozen beside it.
+- Added reusable Digitalogic browser error pages with responsive light/dark styling, English and Persian copy, RTL/LTR layout, safe recovery actions, and stable support references.
 
 ### Fixed
+- Centralized panel authorization across the browser shell, in-process Laravel bridge, AJAX command dispatcher, and authenticated WebSocket path, including a safe WordPress-administrator fallback without granting storefront customers access.
+- Replaced the panel's raw WordPress `wp_die()` authorization response with a scoped, escaped Digitalogic 403 document that does not expose a Query Monitor call stack.
 - Made the `/panel/` and nested panel rewrite rules self-healing when WordPress retains the plugin's rewrite-version marker but another deployment or permalink refresh drops the stored routes.
 - Made panel launches strictly same-origin and in-process using the existing WordPress session; removed the panel token, session handoff, external-panel mode, and copied identity headers.
 - Prevented the custom Digits login and registration footer from blocking a PHP-FPM worker on remote WordPress.org translation discovery while preserving the locale already selected by WordPress.

--- a/assets/css/panel-error.css
+++ b/assets/css/panel-error.css
@@ -1,0 +1,291 @@
+@font-face {
+    font-family: "DigitalogicFanum";
+    src: url("https://digitalogic.ir/wp-content/themes/woodmart-child/fonts/woff2/IRANSansWeb%28FaNum%29.woff2") format("woff2");
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "DigitalogicFanum";
+    src: url("https://digitalogic.ir/wp-content/themes/woodmart-child/fonts/woff2/IRANSansWeb%28FaNum%29_Bold.woff2") format("woff2");
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+}
+
+:root {
+    color-scheme: light dark;
+    --dle-bg: #eef6fb;
+    --dle-card: rgba(255, 255, 255, 0.9);
+    --dle-text: #122f46;
+    --dle-muted: #607688;
+    --dle-border: rgba(17, 105, 216, 0.14);
+    --dle-accent: #0fa7eb;
+    --dle-accent-strong: #1169d8;
+    --dle-accent-soft: rgba(15, 167, 235, 0.12);
+    --dle-shadow: 0 32px 90px rgba(18, 52, 78, 0.18);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body.digitalogic-error-body {
+    min-height: 100%;
+}
+
+body.digitalogic-error-body {
+    margin: 0;
+    color: var(--dle-text);
+    font-family: "DigitalogicFanum", "Segoe UI", Tahoma, system-ui, sans-serif;
+    background:
+        radial-gradient(circle at 12% 16%, rgba(15, 167, 235, 0.22), transparent 30rem),
+        radial-gradient(circle at 88% 84%, rgba(17, 105, 216, 0.18), transparent 32rem),
+        linear-gradient(135deg, var(--dle-bg), #f8fbfe 52%, #e7f2fa);
+}
+
+.digitalogic-error-body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0.18;
+    background-image: linear-gradient(rgba(17, 105, 216, 0.12) 1px, transparent 1px), linear-gradient(90deg, rgba(17, 105, 216, 0.12) 1px, transparent 1px);
+    background-size: 44px 44px;
+    mask-image: linear-gradient(to bottom, black, transparent 80%);
+}
+
+.dle-shell {
+    position: relative;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 32px 18px;
+}
+
+.dle-card {
+    width: min(100%, 720px);
+    padding: clamp(28px, 6vw, 58px);
+    overflow: hidden;
+    border: 1px solid var(--dle-border);
+    border-radius: 30px;
+    background: var(--dle-card);
+    box-shadow: var(--dle-shadow);
+    backdrop-filter: blur(22px);
+}
+
+.dle-brand,
+.dle-brand > span,
+.dle-user,
+.dle-actions,
+.dle-footer {
+    display: flex;
+    align-items: center;
+}
+
+.dle-brand {
+    gap: 13px;
+    margin-bottom: 48px;
+}
+
+.dle-brand > span:last-child {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.dle-brand strong {
+    font-size: 1.05rem;
+    letter-spacing: 0.01em;
+}
+
+.dle-brand small {
+    color: var(--dle-muted);
+    font-size: 0.78rem;
+}
+
+.dle-logo {
+    width: 52px;
+    height: 52px;
+    padding: 9px;
+    border: 1px solid var(--dle-border);
+    border-radius: 17px;
+    background: rgba(255, 255, 255, 0.72);
+    box-shadow: 0 12px 30px rgba(18, 52, 78, 0.1);
+}
+
+.dle-logo img {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.dle-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    margin-bottom: 18px;
+    padding: 8px 12px;
+    border: 1px solid rgba(217, 79, 92, 0.18);
+    border-radius: 999px;
+    color: #b52e44;
+    background: rgba(217, 79, 92, 0.08);
+}
+
+.dle-status svg,
+.dle-user svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+}
+
+.dle-status-code {
+    font-family: "Cascadia Code", Consolas, monospace;
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+.dle-eyebrow {
+    margin: 0 0 8px;
+    color: var(--dle-accent-strong);
+    font-size: 0.86rem;
+    font-weight: 700;
+}
+
+.dle-card h1 {
+    max-width: 620px;
+    margin: 0;
+    font-size: clamp(2rem, 6vw, 3.7rem);
+    line-height: 1.12;
+    letter-spacing: -0.035em;
+}
+
+[dir="rtl"] .dle-card h1 {
+    letter-spacing: 0;
+}
+
+.dle-detail {
+    max-width: 610px;
+    margin: 22px 0 0;
+    color: var(--dle-muted);
+    font-size: clamp(1rem, 2.4vw, 1.14rem);
+    line-height: 1.9;
+}
+
+.dle-user {
+    width: fit-content;
+    gap: 8px;
+    margin: 26px 0 0;
+    padding: 10px 13px;
+    border-radius: 12px;
+    color: var(--dle-muted);
+    background: var(--dle-accent-soft);
+    font-size: 0.88rem;
+}
+
+.dle-actions {
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 34px;
+}
+
+.dle-button {
+    min-height: 46px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border: 1px solid var(--dle-border);
+    border-radius: 13px;
+    color: var(--dle-text);
+    background: rgba(255, 255, 255, 0.62);
+    font-weight: 700;
+    text-decoration: none;
+    transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.dle-button:hover {
+    transform: translateY(-2px);
+    border-color: rgba(17, 105, 216, 0.34);
+    box-shadow: 0 10px 24px rgba(18, 52, 78, 0.1);
+}
+
+.dle-button:focus-visible {
+    outline: 3px solid rgba(15, 167, 235, 0.28);
+    outline-offset: 3px;
+}
+
+.dle-button.is-primary {
+    border-color: transparent;
+    color: #fff;
+    background: linear-gradient(135deg, var(--dle-accent), var(--dle-accent-strong));
+    box-shadow: 0 14px 30px rgba(17, 105, 216, 0.22);
+}
+
+.dle-footer {
+    gap: 9px;
+    margin-top: 42px;
+    padding-top: 20px;
+    border-top: 1px solid var(--dle-border);
+    color: var(--dle-muted);
+    font-size: 0.78rem;
+}
+
+.dle-footer code {
+    padding: 4px 8px;
+    border-radius: 7px;
+    color: var(--dle-accent-strong);
+    background: var(--dle-accent-soft);
+    font-family: "Cascadia Code", Consolas, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --dle-bg: #08131e;
+        --dle-card: rgba(14, 25, 39, 0.9);
+        --dle-text: #eff8ff;
+        --dle-muted: #9fb3c2;
+        --dle-border: rgba(120, 171, 210, 0.2);
+        --dle-accent: #16b9f2;
+        --dle-accent-strong: #79cfff;
+        --dle-accent-soft: rgba(15, 167, 235, 0.14);
+        --dle-shadow: 0 34px 100px rgba(0, 0, 0, 0.48);
+    }
+
+    body.digitalogic-error-body {
+        background: radial-gradient(circle at 12% 16%, rgba(15, 167, 235, 0.2), transparent 30rem), linear-gradient(135deg, #08131e, #0d1d2b 54%, #101825);
+    }
+
+    .dle-logo,
+    .dle-button {
+        background: rgba(255, 255, 255, 0.05);
+    }
+
+    .dle-status {
+        color: #ff92a2;
+    }
+}
+
+@media (max-width: 560px) {
+    .dle-card {
+        border-radius: 22px;
+    }
+
+    .dle-brand {
+        margin-bottom: 34px;
+    }
+
+    .dle-actions,
+    .dle-button {
+        width: 100%;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .dle-button {
+        transition: none;
+    }
+}

--- a/assets/css/panel-error.css
+++ b/assets/css/panel-error.css
@@ -36,6 +36,10 @@ body.digitalogic-error-body {
     min-height: 100%;
 }
 
+.digitalogic-error-embedded {
+    font-family: "DigitalogicFanum", "Segoe UI", Tahoma, system-ui, sans-serif;
+}
+
 body.digitalogic-error-body {
     margin: 0;
     color: var(--dle-text);
@@ -63,6 +67,16 @@ body.digitalogic-error-body {
     display: grid;
     place-items: center;
     padding: 32px 18px;
+}
+
+.digitalogic-error-embedded .dle-shell {
+    min-height: calc(100vh - 150px);
+    padding: 24px 20px 36px 0;
+}
+
+[dir="rtl"].digitalogic-error-embedded .dle-shell {
+    padding-right: 0;
+    padding-left: 20px;
 }
 
 .dle-card {
@@ -270,6 +284,11 @@ body.digitalogic-error-body {
 }
 
 @media (max-width: 560px) {
+    .digitalogic-error-embedded .dle-shell,
+    [dir="rtl"].digitalogic-error-embedded .dle-shell {
+        padding-inline: 0;
+    }
+
     .dle-card {
         border-radius: 22px;
     }

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -113,6 +113,8 @@ final class Digitalogic {
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-options.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-currency-shortcodes.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-woocommerce-currency-status.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-access-control.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/panel/class-digitalogic-panel-error-page.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-logger.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-query.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-manager.php';

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -682,8 +682,14 @@ class Digitalogic_Admin {
     }
 
     public function render_patris_reports_page() {
-        if (!current_user_can('manage_woocommerce')) {
-            wp_die(esc_html__('You do not have permission to manage Patris reports.', 'digitalogic'));
+		if ( ! Digitalogic_Access_Control::can_access_panel() ) {
+			Digitalogic_Panel_Error_Page::render_admin(
+				403,
+				'patris-reports-access-denied',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_PATRIS_REPORTS )
+			);
+			exit;
         }
 
         $feed = Digitalogic_Patris_Feed::instance();
@@ -829,8 +835,14 @@ class Digitalogic_Admin {
 	 * Render exact-ID/SKU metadata diagnostics and an explicit lookup refresh.
 	 */
 	public function render_product_diagnostics_page() {
-		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			wp_die( esc_html__( 'You do not have permission to access this page.', 'digitalogic' ) );
+		if ( ! Digitalogic_Access_Control::can_access_panel() ) {
+			Digitalogic_Panel_Error_Page::render_admin(
+				403,
+				'product-diagnostics-access-denied',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_PRODUCT_DIAGNOSTICS )
+			);
+			exit;
 		}
 
 		$metadata                     = null;
@@ -914,7 +926,13 @@ class Digitalogic_Admin {
      */
     public function render_ui_settings_page() {
         if (!current_user_can('manage_options')) {
-            wp_die(esc_html__('You do not have permission to access this page.', 'digitalogic'));
+			Digitalogic_Panel_Error_Page::render_admin(
+				403,
+				'ui-settings-access-denied',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_UI_SETTINGS )
+			);
+			exit;
         }
 
         if (isset($_POST['digitalogic_ui_settings_submit']) && check_admin_referer('digitalogic_ui_settings')) {

--- a/includes/class-command-dispatcher.php
+++ b/includes/class-command-dispatcher.php
@@ -49,7 +49,7 @@ class Digitalogic_Command_Dispatcher {
     public function execute($command, $payload = array(), $transport = 'ajax') {
         $command = self::normalize_command_name( $command );
 
-        if (!current_user_can( 'manage_woocommerce' )) {
+        if ( ! Digitalogic_Access_Control::can_access_panel() ) {
             return new WP_Error( 'digitalogic_unauthorized', __( 'Unauthorized', 'digitalogic' ), array('status' => 403) );
         }
 

--- a/includes/class-digitalogic-access-control.php
+++ b/includes/class-digitalogic-access-control.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Shared WordPress-native authorization policy for the Digitalogic panel.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Central access predicate shared by every panel transport.
+ */
+final class Digitalogic_Access_Control {
+
+	/**
+	 * Check whether the current WordPress user can operate the Digitalogic panel.
+	 *
+	 * WooCommerce managers remain the primary operator role. The manage_options
+	 * fallback keeps WordPress administrators in control when a custom role or
+	 * another plugin has altered WooCommerce's role capabilities.
+	 *
+	 * @return bool
+	 */
+	public static function can_access_panel() {
+		$capabilities = (array) apply_filters(
+			'digitalogic_panel_access_capabilities',
+			array( 'manage_woocommerce', 'manage_options' )
+		);
+
+		$allowed = false;
+		foreach ( array_unique( array_filter( array_map( 'sanitize_key', $capabilities ) ) ) as $capability ) {
+			if ( current_user_can( $capability ) ) {
+				$allowed = true;
+				break;
+			}
+		}
+
+		return (bool) apply_filters(
+			'digitalogic_panel_access_allowed',
+			$allowed,
+			get_current_user_id(),
+			$capabilities
+		);
+	}
+}

--- a/includes/integrations/class-comment-guard.php
+++ b/includes/integrations/class-comment-guard.php
@@ -55,11 +55,13 @@ class Digitalogic_Comment_Guard {
 
         if ($reasons) {
             $this->log('BLOCK', implode(',', $reasons), $ip, $commentdata, $abuse, $sfs);
-            wp_die(
-                esc_html__('Your comment could not be accepted from this network.', 'digitalogic'),
-                esc_html__('Comment blocked', 'digitalogic'),
-                array('response' => 403)
-            );
+			Digitalogic_Panel_Error_Page::render(
+				403,
+				'comment-network-blocked',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_COMMENT_GUARD )
+			);
+			exit;
         }
 
         $this->log('ALLOW', 'clean', $ip, $commentdata, $abuse, $sfs);

--- a/includes/integrations/class-laravel-bridge.php
+++ b/includes/integrations/class-laravel-bridge.php
@@ -37,12 +37,9 @@ class Digitalogic_Laravel_Bridge {
     public function handle_panel_launch() {
         check_admin_referer('digitalogic_laravel_panel_launch');
 
-        if (!current_user_can('manage_woocommerce')) {
-            wp_die(
-                esc_html__('You are not allowed to open the Digitalogic panel.', 'digitalogic'),
-                esc_html__('Forbidden', 'digitalogic'),
-                array('response' => 403)
-            );
+        if ( ! Digitalogic_Access_Control::can_access_panel() ) {
+            Digitalogic_Panel_Error_Page::render( 403, 'panel-access-denied' );
+            exit;
         }
 
         $return_to = isset($_GET['return_to']) ? esc_url_raw(wp_unslash($_GET['return_to'])) : '';
@@ -89,7 +86,7 @@ class Digitalogic_Laravel_Bridge {
      * been installed, and the returned WP_Error exposes that exact state.
      */
     public function boot_for_panel() {
-        if (!current_user_can('manage_woocommerce')) {
+        if ( ! Digitalogic_Access_Control::can_access_panel() ) {
             return new WP_Error(
                 'digitalogic_laravel_forbidden',
                 __('You are not allowed to use the Digitalogic application.', 'digitalogic'),

--- a/includes/panel/class-digitalogic-panel-error-page.php
+++ b/includes/panel/class-digitalogic-panel-error-page.php
@@ -14,8 +14,29 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class Digitalogic_Panel_Error_Page {
 
+	/** Default panel authorization context. */
+	public const CONTEXT_PANEL = 'panel';
+
+	/** Patris report administration context. */
+	public const CONTEXT_PATRIS_REPORTS = 'patris-reports';
+
+	/** Product metadata diagnostics context. */
+	public const CONTEXT_PRODUCT_DIAGNOSTICS = 'product-diagnostics';
+
+	/** Digitalogic UI settings context. */
+	public const CONTEXT_UI_SETTINGS = 'ui-settings';
+
+	/** Public comment reputation context. */
+	public const CONTEXT_COMMENT_GUARD = 'comment-guard';
+
+	/** Standalone document rendering mode. */
+	public const MODE_DOCUMENT = 'document';
+
+	/** WordPress-admin-safe embedded rendering mode. */
+	public const MODE_ADMIN_EMBEDDED = 'admin-embedded';
+
 	/**
-	 * Render a complete localized error document.
+	 * Render a localized browser error response.
 	 *
 	 * This intentionally avoids wp_die() so plugin errors never fall back to the
 	 * generic WordPress error screen or expose a Query Monitor call stack.
@@ -30,8 +51,10 @@ final class Digitalogic_Panel_Error_Page {
 		$status = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
 		$view   = self::view_model( $status, $code, $message, $args );
 
-		nocache_headers();
-		status_header( $status );
+		if ( self::MODE_DOCUMENT === $view['mode'] ) {
+			nocache_headers();
+			status_header( $status );
+		}
 		wp_enqueue_style(
 			'digitalogic-panel-error',
 			DIGITALOGIC_PLUGIN_URL . 'assets/css/panel-error.css',
@@ -40,6 +63,23 @@ final class Digitalogic_Panel_Error_Page {
 		);
 
 		include DIGITALOGIC_PLUGIN_DIR . 'includes/panel/views/error.php';
+	}
+
+	/**
+	 * Render a localized error inside the existing WordPress admin document.
+	 *
+	 * Admin page callbacks run after the admin header. This mode deliberately
+	 * avoids emitting a second doctype, html, head, or body element.
+	 *
+	 * @param int    $status  HTTP status.
+	 * @param string $code    Stable support reference.
+	 * @param string $message Optional message override.
+	 * @param array  $args    Optional contextual view values.
+	 * @return void
+	 */
+	public static function render_admin( $status, $code, $message = '', $args = array() ) {
+		$args['mode'] = self::MODE_ADMIN_EMBEDDED;
+		self::render( $status, $code, $message, $args );
 	}
 
 	/**
@@ -52,17 +92,19 @@ final class Digitalogic_Panel_Error_Page {
 	 * @return array
 	 */
 	public static function view_model( $status, $code, $message = '', $args = array() ) {
-		$status = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
-		$locale = determine_locale();
-		$is_fa  = 0 === strpos( strtolower( (string) $locale ), 'fa' );
-		$copy   = self::copy( $status, $is_fa );
-		$user   = wp_get_current_user();
+		$status  = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
+		$locale  = determine_locale();
+		$is_fa   = 0 === strpos( strtolower( (string) $locale ), 'fa' );
+		$context = isset( $args['context'] ) ? sanitize_key( (string) $args['context'] ) : self::CONTEXT_PANEL;
+		$mode    = isset( $args['mode'] ) && self::MODE_ADMIN_EMBEDDED === $args['mode'] ? self::MODE_ADMIN_EMBEDDED : self::MODE_DOCUMENT;
+		$copy    = self::copy( $status, $is_fa, $context );
+		$user    = wp_get_current_user();
 
 		$defaults = array(
 			'eyebrow' => $copy['eyebrow'],
 			'title'   => $copy['title'],
 			'detail'  => $copy['detail'],
-			'actions' => self::default_actions( $status, $is_fa ),
+			'actions' => self::default_actions( $status, $is_fa, $context ),
 		);
 		$args     = wp_parse_args( $args, $defaults );
 
@@ -86,6 +128,8 @@ final class Digitalogic_Panel_Error_Page {
 			'code'            => 'DG-' . $reference,
 			'locale'          => str_replace( '_', '-', (string) $locale ),
 			'direction'       => $is_fa ? 'rtl' : 'ltr',
+			'context'         => $context,
+			'mode'            => $mode,
 			'eyebrow'         => (string) $args['eyebrow'],
 			'title'           => (string) $args['title'],
 			'detail'          => (string) $args['detail'],
@@ -103,11 +147,12 @@ final class Digitalogic_Panel_Error_Page {
 	/**
 	 * Return complete English or Persian copy for a supported status.
 	 *
-	 * @param int  $status HTTP status.
-	 * @param bool $is_fa  Whether Persian copy is required.
+	 * @param int    $status  HTTP status.
+	 * @param bool   $is_fa   Whether Persian copy is required.
+	 * @param string $context Browser error context.
 	 * @return array
 	 */
-	private static function copy( $status, $is_fa ) {
+	private static function copy( $status, $is_fa, $context ) {
 		$english = array(
 			400 => array(
 				'eyebrow' => 'Invalid request',
@@ -173,9 +218,11 @@ final class Digitalogic_Panel_Error_Page {
 			),
 		);
 
-		$set = $is_fa ? $persian : $english;
+		$set     = $is_fa ? $persian : $english;
+		$context = self::context_copy( $status, $is_fa, $context );
 		return array_merge(
 			$set[ $status ],
+			$context,
 			array(
 				'signed_in' => $is_fa ? 'واردشده با حساب %s' : 'Signed in as %s',
 				'reference' => $is_fa ? 'کد پیگیری' : 'Reference',
@@ -184,20 +231,99 @@ final class Digitalogic_Panel_Error_Page {
 	}
 
 	/**
-	 * Build safe recovery actions for the current authentication state.
+	 * Return localized copy for plugin-owned forbidden-page contexts.
 	 *
-	 * @param int  $status HTTP status.
-	 * @param bool $is_fa  Whether Persian labels are required.
+	 * @param int    $status  HTTP status.
+	 * @param bool   $is_fa   Whether Persian copy is required.
+	 * @param string $context Browser error context.
 	 * @return array
 	 */
-	private static function default_actions( $status, $is_fa ) {
+	private static function context_copy( $status, $is_fa, $context ) {
+		if ( 403 !== (int) $status ) {
+			return array();
+		}
+
+		$english = array(
+			self::CONTEXT_PATRIS_REPORTS      => array(
+				'eyebrow' => 'Access restricted',
+				'title'   => 'Patris reports are not available to this account',
+				'detail'  => 'This page requires store-management access. Ask a site administrator to grant the appropriate WordPress capability.',
+			),
+			self::CONTEXT_PRODUCT_DIAGNOSTICS => array(
+				'eyebrow' => 'Access restricted',
+				'title'   => 'Product diagnostics are not available to this account',
+				'detail'  => 'This page contains store diagnostics and requires store-management access.',
+			),
+			self::CONTEXT_UI_SETTINGS         => array(
+				'eyebrow' => 'Administrator access required',
+				'title'   => 'Digitalogic interface settings are restricted',
+				'detail'  => 'Only a WordPress administrator can change the Digitalogic interface settings.',
+			),
+			self::CONTEXT_COMMENT_GUARD       => array(
+				'eyebrow' => 'Comment blocked',
+				'title'   => 'We could not accept this comment',
+				'detail'  => 'Your comment could not be accepted from this network.',
+			),
+		);
+		$persian = array(
+			self::CONTEXT_PATRIS_REPORTS      => array(
+				'eyebrow' => 'دسترسی محدود',
+				'title'   => 'این حساب به گزارش‌های پاتریس دسترسی ندارد',
+				'detail'  => 'این صفحه به دسترسی مدیریت فروشگاه نیاز دارد. از مدیر سایت بخواهید مجوز مناسب وردپرس را به حساب شما اختصاص دهد.',
+			),
+			self::CONTEXT_PRODUCT_DIAGNOSTICS => array(
+				'eyebrow' => 'دسترسی محدود',
+				'title'   => 'این حساب به عیب‌یابی محصولات دسترسی ندارد',
+				'detail'  => 'این صفحه شامل اطلاعات عیب‌یابی فروشگاه است و به دسترسی مدیریت فروشگاه نیاز دارد.',
+			),
+			self::CONTEXT_UI_SETTINGS         => array(
+				'eyebrow' => 'نیازمند دسترسی مدیر',
+				'title'   => 'تنظیمات نمای دیجیتالوجیک محدود است',
+				'detail'  => 'فقط مدیر وردپرس می‌تواند تنظیمات نمای دیجیتالوجیک را تغییر دهد.',
+			),
+			self::CONTEXT_COMMENT_GUARD       => array(
+				'eyebrow' => 'دیدگاه مسدود شد',
+				'title'   => 'امکان پذیرش این دیدگاه نبود',
+				'detail'  => 'ارسال دیدگاه از این شبکه پذیرفته نشد.',
+			),
+		);
+		$set     = $is_fa ? $persian : $english;
+
+		return isset( $set[ $context ] ) ? $set[ $context ] : array();
+	}
+
+	/**
+	 * Build safe recovery actions for the current authentication state.
+	 *
+	 * @param int    $status  HTTP status.
+	 * @param bool   $is_fa   Whether Persian labels are required.
+	 * @param string $context Browser error context.
+	 * @return array
+	 */
+	private static function default_actions( $status, $is_fa, $context ) {
 		$panel_url = home_url( '/panel/' );
 		$actions   = array();
+
+		if ( self::CONTEXT_COMMENT_GUARD === $context ) {
+			$actions[] = array(
+				'label'   => $is_fa ? 'بازگشت به فروشگاه' : 'Return to the store',
+				'url'     => home_url( '/' ),
+				'primary' => true,
+			);
+
+			return $actions;
+		}
 
 		if ( 401 === $status || ! is_user_logged_in() ) {
 			$actions[] = array(
 				'label'   => $is_fa ? 'ورود به پنل' : 'Sign in to the panel',
 				'url'     => wp_login_url( $panel_url ),
+				'primary' => true,
+			);
+		} elseif ( in_array( $context, array( self::CONTEXT_PATRIS_REPORTS, self::CONTEXT_PRODUCT_DIAGNOSTICS, self::CONTEXT_UI_SETTINGS ), true ) ) {
+			$actions[] = array(
+				'label'   => $is_fa ? 'بازگشت به پیشخوان وردپرس' : 'Return to WordPress dashboard',
+				'url'     => admin_url(),
 				'primary' => true,
 			);
 		} elseif ( 403 === $status ) {

--- a/includes/panel/class-digitalogic-panel-error-page.php
+++ b/includes/panel/class-digitalogic-panel-error-page.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Standalone branded error pages for Digitalogic-owned browser routes.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Renders plugin-owned browser errors without the generic WordPress die page.
+ */
+final class Digitalogic_Panel_Error_Page {
+
+	/**
+	 * Render a complete localized error document.
+	 *
+	 * This intentionally avoids wp_die() so plugin errors never fall back to the
+	 * generic WordPress error screen or expose a Query Monitor call stack.
+	 *
+	 * @param int    $status  HTTP status.
+	 * @param string $code    Stable support reference.
+	 * @param string $message Optional message override.
+	 * @param array  $args    Optional title, eyebrow, actions, and detail values.
+	 * @return void
+	 */
+	public static function render( $status, $code, $message = '', $args = array() ) {
+		$status = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
+		$view   = self::view_model( $status, $code, $message, $args );
+
+		nocache_headers();
+		status_header( $status );
+		wp_enqueue_style(
+			'digitalogic-panel-error',
+			DIGITALOGIC_PLUGIN_URL . 'assets/css/panel-error.css',
+			array(),
+			DIGITALOGIC_VERSION
+		);
+
+		include DIGITALOGIC_PLUGIN_DIR . 'includes/panel/views/error.php';
+	}
+
+	/**
+	 * Build an escaped-at-output view model for the error template.
+	 *
+	 * @param int    $status  HTTP status.
+	 * @param string $code    Stable support reference.
+	 * @param string $message Optional message override.
+	 * @param array  $args    Optional overrides.
+	 * @return array
+	 */
+	public static function view_model( $status, $code, $message = '', $args = array() ) {
+		$status = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
+		$locale = determine_locale();
+		$is_fa  = 0 === strpos( strtolower( (string) $locale ), 'fa' );
+		$copy   = self::copy( $status, $is_fa );
+		$user   = wp_get_current_user();
+
+		$defaults = array(
+			'eyebrow' => $copy['eyebrow'],
+			'title'   => $copy['title'],
+			'detail'  => $copy['detail'],
+			'actions' => self::default_actions( $status, $is_fa ),
+		);
+		$args     = wp_parse_args( $args, $defaults );
+
+		if ( '' !== trim( (string) $message ) ) {
+			$args['detail'] = $message;
+		}
+
+		$reference = strtoupper( preg_replace( '/[^A-Za-z0-9_-]+/', '-', (string) $code ) );
+		$reference = trim( $reference, '-' );
+		if ( '' === $reference ) {
+			$reference = 'PANEL-ERROR';
+		}
+
+		$display_name = '';
+		if ( is_user_logged_in() && is_object( $user ) ) {
+			$display_name = trim( (string) ( $user->display_name ?? $user->user_login ?? '' ) );
+		}
+
+		$view = array(
+			'status'          => (int) $status,
+			'code'            => 'DG-' . $reference,
+			'locale'          => str_replace( '_', '-', (string) $locale ),
+			'direction'       => $is_fa ? 'rtl' : 'ltr',
+			'eyebrow'         => (string) $args['eyebrow'],
+			'title'           => (string) $args['title'],
+			'detail'          => (string) $args['detail'],
+			'actions'         => is_array( $args['actions'] ) ? $args['actions'] : array(),
+			'site_name'       => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+			'logo_url'        => DIGITALOGIC_PLUGIN_URL . 'assets/images/icon.svg',
+			'style_handle'    => 'digitalogic-panel-error',
+			'signed_in_label' => $display_name ? sprintf( $copy['signed_in'], $display_name ) : '',
+			'reference_label' => $copy['reference'],
+		);
+
+		return (array) apply_filters( 'digitalogic_panel_error_view_model', $view, $status, $code );
+	}
+
+	/**
+	 * Return complete English or Persian copy for a supported status.
+	 *
+	 * @param int  $status HTTP status.
+	 * @param bool $is_fa  Whether Persian copy is required.
+	 * @return array
+	 */
+	private static function copy( $status, $is_fa ) {
+		$english = array(
+			400 => array(
+				'eyebrow' => 'Invalid request',
+				'title'   => 'We could not process this request',
+				'detail'  => 'Check the requested address or values and try again.',
+			),
+			401 => array(
+				'eyebrow' => 'Sign-in required',
+				'title'   => 'Please sign in to continue',
+				'detail'  => 'The Digitalogic panel uses your existing WordPress session.',
+			),
+			403 => array(
+				'eyebrow' => 'Access restricted',
+				'title'   => 'This account does not have panel access',
+				'detail'  => 'You are signed in, but this WordPress account is not assigned store-management access. Ask a site administrator or sign in with another account.',
+			),
+			404 => array(
+				'eyebrow' => 'Page not found',
+				'title'   => 'That Digitalogic page is not here',
+				'detail'  => 'The address may have changed, or the page may no longer be available.',
+			),
+			500 => array(
+				'eyebrow' => 'Unexpected error',
+				'title'   => 'Digitalogic could not complete this request',
+				'detail'  => 'Nothing was changed. Try again, or share the reference below with support.',
+			),
+			503 => array(
+				'eyebrow' => 'Temporarily unavailable',
+				'title'   => 'The Digitalogic service is not ready',
+				'detail'  => 'The service is starting or undergoing maintenance. Please try again shortly.',
+			),
+		);
+		$persian = array(
+			400 => array(
+				'eyebrow' => 'درخواست نامعتبر',
+				'title'   => 'امکان پردازش این درخواست نبود',
+				'detail'  => 'نشانی یا اطلاعات واردشده را بررسی کنید و دوباره تلاش کنید.',
+			),
+			401 => array(
+				'eyebrow' => 'نیاز به ورود',
+				'title'   => 'برای ادامه وارد حساب شوید',
+				'detail'  => 'پنل دیجیتالوجیک از همان نشست وردپرس شما استفاده می‌کند.',
+			),
+			403 => array(
+				'eyebrow' => 'دسترسی محدود',
+				'title'   => 'این حساب به پنل دسترسی ندارد',
+				'detail'  => 'شما وارد شده‌اید، اما این حساب وردپرس دسترسی مدیریت فروشگاه را ندارد. با مدیر سایت هماهنگ کنید یا با حساب دیگری وارد شوید.',
+			),
+			404 => array(
+				'eyebrow' => 'صفحه پیدا نشد',
+				'title'   => 'این صفحه دیجیتالوجیک در دسترس نیست',
+				'detail'  => 'ممکن است نشانی صفحه تغییر کرده باشد یا دیگر در دسترس نباشد.',
+			),
+			500 => array(
+				'eyebrow' => 'خطای پیش‌بینی‌نشده',
+				'title'   => 'انجام این درخواست ممکن نشد',
+				'detail'  => 'هیچ تغییری انجام نشد. دوباره تلاش کنید یا کد پیگیری زیر را برای پشتیبانی بفرستید.',
+			),
+			503 => array(
+				'eyebrow' => 'موقتاً در دسترس نیست',
+				'title'   => 'سرویس دیجیتالوجیک هنوز آماده نیست',
+				'detail'  => 'سرویس در حال راه‌اندازی یا نگهداری است. کمی بعد دوباره تلاش کنید.',
+			),
+		);
+
+		$set = $is_fa ? $persian : $english;
+		return array_merge(
+			$set[ $status ],
+			array(
+				'signed_in' => $is_fa ? 'واردشده با حساب %s' : 'Signed in as %s',
+				'reference' => $is_fa ? 'کد پیگیری' : 'Reference',
+			)
+		);
+	}
+
+	/**
+	 * Build safe recovery actions for the current authentication state.
+	 *
+	 * @param int  $status HTTP status.
+	 * @param bool $is_fa  Whether Persian labels are required.
+	 * @return array
+	 */
+	private static function default_actions( $status, $is_fa ) {
+		$panel_url = home_url( '/panel/' );
+		$actions   = array();
+
+		if ( 401 === $status || ! is_user_logged_in() ) {
+			$actions[] = array(
+				'label'   => $is_fa ? 'ورود به پنل' : 'Sign in to the panel',
+				'url'     => wp_login_url( $panel_url ),
+				'primary' => true,
+			);
+		} elseif ( 403 === $status ) {
+			$actions[] = array(
+				'label'   => $is_fa ? 'ورود با حساب دیگر' : 'Use another account',
+				'url'     => wp_logout_url( wp_login_url( $panel_url ) ),
+				'primary' => true,
+			);
+			$actions[] = array(
+				'label' => $is_fa ? 'نمایه وردپرس' : 'WordPress profile',
+				'url'   => admin_url( 'profile.php' ),
+			);
+		} else {
+			$actions[] = array(
+				'label'   => $is_fa ? 'تلاش دوباره' : 'Try again',
+				'url'     => $panel_url,
+				'primary' => true,
+			);
+		}
+
+		$actions[] = array(
+			'label' => $is_fa ? 'بازگشت به فروشگاه' : 'Return to the store',
+			'url'   => home_url( '/' ),
+		);
+
+		return $actions;
+	}
+}

--- a/includes/panel/class-panel.php
+++ b/includes/panel/class-panel.php
@@ -139,12 +139,9 @@ class Digitalogic_Panel {
             auth_redirect();
         }
 
-        if (!current_user_can('manage_woocommerce')) {
-            wp_die(
-                esc_html__('You are not allowed to open the Digitalogic panel.', 'digitalogic'),
-                esc_html__('Forbidden', 'digitalogic'),
-                array('response' => 403)
-            );
+        if ( ! Digitalogic_Access_Control::can_access_panel() ) {
+            Digitalogic_Panel_Error_Page::render( 403, 'panel-access-denied' );
+            exit;
         }
 
         $laravel = Digitalogic_Laravel_Bridge::instance()->boot_for_panel();

--- a/includes/panel/views/error-content.php
+++ b/includes/panel/views/error-content.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Shared Digitalogic error-card content.
+ *
+ * @package Digitalogic
+ * @var array $view Digitalogic error view model.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<main class="dle-shell">
+	<section class="dle-card" aria-labelledby="dle-title" aria-describedby="dle-detail">
+		<div class="dle-brand">
+			<span class="dle-logo"><img src="<?php echo esc_url( $view['logo_url'] ); ?>" alt=""></span>
+			<span><strong>Digitalogic</strong><small><?php echo esc_html( $view['site_name'] ); ?></small></span>
+		</div>
+
+		<div class="dle-status" aria-hidden="true">
+			<span class="dle-status-code"><?php echo esc_html( $view['status'] ); ?></span>
+			<svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 5.25a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm1.15 9.5h-2.3v-5.5h2.3v5.5Z"/></svg>
+		</div>
+
+		<p class="dle-eyebrow"><?php echo esc_html( $view['eyebrow'] ); ?></p>
+		<h1 id="dle-title"><?php echo esc_html( $view['title'] ); ?></h1>
+		<p class="dle-detail" id="dle-detail"><?php echo esc_html( $view['detail'] ); ?></p>
+
+		<?php if ( '' !== $view['signed_in_label'] ) : ?>
+			<p class="dle-user">
+				<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-5.33 0-8 2.67-8 5v1.5h16V19c0-2.33-2.67-5-8-5Z"/></svg>
+				<?php echo esc_html( $view['signed_in_label'] ); ?>
+			</p>
+		<?php endif; ?>
+
+		<nav class="dle-actions" aria-label="<?php echo esc_attr( $view['eyebrow'] ); ?>">
+			<?php foreach ( $view['actions'] as $error_action ) : ?>
+				<a class="dle-button<?php echo ! empty( $error_action['primary'] ) ? ' is-primary' : ''; ?>" href="<?php echo esc_url( $error_action['url'] ?? '' ); ?>">
+					<?php echo esc_html( $error_action['label'] ?? '' ); ?>
+				</a>
+			<?php endforeach; ?>
+		</nav>
+
+		<footer class="dle-footer">
+			<span><?php echo esc_html( $view['reference_label'] ); ?></span>
+			<code dir="ltr"><?php echo esc_html( $view['code'] ); ?></code>
+		</footer>
+	</section>
+</main>

--- a/includes/panel/views/error.php
+++ b/includes/panel/views/error.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Digitalogic panel error view.
+ *
+ * @package Digitalogic
+ * @var array $view Digitalogic panel error view model.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?><!doctype html>
+<html lang="<?php echo esc_attr( $view['locale'] ); ?>" dir="<?php echo esc_attr( $view['direction'] ); ?>">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="robots" content="noindex,nofollow,noarchive">
+	<title><?php echo esc_html( $view['title'] . ' — ' . $view['site_name'] ); ?></title>
+	<?php wp_print_styles( $view['style_handle'] ); ?>
+</head>
+<body class="digitalogic-error-body">
+	<main class="dle-shell">
+		<section class="dle-card" aria-labelledby="dle-title" aria-describedby="dle-detail">
+			<div class="dle-brand">
+				<span class="dle-logo"><img src="<?php echo esc_url( $view['logo_url'] ); ?>" alt=""></span>
+				<span><strong>Digitalogic</strong><small><?php echo esc_html( $view['site_name'] ); ?></small></span>
+			</div>
+
+			<div class="dle-status" aria-hidden="true">
+				<span class="dle-status-code"><?php echo esc_html( $view['status'] ); ?></span>
+				<svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 5.25a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm1.15 9.5h-2.3v-5.5h2.3v5.5Z"/></svg>
+			</div>
+
+			<p class="dle-eyebrow"><?php echo esc_html( $view['eyebrow'] ); ?></p>
+			<h1 id="dle-title"><?php echo esc_html( $view['title'] ); ?></h1>
+			<p class="dle-detail" id="dle-detail"><?php echo esc_html( $view['detail'] ); ?></p>
+
+			<?php if ( '' !== $view['signed_in_label'] ) : ?>
+				<p class="dle-user">
+					<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-5.33 0-8 2.67-8 5v1.5h16V19c0-2.33-2.67-5-8-5Z"/></svg>
+					<?php echo esc_html( $view['signed_in_label'] ); ?>
+				</p>
+			<?php endif; ?>
+
+			<nav class="dle-actions" aria-label="<?php echo esc_attr( $view['eyebrow'] ); ?>">
+				<?php foreach ( $view['actions'] as $error_action ) : ?>
+					<a class="dle-button<?php echo ! empty( $error_action['primary'] ) ? ' is-primary' : ''; ?>" href="<?php echo esc_url( $error_action['url'] ?? '' ); ?>">
+						<?php echo esc_html( $error_action['label'] ?? '' ); ?>
+					</a>
+				<?php endforeach; ?>
+			</nav>
+
+			<footer class="dle-footer">
+				<span><?php echo esc_html( $view['reference_label'] ); ?></span>
+				<code dir="ltr"><?php echo esc_html( $view['code'] ); ?></code>
+			</footer>
+		</section>
+	</main>
+</body>
+</html>

--- a/includes/panel/views/error.php
+++ b/includes/panel/views/error.php
@@ -9,7 +9,11 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-?><!doctype html>
+
+$is_embedded = Digitalogic_Panel_Error_Page::MODE_ADMIN_EMBEDDED === $view['mode'];
+
+if ( ! $is_embedded ) :
+	?><!doctype html>
 <html lang="<?php echo esc_attr( $view['locale'] ); ?>" dir="<?php echo esc_attr( $view['direction'] ); ?>">
 <head>
 	<meta charset="UTF-8">
@@ -19,42 +23,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php wp_print_styles( $view['style_handle'] ); ?>
 </head>
 <body class="digitalogic-error-body">
-	<main class="dle-shell">
-		<section class="dle-card" aria-labelledby="dle-title" aria-describedby="dle-detail">
-			<div class="dle-brand">
-				<span class="dle-logo"><img src="<?php echo esc_url( $view['logo_url'] ); ?>" alt=""></span>
-				<span><strong>Digitalogic</strong><small><?php echo esc_html( $view['site_name'] ); ?></small></span>
-			</div>
-
-			<div class="dle-status" aria-hidden="true">
-				<span class="dle-status-code"><?php echo esc_html( $view['status'] ); ?></span>
-				<svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 5.25a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm1.15 9.5h-2.3v-5.5h2.3v5.5Z"/></svg>
-			</div>
-
-			<p class="dle-eyebrow"><?php echo esc_html( $view['eyebrow'] ); ?></p>
-			<h1 id="dle-title"><?php echo esc_html( $view['title'] ); ?></h1>
-			<p class="dle-detail" id="dle-detail"><?php echo esc_html( $view['detail'] ); ?></p>
-
-			<?php if ( '' !== $view['signed_in_label'] ) : ?>
-				<p class="dle-user">
-					<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-5.33 0-8 2.67-8 5v1.5h16V19c0-2.33-2.67-5-8-5Z"/></svg>
-					<?php echo esc_html( $view['signed_in_label'] ); ?>
-				</p>
-			<?php endif; ?>
-
-			<nav class="dle-actions" aria-label="<?php echo esc_attr( $view['eyebrow'] ); ?>">
-				<?php foreach ( $view['actions'] as $error_action ) : ?>
-					<a class="dle-button<?php echo ! empty( $error_action['primary'] ) ? ' is-primary' : ''; ?>" href="<?php echo esc_url( $error_action['url'] ?? '' ); ?>">
-						<?php echo esc_html( $error_action['label'] ?? '' ); ?>
-					</a>
-				<?php endforeach; ?>
-			</nav>
-
-			<footer class="dle-footer">
-				<span><?php echo esc_html( $view['reference_label'] ); ?></span>
-				<code dir="ltr"><?php echo esc_html( $view['code'] ); ?></code>
-			</footer>
-		</section>
-	</main>
+	<?php include DIGITALOGIC_PLUGIN_DIR . 'includes/panel/views/error-content.php'; ?>
 </body>
 </html>
+	<?php
+else :
+	wp_print_styles( $view['style_handle'] );
+	?>
+<div class="wrap digitalogic-error-embedded" lang="<?php echo esc_attr( $view['locale'] ); ?>" dir="<?php echo esc_attr( $view['direction'] ); ?>">
+	<?php include DIGITALOGIC_PLUGIN_DIR . 'includes/panel/views/error-content.php'; ?>
+</div>
+	<?php
+endif;

--- a/includes/websocket/class-websocket-auth.php
+++ b/includes/websocket/class-websocket-auth.php
@@ -53,7 +53,7 @@ class Digitalogic_WebSocket_Auth {
             return 0;
         }
 
-        return current_user_can('manage_woocommerce') ? $user_id : 0;
+        return Digitalogic_Access_Control::can_access_panel() ? $user_id : 0;
     }
 
     private static function parse_cookie_header($header) {

--- a/includes/websocket/class-websocket-server.php
+++ b/includes/websocket/class-websocket-server.php
@@ -178,7 +178,7 @@ class Digitalogic_WebSocket_Server {
 
         wp_set_current_user(max(0, (int) $this->clients[$id]['user_id']));
         if ($command === 'digitalogic_panel_events' && class_exists('Digitalogic_Panel')) {
-            if (!current_user_can('manage_woocommerce')) {
+            if ( ! Digitalogic_Access_Control::can_access_panel() ) {
                 $this->send_error($id, $request_id, 'digitalogic_unauthorized', __('Unauthorized', 'digitalogic'));
                 return;
             }

--- a/includes/websocket/class-websocket.php
+++ b/includes/websocket/class-websocket.php
@@ -38,7 +38,7 @@ class Digitalogic_WebSocket {
     }
 
     public function check_permission() {
-        return current_user_can('manage_woocommerce');
+        return Digitalogic_Access_Control::can_access_panel();
     }
 
     public function get_config_response() {
@@ -54,7 +54,7 @@ class Digitalogic_WebSocket {
             'enabled' => (bool) apply_filters('digitalogic_websocket_enabled', true),
             'url' => $default_url,
             'nonce' => wp_create_nonce('digitalogic_ws'),
-            'token' => current_user_can('manage_woocommerce') ? self::create_client_token(get_current_user_id()) : '',
+            'token' => Digitalogic_Access_Control::can_access_panel() ? self::create_client_token(get_current_user_id()) : '',
             'reconnect_interval' => 3000,
             'request_timeout' => 15000,
             'ajax_proxy_enabled' => (bool) apply_filters('digitalogic_websocket_ajax_proxy_enabled', true),
@@ -82,7 +82,7 @@ class Digitalogic_WebSocket {
     }
 
     public function enqueue_admin_proxy() {
-        if (!current_user_can('manage_woocommerce')) {
+        if ( ! Digitalogic_Access_Control::can_access_panel() ) {
             return;
         }
 
@@ -129,7 +129,7 @@ class Digitalogic_WebSocket {
         $user_id = (int) $data['user_id'];
         wp_set_current_user($user_id);
 
-        return current_user_can('manage_woocommerce') ? $user_id : 0;
+        return Digitalogic_Access_Control::can_access_panel() ? $user_id : 0;
     }
 
     public static function create_public_token() {

--- a/tests/PanelAccessControlTest.php
+++ b/tests/PanelAccessControlTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Panel access policy tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies the shared WordPress-native panel access predicate.
+ */
+final class PanelAccessControlTest extends TestCase {
+
+	/**
+	 * Reset current-user capability fixtures.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['digitalogic_test_capabilities']           = array();
+		$GLOBALS['digitalogic_test_filters']                = array();
+		$GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
+		$GLOBALS['digitalogic_test_current_user_id']        = 42;
+	}
+
+	/**
+	 * WooCommerce managers retain panel access.
+	 */
+	public function test_woocommerce_manager_can_access_panel(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
+
+		$this->assertTrue( Digitalogic_Access_Control::can_access_panel() );
+	}
+
+	/**
+	 * WordPress administrators have a safe management fallback.
+	 */
+	public function test_administrator_has_safe_fallback_access(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+
+		$this->assertTrue( Digitalogic_Access_Control::can_access_panel() );
+	}
+
+	/**
+	 * Storefront-only roles never receive implicit panel access.
+	 */
+	public function test_customer_and_subscriber_capabilities_do_not_grant_access(): void {
+		$GLOBALS['digitalogic_test_capabilities']['read']     = true;
+		$GLOBALS['digitalogic_test_capabilities']['customer'] = true;
+
+		$this->assertFalse( Digitalogic_Access_Control::can_access_panel() );
+	}
+
+	/**
+	 * Integrators can add an explicit WordPress capability through the filter.
+	 */
+	public function test_integrators_can_extend_the_capability_list_explicitly(): void {
+		$GLOBALS['digitalogic_test_capabilities']['operate_digitalogic'] = true;
+		add_filter(
+			'digitalogic_panel_access_capabilities',
+			static function ( $capabilities ) {
+				$capabilities[] = 'operate_digitalogic';
+				return $capabilities;
+			}
+		);
+
+		$this->assertTrue( Digitalogic_Access_Control::can_access_panel() );
+	}
+}

--- a/tests/PanelErrorPageTest.php
+++ b/tests/PanelErrorPageTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Panel error-page tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies branded, safe, localized standalone error documents.
+ */
+final class PanelErrorPageTest extends TestCase {
+
+	/**
+	 * Reset request, locale, and user fixtures.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['digitalogic_test_filters']         = array();
+		$GLOBALS['digitalogic_test_locale']          = 'en_US';
+		$GLOBALS['digitalogic_test_current_user_id'] = 0;
+		$GLOBALS['digitalogic_test_current_user']    = (object) array(
+			'ID'           => 0,
+			'user_login'   => '',
+			'display_name' => '',
+		);
+		$GLOBALS['digitalogic_test_status_headers']  = array();
+		$GLOBALS['digitalogic_test_nocache_headers'] = 0;
+	}
+
+	/**
+	 * A forbidden response is branded, escaped, and returns HTTP 403.
+	 */
+	public function test_forbidden_page_is_branded_safe_and_sets_the_status(): void {
+		$GLOBALS['digitalogic_test_current_user_id'] = 12;
+		$GLOBALS['digitalogic_test_current_user']    = (object) array(
+			'ID'           => 12,
+			'user_login'   => 'operator',
+			'display_name' => 'Store Operator',
+		);
+
+		ob_start();
+		Digitalogic_Panel_Error_Page::render( 403, 'panel-access-denied', '<script>alert(1)</script>' );
+		$html = (string) ob_get_clean();
+
+		$this->assertSame( array( 403 ), $GLOBALS['digitalogic_test_status_headers'] );
+		$this->assertSame( 1, $GLOBALS['digitalogic_test_nocache_headers'] );
+		$this->assertStringContainsString( 'class="digitalogic-error-body"', $html );
+		$this->assertStringContainsString( 'Digitalogic', $html );
+		$this->assertStringContainsString( 'DG-PANEL-ACCESS-DENIED', $html );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $html );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+		$this->assertStringNotContainsString( 'wp-die-message', $html );
+	}
+
+	/**
+	 * Persian output is complete and uses the RTL document direction.
+	 */
+	public function test_persian_page_uses_rtl_and_complete_localized_copy(): void {
+		$GLOBALS['digitalogic_test_locale']          = 'fa_IR';
+		$GLOBALS['digitalogic_test_current_user_id'] = 9;
+		$GLOBALS['digitalogic_test_current_user']    = (object) array(
+			'ID'           => 9,
+			'user_login'   => 'mahdi',
+			'display_name' => 'مدیر فروشگاه',
+		);
+
+		ob_start();
+		Digitalogic_Panel_Error_Page::render( 403, 'panel-access-denied' );
+		$html = (string) ob_get_clean();
+
+		$this->assertStringContainsString( '<html lang="fa-IR" dir="rtl">', $html );
+		$this->assertStringContainsString( 'این حساب به پنل دسترسی ندارد', $html );
+		$this->assertStringContainsString( 'ورود با حساب دیگر', $html );
+		$this->assertStringContainsString( 'مدیر فروشگاه', $html );
+	}
+
+	/**
+	 * The reusable renderer exposes non-authorization plugin failures too.
+	 */
+	public function test_renderer_supports_other_plugin_error_statuses(): void {
+		$view = Digitalogic_Panel_Error_Page::view_model( 503, 'laravel-unavailable' );
+
+		$this->assertSame( 503, $view['status'] );
+		$this->assertSame( 'DG-LARAVEL-UNAVAILABLE', $view['code'] );
+		$this->assertSame( 'ltr', $view['direction'] );
+		$this->assertStringContainsString( 'not ready', $view['title'] );
+	}
+}

--- a/tests/PanelErrorPageTest.php
+++ b/tests/PanelErrorPageTest.php
@@ -86,4 +86,93 @@ final class PanelErrorPageTest extends TestCase {
 		$this->assertSame( 'ltr', $view['direction'] );
 		$this->assertStringContainsString( 'not ready', $view['title'] );
 	}
+
+	/**
+	 * Each protected browser surface gets specific copy and a safe admin route.
+	 */
+	public function test_protected_admin_contexts_have_specific_copy_and_recovery_actions(): void {
+		$GLOBALS['digitalogic_test_current_user_id'] = 18;
+
+		$contexts = array(
+			Digitalogic_Panel_Error_Page::CONTEXT_PATRIS_REPORTS      => 'Patris reports',
+			Digitalogic_Panel_Error_Page::CONTEXT_PRODUCT_DIAGNOSTICS => 'Product diagnostics',
+			Digitalogic_Panel_Error_Page::CONTEXT_UI_SETTINGS         => 'Digitalogic interface settings',
+		);
+
+		foreach ( $contexts as $context => $expected_title ) {
+			$view = Digitalogic_Panel_Error_Page::view_model(
+				403,
+				$context . '-access-denied',
+				'',
+				array( 'context' => $context )
+			);
+
+			$this->assertSame( $context, $view['context'] );
+			$this->assertStringContainsString( $expected_title, $view['title'] );
+			$this->assertSame( 'https://digitalogic.test/wp-admin/', $view['actions'][0]['url'] );
+			$this->assertTrue( $view['actions'][0]['primary'] );
+		}
+	}
+
+	/**
+	 * Public comment blocks do not suggest authentication or reveal guard details.
+	 */
+	public function test_comment_guard_context_has_localized_public_recovery_action(): void {
+		$GLOBALS['digitalogic_test_locale'] = 'fa_IR';
+
+		$view = Digitalogic_Panel_Error_Page::view_model(
+			403,
+			'comment-network-blocked',
+			'',
+			array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_COMMENT_GUARD )
+		);
+
+		$this->assertSame( Digitalogic_Panel_Error_Page::CONTEXT_COMMENT_GUARD, $view['context'] );
+		$this->assertSame( 'امکان پذیرش این دیدگاه نبود', $view['title'] );
+		$this->assertSame( 'ارسال دیدگاه از این شبکه پذیرفته نشد.', $view['detail'] );
+		$this->assertCount( 1, $view['actions'] );
+		$this->assertSame( 'بازگشت به فروشگاه', $view['actions'][0]['label'] );
+		$this->assertSame( 'https://digitalogic.test/', $view['actions'][0]['url'] );
+	}
+
+	/**
+	 * Admin callbacks render a card without nesting a second HTML document.
+	 */
+	public function test_admin_mode_is_embedded_in_the_existing_document(): void {
+		$GLOBALS['digitalogic_test_current_user_id'] = 18;
+
+		ob_start();
+		Digitalogic_Panel_Error_Page::render_admin(
+			403,
+			'patris-reports-access-denied',
+			'',
+			array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_PATRIS_REPORTS )
+		);
+		$html = (string) ob_get_clean();
+
+		$this->assertSame( array(), $GLOBALS['digitalogic_test_status_headers'] );
+		$this->assertSame( 0, $GLOBALS['digitalogic_test_nocache_headers'] );
+		$this->assertStringContainsString( 'class="wrap digitalogic-error-embedded"', $html );
+		$this->assertStringContainsString( 'DG-PATRIS-REPORTS-ACCESS-DENIED', $html );
+		$this->assertStringNotContainsString( '<!doctype html>', $html );
+		$this->assertStringNotContainsString( '<html', $html );
+		$this->assertStringNotContainsString( '<body', $html );
+	}
+
+	/**
+	 * Browser-facing plugin denials no longer invoke WordPress' raw die screen.
+	 */
+	public function test_browser_error_call_sites_do_not_use_raw_wp_die(): void {
+		$paths = array(
+			dirname( __DIR__ ) . '/includes/admin/class-admin.php',
+			dirname( __DIR__ ) . '/includes/integrations/class-comment-guard.php',
+		);
+
+		foreach ( $paths as $path ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source audit.
+			$source = file_get_contents( $path );
+			$this->assertIsString( $source );
+			$this->assertDoesNotMatchRegularExpression( '/\\bwp_die\\s*\\(/', $source, $path );
+		}
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,9 @@ define('ARRAY_A', 'ARRAY_A');
 define('MINUTE_IN_SECONDS', 60);
 define('HOUR_IN_SECONDS', 3600);
 define('DAY_IN_SECONDS', 86400);
+define('DIGITALOGIC_VERSION', 'test');
+define('DIGITALOGIC_PLUGIN_DIR', dirname(__DIR__) . '/');
+define('DIGITALOGIC_PLUGIN_URL', 'https://digitalogic.test/wp-content/plugins/digitalogic-wp/');
 
 // phpcs:disable Generic.Formatting.MultipleStatementAlignment -- Preserve the intentionally simple test-global registry.
 $GLOBALS['digitalogic_test_capabilities'] = array();
@@ -18,6 +21,14 @@ $GLOBALS['digitalogic_test_routes'] = array();
 $GLOBALS['digitalogic_test_rest_prefix'] = 'wp-json';
 $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
 $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
+$GLOBALS['digitalogic_test_current_user_id'] = 0;
+$GLOBALS['digitalogic_test_current_user'] = (object) array(
+    'ID' => 0,
+    'user_login' => '',
+    'display_name' => '',
+);
+$GLOBALS['digitalogic_test_status_headers'] = array();
+$GLOBALS['digitalogic_test_nocache_headers'] = 0;
 $GLOBALS['digitalogic_test_options'] = array();
 $GLOBALS['digitalogic_test_option_cache'] = array();
 $GLOBALS['digitalogic_test_actions'] = array();
@@ -268,6 +279,51 @@ function current_user_can($capability) {
     $GLOBALS['digitalogic_test_current_user_can_calls']++;
 
     return !empty($GLOBALS['digitalogic_test_capabilities'][$capability]);
+}
+
+function get_current_user_id() {
+    return (int) $GLOBALS['digitalogic_test_current_user_id'];
+}
+
+function wp_get_current_user() {
+    return $GLOBALS['digitalogic_test_current_user'];
+}
+
+function is_user_logged_in() {
+    return get_current_user_id() > 0;
+}
+
+function wp_login_url($redirect = '', $force_reauth = false) {
+    $url = 'https://digitalogic.test/wp-login.php';
+    return $redirect !== '' ? $url . '?redirect_to=' . rawurlencode((string) $redirect) : $url;
+}
+
+function wp_logout_url($redirect = '') {
+    $url = 'https://digitalogic.test/wp-login.php?action=logout';
+    return $redirect !== '' ? $url . '&redirect_to=' . rawurlencode((string) $redirect) : $url;
+}
+
+function status_header($status_code) {
+    $GLOBALS['digitalogic_test_status_headers'][] = (int) $status_code;
+}
+
+function nocache_headers() {
+    $GLOBALS['digitalogic_test_nocache_headers']++;
+}
+
+function wp_enqueue_style($handle, $src = '', $dependencies = array(), $version = false, $media = 'all') {
+    $GLOBALS['digitalogic_test_enqueued_styles'][$handle] = compact('src', 'dependencies', 'version', 'media');
+}
+
+function wp_print_styles($handles = false) {
+    $handles = false === $handles ? array_keys($GLOBALS['digitalogic_test_enqueued_styles']) : (array) $handles;
+    foreach ($handles as $handle) {
+        if (!isset($GLOBALS['digitalogic_test_enqueued_styles'][$handle])) {
+            continue;
+        }
+        $style = $GLOBALS['digitalogic_test_enqueued_styles'][$handle];
+        echo '<link rel="stylesheet" href="' . esc_url($style['src']) . '">';
+    }
 }
 
 function add_filter($hook_name, $callback, $priority = 10, $accepted_args = 1) {
@@ -2020,6 +2076,8 @@ require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-date-forma
 require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-shortcodes.php';
 require_once dirname(__DIR__) . '/includes/class-unit-converter.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-woocommerce-currency-status.php';
+require_once dirname(__DIR__) . '/includes/class-digitalogic-access-control.php';
+require_once dirname(__DIR__) . '/includes/panel/class-digitalogic-panel-error-page.php';
 require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-query.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-metadata-inspector.php'; // phpcs:ignore


### PR DESCRIPTION
## What changed

- introduces one WordPress-native panel authorization predicate used by the browser panel, in-process Laravel bridge, command dispatcher, and authenticated WebSocket path
- keeps `manage_woocommerce` as the primary operator capability and adds `manage_options` as an administrator safety fallback
- explicitly leaves customer/subscriber users denied
- replaces plugin-owned raw `wp_die()` access responses with a standalone Digitalogic error renderer
- supports reusable 400/401/403/404/500/503 documents with English/Persian copy, RTL/LTR, light/dark styling, escaped content, account recovery actions, and stable support references
- records the behavior in the changelog and adds focused policy/rendering tests

## Why

The reported page was reached through a valid WordPress session, but the authorization failure fell through to WordPress's generic die page and Query Monitor exposed the call stack. A separate production diagnosis found the deeper source defect: the live storefront request CPT pollutes WordPress's global meta-cap map. That exact three-capability correction is being reconciled with the currently divergent production storefront branch and is intentionally not hidden by this fallback.

No second login, bearer handoff, or Laravel identity boundary is introduced.

## Validation

- PHPUnit: 208 tests, 1,213 assertions; 5 pre-existing skips and 1 pre-existing warning
- focused WPCS: clean
- PHP syntax checks: clean
- product-query Node tests: 7/7 pass
- `git diff --check`: clean

Part of #108.

Review state: pending owner approval. Comment `@codex` with requested corrections.