### PR TITLE
Fix storefront capability mapping and panel errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Prevent the private storefront request post type from registering `manage_woocommerce` as an object meta capability, which caused WordPress to deny valid administrator and shop-manager access across the panel, admin, REST, and WebSocket paths.
+
 ## 1.6.1
 
 - Preserve WordPress account-policy authentication filters while exempting only WP Zero Spam's core form honeypot from a signed, browser-bound PBX login consume request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Prevent the private storefront request post type from registering `manage_woocommerce` as an object meta capability, which caused WordPress to deny valid administrator and shop-manager access across the panel, admin, REST, and WebSocket paths.
+- Add reusable Digitalogic browser error pages with responsive light/dark styling, English and Persian copy, RTL/LTR layout, safe recovery actions, and stable support references.
+- Replace the panel's raw WordPress `wp_die()` authorization response and centralize its WordPress capability policy without granting storefront customers access.
 
 ## 1.6.1
 

--- a/assets/css/panel-error.css
+++ b/assets/css/panel-error.css
@@ -1,0 +1,291 @@
+@font-face {
+    font-family: "DigitalogicFanum";
+    src: url("https://digitalogic.ir/wp-content/themes/woodmart-child/fonts/woff2/IRANSansWeb%28FaNum%29.woff2") format("woff2");
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "DigitalogicFanum";
+    src: url("https://digitalogic.ir/wp-content/themes/woodmart-child/fonts/woff2/IRANSansWeb%28FaNum%29_Bold.woff2") format("woff2");
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+}
+
+:root {
+    color-scheme: light dark;
+    --dle-bg: #eef6fb;
+    --dle-card: rgba(255, 255, 255, 0.9);
+    --dle-text: #122f46;
+    --dle-muted: #607688;
+    --dle-border: rgba(17, 105, 216, 0.14);
+    --dle-accent: #0fa7eb;
+    --dle-accent-strong: #1169d8;
+    --dle-accent-soft: rgba(15, 167, 235, 0.12);
+    --dle-shadow: 0 32px 90px rgba(18, 52, 78, 0.18);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body.digitalogic-error-body {
+    min-height: 100%;
+}
+
+body.digitalogic-error-body {
+    margin: 0;
+    color: var(--dle-text);
+    font-family: "DigitalogicFanum", "Segoe UI", Tahoma, system-ui, sans-serif;
+    background:
+        radial-gradient(circle at 12% 16%, rgba(15, 167, 235, 0.22), transparent 30rem),
+        radial-gradient(circle at 88% 84%, rgba(17, 105, 216, 0.18), transparent 32rem),
+        linear-gradient(135deg, var(--dle-bg), #f8fbfe 52%, #e7f2fa);
+}
+
+.digitalogic-error-body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0.18;
+    background-image: linear-gradient(rgba(17, 105, 216, 0.12) 1px, transparent 1px), linear-gradient(90deg, rgba(17, 105, 216, 0.12) 1px, transparent 1px);
+    background-size: 44px 44px;
+    mask-image: linear-gradient(to bottom, black, transparent 80%);
+}
+
+.dle-shell {
+    position: relative;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    padding: 32px 18px;
+}
+
+.dle-card {
+    width: min(100%, 720px);
+    padding: clamp(28px, 6vw, 58px);
+    overflow: hidden;
+    border: 1px solid var(--dle-border);
+    border-radius: 30px;
+    background: var(--dle-card);
+    box-shadow: var(--dle-shadow);
+    backdrop-filter: blur(22px);
+}
+
+.dle-brand,
+.dle-brand > span,
+.dle-user,
+.dle-actions,
+.dle-footer {
+    display: flex;
+    align-items: center;
+}
+
+.dle-brand {
+    gap: 13px;
+    margin-bottom: 48px;
+}
+
+.dle-brand > span:last-child {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.dle-brand strong {
+    font-size: 1.05rem;
+    letter-spacing: 0.01em;
+}
+
+.dle-brand small {
+    color: var(--dle-muted);
+    font-size: 0.78rem;
+}
+
+.dle-logo {
+    width: 52px;
+    height: 52px;
+    padding: 9px;
+    border: 1px solid var(--dle-border);
+    border-radius: 17px;
+    background: rgba(255, 255, 255, 0.72);
+    box-shadow: 0 12px 30px rgba(18, 52, 78, 0.1);
+}
+
+.dle-logo img {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.dle-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    margin-bottom: 18px;
+    padding: 8px 12px;
+    border: 1px solid rgba(217, 79, 92, 0.18);
+    border-radius: 999px;
+    color: #b52e44;
+    background: rgba(217, 79, 92, 0.08);
+}
+
+.dle-status svg,
+.dle-user svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+}
+
+.dle-status-code {
+    font-family: "Cascadia Code", Consolas, monospace;
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+.dle-eyebrow {
+    margin: 0 0 8px;
+    color: var(--dle-accent-strong);
+    font-size: 0.86rem;
+    font-weight: 700;
+}
+
+.dle-card h1 {
+    max-width: 620px;
+    margin: 0;
+    font-size: clamp(2rem, 6vw, 3.7rem);
+    line-height: 1.12;
+    letter-spacing: -0.035em;
+}
+
+[dir="rtl"] .dle-card h1 {
+    letter-spacing: 0;
+}
+
+.dle-detail {
+    max-width: 610px;
+    margin: 22px 0 0;
+    color: var(--dle-muted);
+    font-size: clamp(1rem, 2.4vw, 1.14rem);
+    line-height: 1.9;
+}
+
+.dle-user {
+    width: fit-content;
+    gap: 8px;
+    margin: 26px 0 0;
+    padding: 10px 13px;
+    border-radius: 12px;
+    color: var(--dle-muted);
+    background: var(--dle-accent-soft);
+    font-size: 0.88rem;
+}
+
+.dle-actions {
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 34px;
+}
+
+.dle-button {
+    min-height: 46px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border: 1px solid var(--dle-border);
+    border-radius: 13px;
+    color: var(--dle-text);
+    background: rgba(255, 255, 255, 0.62);
+    font-weight: 700;
+    text-decoration: none;
+    transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.dle-button:hover {
+    transform: translateY(-2px);
+    border-color: rgba(17, 105, 216, 0.34);
+    box-shadow: 0 10px 24px rgba(18, 52, 78, 0.1);
+}
+
+.dle-button:focus-visible {
+    outline: 3px solid rgba(15, 167, 235, 0.28);
+    outline-offset: 3px;
+}
+
+.dle-button.is-primary {
+    border-color: transparent;
+    color: #fff;
+    background: linear-gradient(135deg, var(--dle-accent), var(--dle-accent-strong));
+    box-shadow: 0 14px 30px rgba(17, 105, 216, 0.22);
+}
+
+.dle-footer {
+    gap: 9px;
+    margin-top: 42px;
+    padding-top: 20px;
+    border-top: 1px solid var(--dle-border);
+    color: var(--dle-muted);
+    font-size: 0.78rem;
+}
+
+.dle-footer code {
+    padding: 4px 8px;
+    border-radius: 7px;
+    color: var(--dle-accent-strong);
+    background: var(--dle-accent-soft);
+    font-family: "Cascadia Code", Consolas, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --dle-bg: #08131e;
+        --dle-card: rgba(14, 25, 39, 0.9);
+        --dle-text: #eff8ff;
+        --dle-muted: #9fb3c2;
+        --dle-border: rgba(120, 171, 210, 0.2);
+        --dle-accent: #16b9f2;
+        --dle-accent-strong: #79cfff;
+        --dle-accent-soft: rgba(15, 167, 235, 0.14);
+        --dle-shadow: 0 34px 100px rgba(0, 0, 0, 0.48);
+    }
+
+    body.digitalogic-error-body {
+        background: radial-gradient(circle at 12% 16%, rgba(15, 167, 235, 0.2), transparent 30rem), linear-gradient(135deg, #08131e, #0d1d2b 54%, #101825);
+    }
+
+    .dle-logo,
+    .dle-button {
+        background: rgba(255, 255, 255, 0.05);
+    }
+
+    .dle-status {
+        color: #ff92a2;
+    }
+}
+
+@media (max-width: 560px) {
+    .dle-card {
+        border-radius: 22px;
+    }
+
+    .dle-brand {
+        margin-bottom: 34px;
+    }
+
+    .dle-actions,
+    .dle-button {
+        width: 100%;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .dle-button {
+        transition: none;
+    }
+}

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -113,6 +113,8 @@ final class Digitalogic {
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-options.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-currency-shortcodes.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-woocommerce-currency-status.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-access-control.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/panel/class-digitalogic-panel-error-page.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-logger.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-query.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-manager.php';

--- a/includes/class-command-dispatcher.php
+++ b/includes/class-command-dispatcher.php
@@ -54,7 +54,7 @@ class Digitalogic_Command_Dispatcher {
         }
 
         $requires_auth = (bool) apply_filters('digitalogic_command_requires_auth', true, $command, $payload, $transport);
-        if ($requires_auth && !current_user_can('manage_woocommerce')) {
+        if ($requires_auth && !Digitalogic_Access_Control::can_access_panel()) {
             return new WP_Error('digitalogic_unauthorized', __('Unauthorized', 'digitalogic'), array('status' => 403));
         }
 

--- a/includes/class-digitalogic-access-control.php
+++ b/includes/class-digitalogic-access-control.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Shared WordPress-native authorization policy for the Digitalogic panel.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Central access predicate shared by every panel transport.
+ */
+final class Digitalogic_Access_Control {
+
+	/**
+	 * Check whether the current WordPress user can operate the Digitalogic panel.
+	 *
+	 * WooCommerce managers remain the primary operator role. The manage_options
+	 * fallback keeps WordPress administrators in control when a custom role or
+	 * another plugin has altered WooCommerce's role capabilities.
+	 *
+	 * @return bool
+	 */
+	public static function can_access_panel() {
+		$capabilities = (array) apply_filters(
+			'digitalogic_panel_access_capabilities',
+			array( 'manage_woocommerce', 'manage_options' )
+		);
+
+		$allowed = false;
+		foreach ( array_unique( array_filter( array_map( 'sanitize_key', $capabilities ) ) ) as $capability ) {
+			if ( current_user_can( $capability ) ) {
+				$allowed = true;
+				break;
+			}
+		}
+
+		return (bool) apply_filters(
+			'digitalogic_panel_access_allowed',
+			$allowed,
+			get_current_user_id(),
+			$capabilities
+		);
+	}
+}

--- a/includes/integrations/class-laravel-bridge.php
+++ b/includes/integrations/class-laravel-bridge.php
@@ -135,12 +135,9 @@ class Digitalogic_Laravel_Bridge {
     public function handle_panel_launch() {
         check_admin_referer('digitalogic_laravel_panel_launch');
 
-        if (!current_user_can('manage_woocommerce')) {
-            wp_die(
-                esc_html__('You are not allowed to open the Digitalogic panel.', 'digitalogic'),
-                esc_html__('Forbidden', 'digitalogic'),
-                array('response' => 403)
-            );
+        if ( ! Digitalogic_Access_Control::can_access_panel() ) {
+            Digitalogic_Panel_Error_Page::render( 403, 'panel-access-denied' );
+            exit;
         }
 
         $return_to = isset($_GET['return_to']) ? esc_url_raw(wp_unslash($_GET['return_to'])) : '';

--- a/includes/integrations/class-storefront-order-forms.php
+++ b/includes/integrations/class-storefront-order-forms.php
@@ -73,9 +73,9 @@ final class Digitalogic_Storefront_Order_Forms {
 				'supports'     => array( 'title', 'author' ),
 				'map_meta_cap' => true,
 				'capabilities' => array(
-					'edit_post'              => 'manage_woocommerce',
-					'read_post'              => 'manage_woocommerce',
-					'delete_post'            => 'manage_woocommerce',
+					'edit_post'              => 'edit_digitalogic_request',
+					'read_post'              => 'read_digitalogic_request',
+					'delete_post'            => 'delete_digitalogic_request',
 					'edit_posts'             => 'manage_woocommerce',
 					'edit_others_posts'      => 'manage_woocommerce',
 					'publish_posts'          => 'manage_woocommerce',

--- a/includes/panel/class-digitalogic-panel-error-page.php
+++ b/includes/panel/class-digitalogic-panel-error-page.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Standalone branded error pages for Digitalogic-owned browser routes.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Renders plugin-owned browser errors without the generic WordPress die page.
+ */
+final class Digitalogic_Panel_Error_Page {
+
+	/**
+	 * Render a complete localized error document.
+	 *
+	 * This intentionally avoids wp_die() so plugin errors never fall back to the
+	 * generic WordPress error screen or expose a Query Monitor call stack.
+	 *
+	 * @param int    $status  HTTP status.
+	 * @param string $code    Stable support reference.
+	 * @param string $message Optional message override.
+	 * @param array  $args    Optional title, eyebrow, actions, and detail values.
+	 * @return void
+	 */
+	public static function render( $status, $code, $message = '', $args = array() ) {
+		$status = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
+		$view   = self::view_model( $status, $code, $message, $args );
+
+		nocache_headers();
+		status_header( $status );
+		wp_enqueue_style(
+			'digitalogic-panel-error',
+			DIGITALOGIC_PLUGIN_URL . 'assets/css/panel-error.css',
+			array(),
+			DIGITALOGIC_VERSION
+		);
+
+		include DIGITALOGIC_PLUGIN_DIR . 'includes/panel/views/error.php';
+	}
+
+	/**
+	 * Build an escaped-at-output view model for the error template.
+	 *
+	 * @param int    $status  HTTP status.
+	 * @param string $code    Stable support reference.
+	 * @param string $message Optional message override.
+	 * @param array  $args    Optional overrides.
+	 * @return array
+	 */
+	public static function view_model( $status, $code, $message = '', $args = array() ) {
+		$status = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
+		$locale = determine_locale();
+		$is_fa  = 0 === strpos( strtolower( (string) $locale ), 'fa' );
+		$copy   = self::copy( $status, $is_fa );
+		$user   = wp_get_current_user();
+
+		$defaults = array(
+			'eyebrow' => $copy['eyebrow'],
+			'title'   => $copy['title'],
+			'detail'  => $copy['detail'],
+			'actions' => self::default_actions( $status, $is_fa ),
+		);
+		$args     = wp_parse_args( $args, $defaults );
+
+		if ( '' !== trim( (string) $message ) ) {
+			$args['detail'] = $message;
+		}
+
+		$reference = strtoupper( preg_replace( '/[^A-Za-z0-9_-]+/', '-', (string) $code ) );
+		$reference = trim( $reference, '-' );
+		if ( '' === $reference ) {
+			$reference = 'PANEL-ERROR';
+		}
+
+		$display_name = '';
+		if ( is_user_logged_in() && is_object( $user ) ) {
+			$display_name = trim( (string) ( $user->display_name ?? $user->user_login ?? '' ) );
+		}
+
+		$view = array(
+			'status'          => (int) $status,
+			'code'            => 'DG-' . $reference,
+			'locale'          => str_replace( '_', '-', (string) $locale ),
+			'direction'       => $is_fa ? 'rtl' : 'ltr',
+			'eyebrow'         => (string) $args['eyebrow'],
+			'title'           => (string) $args['title'],
+			'detail'          => (string) $args['detail'],
+			'actions'         => is_array( $args['actions'] ) ? $args['actions'] : array(),
+			'site_name'       => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+			'logo_url'        => DIGITALOGIC_PLUGIN_URL . 'assets/images/icon.svg',
+			'style_handle'    => 'digitalogic-panel-error',
+			'signed_in_label' => $display_name ? sprintf( $copy['signed_in'], $display_name ) : '',
+			'reference_label' => $copy['reference'],
+		);
+
+		return (array) apply_filters( 'digitalogic_panel_error_view_model', $view, $status, $code );
+	}
+
+	/**
+	 * Return complete English or Persian copy for a supported status.
+	 *
+	 * @param int  $status HTTP status.
+	 * @param bool $is_fa  Whether Persian copy is required.
+	 * @return array
+	 */
+	private static function copy( $status, $is_fa ) {
+		$english = array(
+			400 => array(
+				'eyebrow' => 'Invalid request',
+				'title'   => 'We could not process this request',
+				'detail'  => 'Check the requested address or values and try again.',
+			),
+			401 => array(
+				'eyebrow' => 'Sign-in required',
+				'title'   => 'Please sign in to continue',
+				'detail'  => 'The Digitalogic panel uses your existing WordPress session.',
+			),
+			403 => array(
+				'eyebrow' => 'Access restricted',
+				'title'   => 'This account does not have panel access',
+				'detail'  => 'You are signed in, but this WordPress account is not assigned store-management access. Ask a site administrator or sign in with another account.',
+			),
+			404 => array(
+				'eyebrow' => 'Page not found',
+				'title'   => 'That Digitalogic page is not here',
+				'detail'  => 'The address may have changed, or the page may no longer be available.',
+			),
+			500 => array(
+				'eyebrow' => 'Unexpected error',
+				'title'   => 'Digitalogic could not complete this request',
+				'detail'  => 'Nothing was changed. Try again, or share the reference below with support.',
+			),
+			503 => array(
+				'eyebrow' => 'Temporarily unavailable',
+				'title'   => 'The Digitalogic service is not ready',
+				'detail'  => 'The service is starting or undergoing maintenance. Please try again shortly.',
+			),
+		);
+		$persian = array(
+			400 => array(
+				'eyebrow' => 'درخواست نامعتبر',
+				'title'   => 'امکان پردازش این درخواست نبود',
+				'detail'  => 'نشانی یا اطلاعات واردشده را بررسی کنید و دوباره تلاش کنید.',
+			),
+			401 => array(
+				'eyebrow' => 'نیاز به ورود',
+				'title'   => 'برای ادامه وارد حساب شوید',
+				'detail'  => 'پنل دیجیتالوجیک از همان نشست وردپرس شما استفاده می‌کند.',
+			),
+			403 => array(
+				'eyebrow' => 'دسترسی محدود',
+				'title'   => 'این حساب به پنل دسترسی ندارد',
+				'detail'  => 'شما وارد شده‌اید، اما این حساب وردپرس دسترسی مدیریت فروشگاه را ندارد. با مدیر سایت هماهنگ کنید یا با حساب دیگری وارد شوید.',
+			),
+			404 => array(
+				'eyebrow' => 'صفحه پیدا نشد',
+				'title'   => 'این صفحه دیجیتالوجیک در دسترس نیست',
+				'detail'  => 'ممکن است نشانی صفحه تغییر کرده باشد یا دیگر در دسترس نباشد.',
+			),
+			500 => array(
+				'eyebrow' => 'خطای پیش‌بینی‌نشده',
+				'title'   => 'انجام این درخواست ممکن نشد',
+				'detail'  => 'هیچ تغییری انجام نشد. دوباره تلاش کنید یا کد پیگیری زیر را برای پشتیبانی بفرستید.',
+			),
+			503 => array(
+				'eyebrow' => 'موقتاً در دسترس نیست',
+				'title'   => 'سرویس دیجیتالوجیک هنوز آماده نیست',
+				'detail'  => 'سرویس در حال راه‌اندازی یا نگهداری است. کمی بعد دوباره تلاش کنید.',
+			),
+		);
+
+		$set = $is_fa ? $persian : $english;
+		return array_merge(
+			$set[ $status ],
+			array(
+				'signed_in' => $is_fa ? 'واردشده با حساب %s' : 'Signed in as %s',
+				'reference' => $is_fa ? 'کد پیگیری' : 'Reference',
+			)
+		);
+	}
+
+	/**
+	 * Build safe recovery actions for the current authentication state.
+	 *
+	 * @param int  $status HTTP status.
+	 * @param bool $is_fa  Whether Persian labels are required.
+	 * @return array
+	 */
+	private static function default_actions( $status, $is_fa ) {
+		$panel_url = home_url( '/panel/' );
+		$actions   = array();
+
+		if ( 401 === $status || ! is_user_logged_in() ) {
+			$actions[] = array(
+				'label'   => $is_fa ? 'ورود به پنل' : 'Sign in to the panel',
+				'url'     => wp_login_url( $panel_url ),
+				'primary' => true,
+			);
+		} elseif ( 403 === $status ) {
+			$actions[] = array(
+				'label'   => $is_fa ? 'ورود با حساب دیگر' : 'Use another account',
+				'url'     => wp_logout_url( wp_login_url( $panel_url ) ),
+				'primary' => true,
+			);
+			$actions[] = array(
+				'label' => $is_fa ? 'نمایه وردپرس' : 'WordPress profile',
+				'url'   => admin_url( 'profile.php' ),
+			);
+		} else {
+			$actions[] = array(
+				'label'   => $is_fa ? 'تلاش دوباره' : 'Try again',
+				'url'     => $panel_url,
+				'primary' => true,
+			);
+		}
+
+		$actions[] = array(
+			'label' => $is_fa ? 'بازگشت به فروشگاه' : 'Return to the store',
+			'url'   => home_url( '/' ),
+		);
+
+		return $actions;
+	}
+}

--- a/includes/panel/class-panel.php
+++ b/includes/panel/class-panel.php
@@ -111,12 +111,9 @@ class Digitalogic_Panel {
             auth_redirect();
         }
 
-        if (!current_user_can('manage_woocommerce')) {
-            wp_die(
-                esc_html__('You are not allowed to open the Digitalogic panel.', 'digitalogic'),
-                esc_html__('Forbidden', 'digitalogic'),
-                array('response' => 403)
-            );
+        if ( ! Digitalogic_Access_Control::can_access_panel() ) {
+            Digitalogic_Panel_Error_Page::render( 403, 'panel-access-denied' );
+            exit;
         }
 
         $this->enqueue_assets();

--- a/includes/panel/views/error.php
+++ b/includes/panel/views/error.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Digitalogic panel error view.
+ *
+ * @package Digitalogic
+ * @var array $view Digitalogic panel error view model.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?><!doctype html>
+<html lang="<?php echo esc_attr( $view['locale'] ); ?>" dir="<?php echo esc_attr( $view['direction'] ); ?>">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="robots" content="noindex,nofollow,noarchive">
+	<title><?php echo esc_html( $view['title'] . ' — ' . $view['site_name'] ); ?></title>
+	<?php wp_print_styles( $view['style_handle'] ); ?>
+</head>
+<body class="digitalogic-error-body">
+	<main class="dle-shell">
+		<section class="dle-card" aria-labelledby="dle-title" aria-describedby="dle-detail">
+			<div class="dle-brand">
+				<span class="dle-logo"><img src="<?php echo esc_url( $view['logo_url'] ); ?>" alt=""></span>
+				<span><strong>Digitalogic</strong><small><?php echo esc_html( $view['site_name'] ); ?></small></span>
+			</div>
+
+			<div class="dle-status" aria-hidden="true">
+				<span class="dle-status-code"><?php echo esc_html( $view['status'] ); ?></span>
+				<svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 5.25a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm1.15 9.5h-2.3v-5.5h2.3v5.5Z"/></svg>
+			</div>
+
+			<p class="dle-eyebrow"><?php echo esc_html( $view['eyebrow'] ); ?></p>
+			<h1 id="dle-title"><?php echo esc_html( $view['title'] ); ?></h1>
+			<p class="dle-detail" id="dle-detail"><?php echo esc_html( $view['detail'] ); ?></p>
+
+			<?php if ( '' !== $view['signed_in_label'] ) : ?>
+				<p class="dle-user">
+					<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-5.33 0-8 2.67-8 5v1.5h16V19c0-2.33-2.67-5-8-5Z"/></svg>
+					<?php echo esc_html( $view['signed_in_label'] ); ?>
+				</p>
+			<?php endif; ?>
+
+			<nav class="dle-actions" aria-label="<?php echo esc_attr( $view['eyebrow'] ); ?>">
+				<?php foreach ( $view['actions'] as $error_action ) : ?>
+					<a class="dle-button<?php echo ! empty( $error_action['primary'] ) ? ' is-primary' : ''; ?>" href="<?php echo esc_url( $error_action['url'] ?? '' ); ?>">
+						<?php echo esc_html( $error_action['label'] ?? '' ); ?>
+					</a>
+				<?php endforeach; ?>
+			</nav>
+
+			<footer class="dle-footer">
+				<span><?php echo esc_html( $view['reference_label'] ); ?></span>
+				<code dir="ltr"><?php echo esc_html( $view['code'] ); ?></code>
+			</footer>
+		</section>
+	</main>
+</body>
+</html>

--- a/includes/websocket/class-websocket-auth.php
+++ b/includes/websocket/class-websocket-auth.php
@@ -53,7 +53,7 @@ class Digitalogic_WebSocket_Auth {
             return 0;
         }
 
-        return current_user_can('manage_woocommerce') ? $user_id : 0;
+        return Digitalogic_Access_Control::can_access_panel() ? $user_id : 0;
     }
 
     private static function parse_cookie_header($header) {

--- a/includes/websocket/class-websocket-server.php
+++ b/includes/websocket/class-websocket-server.php
@@ -178,7 +178,7 @@ class Digitalogic_WebSocket_Server {
 
         wp_set_current_user(max(0, (int) $this->clients[$id]['user_id']));
         if ($command === 'digitalogic_panel_events' && class_exists('Digitalogic_Panel')) {
-            if (!current_user_can('manage_woocommerce')) {
+            if ( ! Digitalogic_Access_Control::can_access_panel() ) {
                 $this->send_error($id, $request_id, 'digitalogic_unauthorized', __('Unauthorized', 'digitalogic'));
                 return;
             }

--- a/includes/websocket/class-websocket.php
+++ b/includes/websocket/class-websocket.php
@@ -38,7 +38,7 @@ class Digitalogic_WebSocket {
     }
 
     public function check_permission() {
-        return current_user_can('manage_woocommerce');
+        return Digitalogic_Access_Control::can_access_panel();
     }
 
     public function get_config_response() {
@@ -54,7 +54,7 @@ class Digitalogic_WebSocket {
             'enabled' => (bool) apply_filters('digitalogic_websocket_enabled', true),
             'url' => $default_url,
             'nonce' => wp_create_nonce('digitalogic_ws'),
-            'token' => current_user_can('manage_woocommerce') ? self::create_client_token(get_current_user_id()) : '',
+            'token' => Digitalogic_Access_Control::can_access_panel() ? self::create_client_token(get_current_user_id()) : '',
             'reconnect_interval' => 3000,
             'request_timeout' => 15000,
             'ajax_proxy_enabled' => (bool) apply_filters('digitalogic_websocket_ajax_proxy_enabled', true),
@@ -82,7 +82,7 @@ class Digitalogic_WebSocket {
     }
 
     public function enqueue_admin_proxy() {
-        if (!current_user_can('manage_woocommerce')) {
+        if ( ! Digitalogic_Access_Control::can_access_panel() ) {
             return;
         }
 
@@ -129,7 +129,7 @@ class Digitalogic_WebSocket {
         $user_id = (int) $data['user_id'];
         wp_set_current_user($user_id);
 
-        return current_user_can('manage_woocommerce') ? $user_id : 0;
+        return Digitalogic_Access_Control::can_access_panel() ? $user_id : 0;
     }
 
     public static function create_public_token() {

--- a/tests/PanelAccessControlTest.php
+++ b/tests/PanelAccessControlTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Panel access policy tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies the shared WordPress-native panel access predicate.
+ */
+final class PanelAccessControlTest extends TestCase {
+
+	/**
+	 * Reset current-user capability fixtures.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['digitalogic_test_capabilities']           = array();
+		$GLOBALS['digitalogic_test_filters']                = array();
+		$GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
+		$GLOBALS['digitalogic_test_current_user_id']        = 42;
+	}
+
+	/**
+	 * WooCommerce managers retain panel access.
+	 */
+	public function test_woocommerce_manager_can_access_panel(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_woocommerce'] = true;
+
+		$this->assertTrue( Digitalogic_Access_Control::can_access_panel() );
+	}
+
+	/**
+	 * WordPress administrators have a safe management fallback.
+	 */
+	public function test_administrator_has_safe_fallback_access(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+
+		$this->assertTrue( Digitalogic_Access_Control::can_access_panel() );
+	}
+
+	/**
+	 * Storefront-only roles never receive implicit panel access.
+	 */
+	public function test_customer_and_subscriber_capabilities_do_not_grant_access(): void {
+		$GLOBALS['digitalogic_test_capabilities']['read']     = true;
+		$GLOBALS['digitalogic_test_capabilities']['customer'] = true;
+
+		$this->assertFalse( Digitalogic_Access_Control::can_access_panel() );
+	}
+
+	/**
+	 * Integrators can add an explicit WordPress capability through the filter.
+	 */
+	public function test_integrators_can_extend_the_capability_list_explicitly(): void {
+		$GLOBALS['digitalogic_test_capabilities']['operate_digitalogic'] = true;
+		add_filter(
+			'digitalogic_panel_access_capabilities',
+			static function ( $capabilities ) {
+				$capabilities[] = 'operate_digitalogic';
+				return $capabilities;
+			}
+		);
+
+		$this->assertTrue( Digitalogic_Access_Control::can_access_panel() );
+	}
+}

--- a/tests/PanelErrorPageTest.php
+++ b/tests/PanelErrorPageTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Panel error-page tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies branded, safe, localized standalone error documents.
+ */
+final class PanelErrorPageTest extends TestCase {
+
+	/**
+	 * Reset request, locale, and user fixtures.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['digitalogic_test_filters']         = array();
+		$GLOBALS['digitalogic_test_locale']          = 'en_US';
+		$GLOBALS['digitalogic_test_current_user_id'] = 0;
+		$GLOBALS['digitalogic_test_current_user']    = (object) array(
+			'ID'           => 0,
+			'user_login'   => '',
+			'display_name' => '',
+		);
+		$GLOBALS['digitalogic_test_status_headers']  = array();
+		$GLOBALS['digitalogic_test_nocache_headers'] = 0;
+	}
+
+	/**
+	 * A forbidden response is branded, escaped, and returns HTTP 403.
+	 */
+	public function test_forbidden_page_is_branded_safe_and_sets_the_status(): void {
+		$GLOBALS['digitalogic_test_current_user_id'] = 12;
+		$GLOBALS['digitalogic_test_current_user']    = (object) array(
+			'ID'           => 12,
+			'user_login'   => 'operator',
+			'display_name' => 'Store Operator',
+		);
+
+		ob_start();
+		Digitalogic_Panel_Error_Page::render( 403, 'panel-access-denied', '<script>alert(1)</script>' );
+		$html = (string) ob_get_clean();
+
+		$this->assertSame( array( 403 ), $GLOBALS['digitalogic_test_status_headers'] );
+		$this->assertSame( 1, $GLOBALS['digitalogic_test_nocache_headers'] );
+		$this->assertStringContainsString( 'class="digitalogic-error-body"', $html );
+		$this->assertStringContainsString( 'Digitalogic', $html );
+		$this->assertStringContainsString( 'DG-PANEL-ACCESS-DENIED', $html );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $html );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+		$this->assertStringNotContainsString( 'wp-die-message', $html );
+	}
+
+	/**
+	 * Persian output is complete and uses the RTL document direction.
+	 */
+	public function test_persian_page_uses_rtl_and_complete_localized_copy(): void {
+		$GLOBALS['digitalogic_test_locale']          = 'fa_IR';
+		$GLOBALS['digitalogic_test_current_user_id'] = 9;
+		$GLOBALS['digitalogic_test_current_user']    = (object) array(
+			'ID'           => 9,
+			'user_login'   => 'mahdi',
+			'display_name' => 'مدیر فروشگاه',
+		);
+
+		ob_start();
+		Digitalogic_Panel_Error_Page::render( 403, 'panel-access-denied' );
+		$html = (string) ob_get_clean();
+
+		$this->assertStringContainsString( '<html lang="fa-IR" dir="rtl">', $html );
+		$this->assertStringContainsString( 'این حساب به پنل دسترسی ندارد', $html );
+		$this->assertStringContainsString( 'ورود با حساب دیگر', $html );
+		$this->assertStringContainsString( 'مدیر فروشگاه', $html );
+	}
+
+	/**
+	 * The reusable renderer exposes non-authorization plugin failures too.
+	 */
+	public function test_renderer_supports_other_plugin_error_statuses(): void {
+		$view = Digitalogic_Panel_Error_Page::view_model( 503, 'laravel-unavailable' );
+
+		$this->assertSame( 503, $view['status'] );
+		$this->assertSame( 'DG-LARAVEL-UNAVAILABLE', $view['code'] );
+		$this->assertSame( 'ltr', $view['direction'] );
+		$this->assertStringContainsString( 'not ready', $view['title'] );
+	}
+}

--- a/tests/PublicCatalogTransportTest.php
+++ b/tests/PublicCatalogTransportTest.php
@@ -58,7 +58,7 @@ final class PublicCatalogTransportTest extends TestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'digitalogic_unauthorized', $result->get_error_code() );
-		$this->assertSame( 1, $GLOBALS['digitalogic_test_current_user_can_calls'] );
+		$this->assertSame( 2, $GLOBALS['digitalogic_test_current_user_can_calls'] );
 	}
 
 	/** Ensure malformed payloads fail before any public-command exception. */

--- a/tests/StorefrontOrderFormsCapabilitiesTest.php
+++ b/tests/StorefrontOrderFormsCapabilitiesTest.php
@@ -7,32 +7,6 @@
 
 use PHPUnit\Framework\TestCase;
 
-if ( ! function_exists( 'register_post_type' ) ) {
-	/**
-	 * Capture post-type arguments and model WordPress's object meta-cap map.
-	 *
-	 * @param string $post_type Post-type key.
-	 * @param array  $args      Registration arguments.
-	 * @return object
-	 */
-	function register_post_type( $post_type, $args = array() ) {
-		$GLOBALS['digitalogic_test_registered_post_types'][ $post_type ] = $args;
-
-		if ( ! empty( $args['map_meta_cap'] ) ) {
-			foreach ( array( 'edit_post', 'read_post', 'delete_post' ) as $meta_cap ) {
-				$capability = $args['capabilities'][ $meta_cap ] ?? '';
-				if ( '' !== $capability ) {
-					$GLOBALS['digitalogic_test_post_type_meta_caps'][ $capability ] = $meta_cap;
-				}
-			}
-		}
-
-		return (object) array(
-			'name' => $post_type,
-		);
-	}
-}
-
 require_once dirname( __DIR__ ) . '/includes/integrations/class-storefront-order-forms.php';
 
 /**
@@ -45,7 +19,7 @@ final class StorefrontOrderFormsCapabilitiesTest extends TestCase {
 	 */
 	protected function setUp(): void {
 		$GLOBALS['digitalogic_test_registered_post_types'] = array();
-		$GLOBALS['digitalogic_test_post_type_meta_caps']    = array();
+		$GLOBALS['digitalogic_test_post_type_meta_caps']   = array();
 	}
 
 	/**

--- a/tests/StorefrontOrderFormsCapabilitiesTest.php
+++ b/tests/StorefrontOrderFormsCapabilitiesTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Storefront order-request capability tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'register_post_type' ) ) {
+	/**
+	 * Capture post-type arguments and model WordPress's object meta-cap map.
+	 *
+	 * @param string $post_type Post-type key.
+	 * @param array  $args      Registration arguments.
+	 * @return object
+	 */
+	function register_post_type( $post_type, $args = array() ) {
+		$GLOBALS['digitalogic_test_registered_post_types'][ $post_type ] = $args;
+
+		if ( ! empty( $args['map_meta_cap'] ) ) {
+			foreach ( array( 'edit_post', 'read_post', 'delete_post' ) as $meta_cap ) {
+				$capability = $args['capabilities'][ $meta_cap ] ?? '';
+				if ( '' !== $capability ) {
+					$GLOBALS['digitalogic_test_post_type_meta_caps'][ $capability ] = $meta_cap;
+				}
+			}
+		}
+
+		return (object) array(
+			'name' => $post_type,
+		);
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/integrations/class-storefront-order-forms.php';
+
+/**
+ * Prevents custom request caps from poisoning manage_woocommerce globally.
+ */
+final class StorefrontOrderFormsCapabilitiesTest extends TestCase {
+
+	/**
+	 * Reset post-type registration fixtures.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['digitalogic_test_registered_post_types'] = array();
+		$GLOBALS['digitalogic_test_post_type_meta_caps']    = array();
+	}
+
+	/**
+	 * Object caps are unique while collection operations remain manager-only.
+	 */
+	public function test_request_type_does_not_register_manage_woocommerce_as_a_meta_cap(): void {
+		$forms = ( new ReflectionClass( Digitalogic_Storefront_Order_Forms::class ) )->newInstanceWithoutConstructor();
+		$forms->register_request_type();
+
+		$args = $GLOBALS['digitalogic_test_registered_post_types']['digitalogic_request'];
+		$caps = $args['capabilities'];
+
+		$this->assertTrue( $args['map_meta_cap'] );
+		$this->assertSame( 'edit_digitalogic_request', $caps['edit_post'] );
+		$this->assertSame( 'read_digitalogic_request', $caps['read_post'] );
+		$this->assertSame( 'delete_digitalogic_request', $caps['delete_post'] );
+		$this->assertArrayNotHasKey( 'manage_woocommerce', $GLOBALS['digitalogic_test_post_type_meta_caps'] );
+
+		foreach ( array( 'edit_posts', 'edit_others_posts', 'read_private_posts', 'delete_posts' ) as $collection_cap ) {
+			$this->assertSame( 'manage_woocommerce', $caps[ $collection_cap ] );
+		}
+		$this->assertSame( 'do_not_allow', $caps['create_posts'] );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,9 @@ define('MINUTE_IN_SECONDS', 60);
 define('HOUR_IN_SECONDS', 3600);
 define('DAY_IN_SECONDS', 86400);
 // phpcs:enable
+define('DIGITALOGIC_VERSION', 'test');
+define('DIGITALOGIC_PLUGIN_DIR', dirname(__DIR__) . '/');
+define('DIGITALOGIC_PLUGIN_URL', 'https://digitalogic.test/wp-content/plugins/digitalogic-wp/');
 
 // phpcs:disable Generic.Formatting.MultipleStatementAlignment -- Preserve the intentionally simple test-global registry.
 $GLOBALS['digitalogic_test_capabilities'] = array();
@@ -20,6 +23,14 @@ $GLOBALS['digitalogic_test_routes'] = array();
 $GLOBALS['digitalogic_test_rest_prefix'] = 'wp-json';
 $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
 $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
+$GLOBALS['digitalogic_test_current_user_id'] = 0;
+$GLOBALS['digitalogic_test_current_user'] = (object) array(
+    'ID' => 0,
+    'user_login' => '',
+    'display_name' => '',
+);
+$GLOBALS['digitalogic_test_status_headers'] = array();
+$GLOBALS['digitalogic_test_nocache_headers'] = 0;
 $GLOBALS['digitalogic_test_options'] = array();
 $GLOBALS['digitalogic_test_option_cache'] = array();
 $GLOBALS['digitalogic_test_actions'] = array();
@@ -271,6 +282,51 @@ function current_user_can($capability) {
     $GLOBALS['digitalogic_test_current_user_can_calls']++;
 
     return !empty($GLOBALS['digitalogic_test_capabilities'][$capability]);
+}
+
+function get_current_user_id() {
+    return (int) $GLOBALS['digitalogic_test_current_user_id'];
+}
+
+function wp_get_current_user() {
+    return $GLOBALS['digitalogic_test_current_user'];
+}
+
+function is_user_logged_in() {
+    return get_current_user_id() > 0;
+}
+
+function wp_login_url($redirect = '', $force_reauth = false) {
+    $url = 'https://digitalogic.test/wp-login.php';
+    return $redirect !== '' ? $url . '?redirect_to=' . rawurlencode((string) $redirect) : $url;
+}
+
+function wp_logout_url($redirect = '') {
+    $url = 'https://digitalogic.test/wp-login.php?action=logout';
+    return $redirect !== '' ? $url . '&redirect_to=' . rawurlencode((string) $redirect) : $url;
+}
+
+function status_header($status_code) {
+    $GLOBALS['digitalogic_test_status_headers'][] = (int) $status_code;
+}
+
+function nocache_headers() {
+    $GLOBALS['digitalogic_test_nocache_headers']++;
+}
+
+function wp_enqueue_style($handle, $src = '', $dependencies = array(), $version = false, $media = 'all') {
+    $GLOBALS['digitalogic_test_enqueued_styles'][$handle] = compact('src', 'dependencies', 'version', 'media');
+}
+
+function wp_print_styles($handles = false) {
+    $handles = false === $handles ? array_keys($GLOBALS['digitalogic_test_enqueued_styles']) : (array) $handles;
+    foreach ($handles as $handle) {
+        if (!isset($GLOBALS['digitalogic_test_enqueued_styles'][$handle])) {
+            continue;
+        }
+        $style = $GLOBALS['digitalogic_test_enqueued_styles'][$handle];
+        echo '<link rel="stylesheet" href="' . esc_url($style['src']) . '">';
+    }
 }
 
 function add_filter($hook_name, $callback, $priority = 10, $accepted_args = 1) {
@@ -1951,6 +2007,8 @@ require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-date-forma
 require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-shortcodes.php';
 require_once dirname(__DIR__) . '/includes/class-unit-converter.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-woocommerce-currency-status.php';
+require_once dirname(__DIR__) . '/includes/class-digitalogic-access-control.php';
+require_once dirname(__DIR__) . '/includes/panel/class-digitalogic-panel-error-page.php';
 require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-query.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-metadata-inspector.php'; // phpcs:ignore

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,6 +62,8 @@ $GLOBALS['digitalogic_test_primed_post_ids'] = array();
 $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
 $GLOBALS['digitalogic_test_transients'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_transient_deletes'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_registered_post_types'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_post_type_meta_caps'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_locale'] = 'en_US';
 $GLOBALS['digitalogic_test_shortcodes'] = array();
 $GLOBALS['digitalogic_test_enqueued_styles'] = array();
@@ -282,6 +284,21 @@ function current_user_can($capability) {
     $GLOBALS['digitalogic_test_current_user_can_calls']++;
 
     return !empty($GLOBALS['digitalogic_test_capabilities'][$capability]);
+}
+
+function register_post_type($post_type, $args = array()) {
+    $GLOBALS['digitalogic_test_registered_post_types'][$post_type] = $args;
+
+    if (!empty($args['map_meta_cap'])) {
+        foreach (array('edit_post', 'read_post', 'delete_post') as $meta_cap) {
+            $capability = $args['capabilities'][$meta_cap] ?? '';
+            if ($capability !== '') {
+                $GLOBALS['digitalogic_test_post_type_meta_caps'][$capability] = $meta_cap;
+            }
+        }
+    }
+
+    return (object) array('name' => $post_type);
 }
 
 function get_current_user_id() {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,9 +12,9 @@ define('MINUTE_IN_SECONDS', 60);
 define('HOUR_IN_SECONDS', 3600);
 define('DAY_IN_SECONDS', 86400);
 // phpcs:enable
-define('DIGITALOGIC_VERSION', 'test');
-define('DIGITALOGIC_PLUGIN_DIR', dirname(__DIR__) . '/');
-define('DIGITALOGIC_PLUGIN_URL', 'https://digitalogic.test/wp-content/plugins/digitalogic-wp/');
+define( 'DIGITALOGIC_VERSION', 'test' );
+define( 'DIGITALOGIC_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+define( 'DIGITALOGIC_PLUGIN_URL', 'https://digitalogic.test/wp-content/plugins/digitalogic-wp/' );
 
 // phpcs:disable Generic.Formatting.MultipleStatementAlignment -- Preserve the intentionally simple test-global registry.
 $GLOBALS['digitalogic_test_capabilities'] = array();
@@ -25,9 +25,9 @@ $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
 $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
 $GLOBALS['digitalogic_test_current_user_id'] = 0;
 $GLOBALS['digitalogic_test_current_user'] = (object) array(
-    'ID' => 0,
-    'user_login' => '',
-    'display_name' => '',
+	'ID'           => 0,
+	'user_login'   => '',
+	'display_name' => '',
 );
 $GLOBALS['digitalogic_test_status_headers'] = array();
 $GLOBALS['digitalogic_test_nocache_headers'] = 0;
@@ -286,64 +286,136 @@ function current_user_can($capability) {
     return !empty($GLOBALS['digitalogic_test_capabilities'][$capability]);
 }
 
-function register_post_type($post_type, $args = array()) {
-    $GLOBALS['digitalogic_test_registered_post_types'][$post_type] = $args;
+/**
+ * Capture post-type arguments and model WordPress's object meta-cap map.
+ *
+ * @param string $post_type Post-type key.
+ * @param array  $args      Registration arguments.
+ * @return object
+ */
+function register_post_type( $post_type, $args = array() ) {
+	$GLOBALS['digitalogic_test_registered_post_types'][ $post_type ] = $args;
 
-    if (!empty($args['map_meta_cap'])) {
-        foreach (array('edit_post', 'read_post', 'delete_post') as $meta_cap) {
-            $capability = $args['capabilities'][$meta_cap] ?? '';
-            if ($capability !== '') {
-                $GLOBALS['digitalogic_test_post_type_meta_caps'][$capability] = $meta_cap;
-            }
-        }
-    }
+	if ( ! empty( $args['map_meta_cap'] ) ) {
+		foreach ( array( 'edit_post', 'read_post', 'delete_post' ) as $meta_cap ) {
+			$capability = $args['capabilities'][ $meta_cap ] ?? '';
+			if ( '' !== $capability ) {
+				$GLOBALS['digitalogic_test_post_type_meta_caps'][ $capability ] = $meta_cap;
+			}
+		}
+	}
 
-    return (object) array('name' => $post_type);
+	return (object) array(
+		'name' => $post_type,
+	);
 }
 
+/**
+ * Return the current test user ID.
+ *
+ * @return int
+ */
 function get_current_user_id() {
-    return (int) $GLOBALS['digitalogic_test_current_user_id'];
+	return (int) $GLOBALS['digitalogic_test_current_user_id'];
 }
 
+/**
+ * Return the current test user object.
+ *
+ * @return object
+ */
 function wp_get_current_user() {
-    return $GLOBALS['digitalogic_test_current_user'];
+	return $GLOBALS['digitalogic_test_current_user'];
 }
 
+/**
+ * Determine whether a test user is signed in.
+ *
+ * @return bool
+ */
 function is_user_logged_in() {
-    return get_current_user_id() > 0;
+	return 0 < get_current_user_id();
 }
 
-function wp_login_url($redirect = '', $force_reauth = false) {
-    $url = 'https://digitalogic.test/wp-login.php';
-    return $redirect !== '' ? $url . '?redirect_to=' . rawurlencode((string) $redirect) : $url;
+/**
+ * Build a test login URL.
+ *
+ * @param string $redirect     Redirect URL after login.
+ * @param bool   $force_reauth Whether reauthentication is requested.
+ * @return string
+ */
+function wp_login_url( $redirect = '', $force_reauth = false ) {
+	$url = 'https://digitalogic.test/wp-login.php';
+	unset( $force_reauth );
+
+	return '' !== $redirect ? $url . '?redirect_to=' . rawurlencode( (string) $redirect ) : $url;
 }
 
-function wp_logout_url($redirect = '') {
-    $url = 'https://digitalogic.test/wp-login.php?action=logout';
-    return $redirect !== '' ? $url . '&redirect_to=' . rawurlencode((string) $redirect) : $url;
+/**
+ * Build a test logout URL.
+ *
+ * @param string $redirect Redirect URL after logout.
+ * @return string
+ */
+function wp_logout_url( $redirect = '' ) {
+	$url = 'https://digitalogic.test/wp-login.php?action=logout';
+
+	return '' !== $redirect ? $url . '&redirect_to=' . rawurlencode( (string) $redirect ) : $url;
 }
 
-function status_header($status_code) {
-    $GLOBALS['digitalogic_test_status_headers'][] = (int) $status_code;
+/**
+ * Capture a test response status.
+ *
+ * @param int $status_code HTTP response status.
+ * @return void
+ */
+function status_header( $status_code ) {
+	$GLOBALS['digitalogic_test_status_headers'][] = (int) $status_code;
 }
 
+/**
+ * Record a no-cache header request.
+ *
+ * @return void
+ */
 function nocache_headers() {
-    $GLOBALS['digitalogic_test_nocache_headers']++;
+	++$GLOBALS['digitalogic_test_nocache_headers'];
 }
 
-function wp_enqueue_style($handle, $src = '', $dependencies = array(), $version = false, $media = 'all') {
-    $GLOBALS['digitalogic_test_enqueued_styles'][$handle] = compact('src', 'dependencies', 'version', 'media');
+/**
+ * Capture an enqueued test stylesheet.
+ *
+ * @param string       $handle       Stylesheet handle.
+ * @param string       $src          Stylesheet URL.
+ * @param array        $dependencies Dependency handles.
+ * @param string|false $version      Stylesheet version.
+ * @param string       $media        Stylesheet media target.
+ * @return void
+ */
+function wp_enqueue_style( $handle, $src = '', $dependencies = array(), $version = false, $media = 'all' ) {
+	$GLOBALS['digitalogic_test_enqueued_styles'][ $handle ] = array(
+		'src'          => $src,
+		'dependencies' => $dependencies,
+		'version'      => $version,
+		'media'        => $media,
+	);
 }
 
-function wp_print_styles($handles = false) {
-    $handles = false === $handles ? array_keys($GLOBALS['digitalogic_test_enqueued_styles']) : (array) $handles;
-    foreach ($handles as $handle) {
-        if (!isset($GLOBALS['digitalogic_test_enqueued_styles'][$handle])) {
-            continue;
-        }
-        $style = $GLOBALS['digitalogic_test_enqueued_styles'][$handle];
-        echo '<link rel="stylesheet" href="' . esc_url($style['src']) . '">';
-    }
+/**
+ * Print captured test stylesheet tags.
+ *
+ * @param string|array|false $handles Stylesheet handles.
+ * @return void
+ */
+function wp_print_styles( $handles = false ) {
+	$handles = false === $handles ? array_keys( $GLOBALS['digitalogic_test_enqueued_styles'] ) : (array) $handles;
+	foreach ( $handles as $handle ) {
+		if ( ! isset( $GLOBALS['digitalogic_test_enqueued_styles'][ $handle ] ) ) {
+			continue;
+		}
+		$style = $GLOBALS['digitalogic_test_enqueued_styles'][ $handle ];
+		echo '<link rel="stylesheet" href="' . esc_url( $style['src'] ) . '">';
+	}
 }
 
 function add_filter($hook_name, $callback, $priority = 10, $accepted_args = 1) {
@@ -2024,8 +2096,8 @@ require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-date-forma
 require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-shortcodes.php';
 require_once dirname(__DIR__) . '/includes/class-unit-converter.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-woocommerce-currency-status.php';
-require_once dirname(__DIR__) . '/includes/class-digitalogic-access-control.php';
-require_once dirname(__DIR__) . '/includes/panel/class-digitalogic-panel-error-page.php';
+require_once dirname( __DIR__ ) . '/includes/class-digitalogic-access-control.php';
+require_once dirname( __DIR__ ) . '/includes/panel/class-digitalogic-panel-error-page.php';
 require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-query.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-metadata-inspector.php'; // phpcs:ignore


### PR DESCRIPTION
## Root cause and correction

The private `digitalogic_request` post type enabled `map_meta_cap` while assigning `edit_post`, `read_post`, and `delete_post` to `manage_woocommerce`. WordPress registered that primitive globally as an object meta capability, so normal no-object checks mapped to `do_not_allow` for every administrator and shop manager.

This PR:

- uses unique object caps: `edit_digitalogic_request`, `read_digitalogic_request`, and `delete_digitalogic_request`
- keeps collection operations restricted to `manage_woocommerce`
- keeps request creation disabled with `do_not_allow`
- adds a regression model proving `manage_woocommerce` is never inserted into the object meta-cap registry
- centralizes panel authorization for the browser, existing Laravel bridge entry point, dispatcher, and authenticated WebSocket path while preserving the storefront's explicit public-command filter
- adds standalone Digitalogic 400/401/403/404/500/503 pages with safe English/Persian copy, RTL/LTR, responsive light/dark styling, account recovery actions, and no raw `wp_die()` stack

The production CPT hotfix was deployed as the exact three-capability delta and verified live: collision absent, administrator=true, shop_manager=true, customer=false.

## Validation

- storefront capability regression: 1 test, 10 assertions
- panel access policy: 4 tests, 4 assertions
- error renderer: 3 tests, 16 assertions
- focused WPCS: clean
- PHP syntax and diff whitespace: clean
- storefront product-query Node tests: 6/6 pass
- the branch's older full suite exceeded the local 120-second observation window; focused coverage completed normally and CI remains authoritative

This PR targets the exact v1.6.1 source deployed in production. The broader storefront-to-main reconciliation remains separately reviewable because it contains security-sensitive PBX conflicts.

Part of #108.

Review state: pending owner approval. Comment `@codex` with requested corrections.