### PR TITLE
Brand all Digitalogic browser error pages

### DIFF
--- a/assets/css/panel-error.css
+++ b/assets/css/panel-error.css
@@ -36,6 +36,10 @@ body.digitalogic-error-body {
     min-height: 100%;
 }
 
+.digitalogic-error-embedded {
+    font-family: "DigitalogicFanum", "Segoe UI", Tahoma, system-ui, sans-serif;
+}
+
 body.digitalogic-error-body {
     margin: 0;
     color: var(--dle-text);
@@ -63,6 +67,16 @@ body.digitalogic-error-body {
     display: grid;
     place-items: center;
     padding: 32px 18px;
+}
+
+.digitalogic-error-embedded .dle-shell {
+    min-height: calc(100vh - 150px);
+    padding: 24px 20px 36px 0;
+}
+
+[dir="rtl"].digitalogic-error-embedded .dle-shell {
+    padding-right: 0;
+    padding-left: 20px;
 }
 
 .dle-card {
@@ -270,6 +284,11 @@ body.digitalogic-error-body {
 }
 
 @media (max-width: 560px) {
+    .digitalogic-error-embedded .dle-shell,
+    [dir="rtl"].digitalogic-error-embedded .dle-shell {
+        padding-inline: 0;
+    }
+
     .dle-card {
         border-radius: 22px;
     }

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -682,8 +682,14 @@ class Digitalogic_Admin {
     }
 
     public function render_patris_reports_page() {
-        if (!current_user_can('manage_woocommerce')) {
-            wp_die(esc_html__('You do not have permission to manage Patris reports.', 'digitalogic'));
+		if ( ! Digitalogic_Access_Control::can_access_panel() ) {
+			Digitalogic_Panel_Error_Page::render_admin(
+				403,
+				'patris-reports-access-denied',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_PATRIS_REPORTS )
+			);
+			exit;
         }
 
         $feed = Digitalogic_Patris_Feed::instance();
@@ -829,8 +835,14 @@ class Digitalogic_Admin {
 	 * Render exact-ID/SKU metadata diagnostics and an explicit lookup refresh.
 	 */
 	public function render_product_diagnostics_page() {
-		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			wp_die( esc_html__( 'You do not have permission to access this page.', 'digitalogic' ) );
+		if ( ! Digitalogic_Access_Control::can_access_panel() ) {
+			Digitalogic_Panel_Error_Page::render_admin(
+				403,
+				'product-diagnostics-access-denied',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_PRODUCT_DIAGNOSTICS )
+			);
+			exit;
 		}
 
 		$metadata                     = null;
@@ -914,7 +926,13 @@ class Digitalogic_Admin {
      */
     public function render_ui_settings_page() {
         if (!current_user_can('manage_options')) {
-            wp_die(esc_html__('You do not have permission to access this page.', 'digitalogic'));
+			Digitalogic_Panel_Error_Page::render_admin(
+				403,
+				'ui-settings-access-denied',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_UI_SETTINGS )
+			);
+			exit;
         }
 
         if (isset($_POST['digitalogic_ui_settings_submit']) && check_admin_referer('digitalogic_ui_settings')) {

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -689,7 +689,7 @@ class Digitalogic_Admin {
 				'',
 				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_PATRIS_REPORTS )
 			);
-			exit;
+			return;
         }
 
         $feed = Digitalogic_Patris_Feed::instance();
@@ -842,7 +842,7 @@ class Digitalogic_Admin {
 				'',
 				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_PRODUCT_DIAGNOSTICS )
 			);
-			exit;
+			return;
 		}
 
 		$metadata                     = null;
@@ -932,7 +932,7 @@ class Digitalogic_Admin {
 				'',
 				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_UI_SETTINGS )
 			);
-			exit;
+			return;
         }
 
         if (isset($_POST['digitalogic_ui_settings_submit']) && check_admin_referer('digitalogic_ui_settings')) {

--- a/includes/integrations/class-comment-guard.php
+++ b/includes/integrations/class-comment-guard.php
@@ -55,11 +55,13 @@ class Digitalogic_Comment_Guard {
 
         if ($reasons) {
             $this->log('BLOCK', implode(',', $reasons), $ip, $commentdata, $abuse, $sfs);
-            wp_die(
-                esc_html__('Your comment could not be accepted from this network.', 'digitalogic'),
-                esc_html__('Comment blocked', 'digitalogic'),
-                array('response' => 403)
-            );
+			Digitalogic_Panel_Error_Page::render(
+				403,
+				'comment-network-blocked',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_COMMENT_GUARD )
+			);
+			exit;
         }
 
         $this->log('ALLOW', 'clean', $ip, $commentdata, $abuse, $sfs);

--- a/includes/integrations/class-storefront-order-forms.php
+++ b/includes/integrations/class-storefront-order-forms.php
@@ -695,14 +695,26 @@ final class Digitalogic_Storefront_Order_Forms {
 	 */
 	public function download_request_file() {
 		$request_id = absint( $this->query_scalar( 'request_id', 24 ) );
-		if ( ! $request_id || ! current_user_can( 'manage_woocommerce' ) ) {
-			wp_die( esc_html__( 'You are not allowed to download this file.', 'digitalogic' ), '', array( 'response' => 403 ) );
+		if ( ! $request_id || ! Digitalogic_Access_Control::can_access_panel() ) {
+			Digitalogic_Panel_Error_Page::render(
+				403,
+				'request-download-access-denied',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_REQUEST_DOWNLOAD )
+			);
+			exit;
 		}
 		check_admin_referer( 'dgl_download_request_' . $request_id );
 		$file = (array) get_post_meta( $request_id, '_dgl_request_file', true );
 		$path = isset( $file['path'] ) ? wp_normalize_path( $file['path'] ) : '';
 		if ( ! $path || ! is_file( $path ) ) {
-			wp_die( esc_html__( 'The request file no longer exists.', 'digitalogic' ), '', array( 'response' => 404 ) );
+			Digitalogic_Panel_Error_Page::render(
+				404,
+				'request-file-not-found',
+				'',
+				array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_REQUEST_DOWNLOAD )
+			);
+			exit;
 		}
 
 		nocache_headers();

--- a/includes/panel/class-digitalogic-panel-error-page.php
+++ b/includes/panel/class-digitalogic-panel-error-page.php
@@ -14,8 +14,32 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class Digitalogic_Panel_Error_Page {
 
+	/** Default panel authorization context. */
+	public const CONTEXT_PANEL = 'panel';
+
+	/** Patris report administration context. */
+	public const CONTEXT_PATRIS_REPORTS = 'patris-reports';
+
+	/** Product metadata diagnostics context. */
+	public const CONTEXT_PRODUCT_DIAGNOSTICS = 'product-diagnostics';
+
+	/** Digitalogic UI settings context. */
+	public const CONTEXT_UI_SETTINGS = 'ui-settings';
+
+	/** Public comment reputation context. */
+	public const CONTEXT_COMMENT_GUARD = 'comment-guard';
+
+	/** Private storefront request-file download context. */
+	public const CONTEXT_REQUEST_DOWNLOAD = 'request-download';
+
+	/** Standalone document rendering mode. */
+	public const MODE_DOCUMENT = 'document';
+
+	/** WordPress-admin-safe embedded rendering mode. */
+	public const MODE_ADMIN_EMBEDDED = 'admin-embedded';
+
 	/**
-	 * Render a complete localized error document.
+	 * Render a localized browser error response.
 	 *
 	 * This intentionally avoids wp_die() so plugin errors never fall back to the
 	 * generic WordPress error screen or expose a Query Monitor call stack.
@@ -30,8 +54,10 @@ final class Digitalogic_Panel_Error_Page {
 		$status = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
 		$view   = self::view_model( $status, $code, $message, $args );
 
-		nocache_headers();
-		status_header( $status );
+		if ( self::MODE_DOCUMENT === $view['mode'] ) {
+			nocache_headers();
+			status_header( $status );
+		}
 		wp_enqueue_style(
 			'digitalogic-panel-error',
 			DIGITALOGIC_PLUGIN_URL . 'assets/css/panel-error.css',
@@ -40,6 +66,23 @@ final class Digitalogic_Panel_Error_Page {
 		);
 
 		include DIGITALOGIC_PLUGIN_DIR . 'includes/panel/views/error.php';
+	}
+
+	/**
+	 * Render a localized error inside the existing WordPress admin document.
+	 *
+	 * Admin page callbacks run after the admin header. This mode deliberately
+	 * avoids emitting a second doctype, html, head, or body element.
+	 *
+	 * @param int    $status  HTTP status.
+	 * @param string $code    Stable support reference.
+	 * @param string $message Optional message override.
+	 * @param array  $args    Optional contextual view values.
+	 * @return void
+	 */
+	public static function render_admin( $status, $code, $message = '', $args = array() ) {
+		$args['mode'] = self::MODE_ADMIN_EMBEDDED;
+		self::render( $status, $code, $message, $args );
 	}
 
 	/**
@@ -52,17 +95,19 @@ final class Digitalogic_Panel_Error_Page {
 	 * @return array
 	 */
 	public static function view_model( $status, $code, $message = '', $args = array() ) {
-		$status = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
-		$locale = determine_locale();
-		$is_fa  = 0 === strpos( strtolower( (string) $locale ), 'fa' );
-		$copy   = self::copy( $status, $is_fa );
-		$user   = wp_get_current_user();
+		$status  = in_array( (int) $status, array( 400, 401, 403, 404, 500, 503 ), true ) ? (int) $status : 500;
+		$locale  = determine_locale();
+		$is_fa   = 0 === strpos( strtolower( (string) $locale ), 'fa' );
+		$context = isset( $args['context'] ) ? sanitize_key( (string) $args['context'] ) : self::CONTEXT_PANEL;
+		$mode    = isset( $args['mode'] ) && self::MODE_ADMIN_EMBEDDED === $args['mode'] ? self::MODE_ADMIN_EMBEDDED : self::MODE_DOCUMENT;
+		$copy    = self::copy( $status, $is_fa, $context );
+		$user    = wp_get_current_user();
 
 		$defaults = array(
 			'eyebrow' => $copy['eyebrow'],
 			'title'   => $copy['title'],
 			'detail'  => $copy['detail'],
-			'actions' => self::default_actions( $status, $is_fa ),
+			'actions' => self::default_actions( $status, $is_fa, $context ),
 		);
 		$args     = wp_parse_args( $args, $defaults );
 
@@ -86,6 +131,8 @@ final class Digitalogic_Panel_Error_Page {
 			'code'            => 'DG-' . $reference,
 			'locale'          => str_replace( '_', '-', (string) $locale ),
 			'direction'       => $is_fa ? 'rtl' : 'ltr',
+			'context'         => $context,
+			'mode'            => $mode,
 			'eyebrow'         => (string) $args['eyebrow'],
 			'title'           => (string) $args['title'],
 			'detail'          => (string) $args['detail'],
@@ -103,11 +150,12 @@ final class Digitalogic_Panel_Error_Page {
 	/**
 	 * Return complete English or Persian copy for a supported status.
 	 *
-	 * @param int  $status HTTP status.
-	 * @param bool $is_fa  Whether Persian copy is required.
+	 * @param int    $status  HTTP status.
+	 * @param bool   $is_fa   Whether Persian copy is required.
+	 * @param string $context Browser error context.
 	 * @return array
 	 */
-	private static function copy( $status, $is_fa ) {
+	private static function copy( $status, $is_fa, $context ) {
 		$english = array(
 			400 => array(
 				'eyebrow' => 'Invalid request',
@@ -173,9 +221,11 @@ final class Digitalogic_Panel_Error_Page {
 			),
 		);
 
-		$set = $is_fa ? $persian : $english;
+		$set     = $is_fa ? $persian : $english;
+		$context = self::context_copy( $status, $is_fa, $context );
 		return array_merge(
 			$set[ $status ],
+			$context,
 			array(
 				'signed_in' => $is_fa ? 'واردشده با حساب %s' : 'Signed in as %s',
 				'reference' => $is_fa ? 'کد پیگیری' : 'Reference',
@@ -184,20 +234,123 @@ final class Digitalogic_Panel_Error_Page {
 	}
 
 	/**
-	 * Build safe recovery actions for the current authentication state.
+	 * Return localized copy for plugin-owned forbidden-page contexts.
 	 *
-	 * @param int  $status HTTP status.
-	 * @param bool $is_fa  Whether Persian labels are required.
+	 * @param int    $status  HTTP status.
+	 * @param bool   $is_fa   Whether Persian copy is required.
+	 * @param string $context Browser error context.
 	 * @return array
 	 */
-	private static function default_actions( $status, $is_fa ) {
+	private static function context_copy( $status, $is_fa, $context ) {
+		if ( 404 === (int) $status && self::CONTEXT_REQUEST_DOWNLOAD === $context ) {
+			return $is_fa
+				? array(
+					'eyebrow' => 'فایل پیدا نشد',
+					'title'   => 'فایل این درخواست دیگر در دسترس نیست',
+					'detail'  => 'ممکن است فایل پیوست حذف یا جابه‌جا شده باشد. برای بررسی درخواست به پیشخوان وردپرس بازگردید.',
+				)
+				: array(
+					'eyebrow' => 'File not found',
+					'title'   => 'This request file is no longer available',
+					'detail'  => 'The attachment may have been removed or moved. Return to the WordPress dashboard to review the request.',
+				);
+		}
+
+		if ( 403 !== (int) $status ) {
+			return array();
+		}
+
+		$english = array(
+			self::CONTEXT_PATRIS_REPORTS      => array(
+				'eyebrow' => 'Access restricted',
+				'title'   => 'Patris reports are not available to this account',
+				'detail'  => 'This page requires store-management access. Ask a site administrator to grant the appropriate WordPress capability.',
+			),
+			self::CONTEXT_PRODUCT_DIAGNOSTICS => array(
+				'eyebrow' => 'Access restricted',
+				'title'   => 'Product diagnostics are not available to this account',
+				'detail'  => 'This page contains store diagnostics and requires store-management access.',
+			),
+			self::CONTEXT_UI_SETTINGS         => array(
+				'eyebrow' => 'Administrator access required',
+				'title'   => 'Digitalogic interface settings are restricted',
+				'detail'  => 'Only a WordPress administrator can change the Digitalogic interface settings.',
+			),
+			self::CONTEXT_COMMENT_GUARD       => array(
+				'eyebrow' => 'Comment blocked',
+				'title'   => 'We could not accept this comment',
+				'detail'  => 'Your comment could not be accepted from this network.',
+			),
+			self::CONTEXT_REQUEST_DOWNLOAD    => array(
+				'eyebrow' => 'Download restricted',
+				'title'   => 'This request file is protected',
+				'detail'  => 'Only an authorized store manager can download private request attachments.',
+			),
+		);
+		$persian = array(
+			self::CONTEXT_PATRIS_REPORTS      => array(
+				'eyebrow' => 'دسترسی محدود',
+				'title'   => 'این حساب به گزارش‌های پاتریس دسترسی ندارد',
+				'detail'  => 'این صفحه به دسترسی مدیریت فروشگاه نیاز دارد. از مدیر سایت بخواهید مجوز مناسب وردپرس را به حساب شما اختصاص دهد.',
+			),
+			self::CONTEXT_PRODUCT_DIAGNOSTICS => array(
+				'eyebrow' => 'دسترسی محدود',
+				'title'   => 'این حساب به عیب‌یابی محصولات دسترسی ندارد',
+				'detail'  => 'این صفحه شامل اطلاعات عیب‌یابی فروشگاه است و به دسترسی مدیریت فروشگاه نیاز دارد.',
+			),
+			self::CONTEXT_UI_SETTINGS         => array(
+				'eyebrow' => 'نیازمند دسترسی مدیر',
+				'title'   => 'تنظیمات نمای دیجیتالوجیک محدود است',
+				'detail'  => 'فقط مدیر وردپرس می‌تواند تنظیمات نمای دیجیتالوجیک را تغییر دهد.',
+			),
+			self::CONTEXT_COMMENT_GUARD       => array(
+				'eyebrow' => 'دیدگاه مسدود شد',
+				'title'   => 'امکان پذیرش این دیدگاه نبود',
+				'detail'  => 'ارسال دیدگاه از این شبکه پذیرفته نشد.',
+			),
+			self::CONTEXT_REQUEST_DOWNLOAD    => array(
+				'eyebrow' => 'دانلود محدود است',
+				'title'   => 'فایل این درخواست محافظت‌شده است',
+				'detail'  => 'فقط مدیر مجاز فروشگاه می‌تواند فایل‌های پیوست خصوصی درخواست‌ها را دانلود کند.',
+			),
+		);
+		$set     = $is_fa ? $persian : $english;
+
+		return isset( $set[ $context ] ) ? $set[ $context ] : array();
+	}
+
+	/**
+	 * Build safe recovery actions for the current authentication state.
+	 *
+	 * @param int    $status  HTTP status.
+	 * @param bool   $is_fa   Whether Persian labels are required.
+	 * @param string $context Browser error context.
+	 * @return array
+	 */
+	private static function default_actions( $status, $is_fa, $context ) {
 		$panel_url = home_url( '/panel/' );
 		$actions   = array();
+
+		if ( self::CONTEXT_COMMENT_GUARD === $context ) {
+			$actions[] = array(
+				'label'   => $is_fa ? 'بازگشت به فروشگاه' : 'Return to the store',
+				'url'     => home_url( '/' ),
+				'primary' => true,
+			);
+
+			return $actions;
+		}
 
 		if ( 401 === $status || ! is_user_logged_in() ) {
 			$actions[] = array(
 				'label'   => $is_fa ? 'ورود به پنل' : 'Sign in to the panel',
 				'url'     => wp_login_url( $panel_url ),
+				'primary' => true,
+			);
+		} elseif ( in_array( $context, array( self::CONTEXT_PATRIS_REPORTS, self::CONTEXT_PRODUCT_DIAGNOSTICS, self::CONTEXT_UI_SETTINGS, self::CONTEXT_REQUEST_DOWNLOAD ), true ) ) {
+			$actions[] = array(
+				'label'   => $is_fa ? 'بازگشت به پیشخوان وردپرس' : 'Return to WordPress dashboard',
+				'url'     => admin_url(),
 				'primary' => true,
 			);
 		} elseif ( 403 === $status ) {

--- a/includes/panel/views/error-content.php
+++ b/includes/panel/views/error-content.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Shared Digitalogic error-card content.
+ *
+ * @package Digitalogic
+ * @var array $view Digitalogic error view model.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<main class="dle-shell">
+	<section class="dle-card" aria-labelledby="dle-title" aria-describedby="dle-detail">
+		<div class="dle-brand">
+			<span class="dle-logo"><img src="<?php echo esc_url( $view['logo_url'] ); ?>" alt=""></span>
+			<span><strong>Digitalogic</strong><small><?php echo esc_html( $view['site_name'] ); ?></small></span>
+		</div>
+
+		<div class="dle-status" aria-hidden="true">
+			<span class="dle-status-code"><?php echo esc_html( $view['status'] ); ?></span>
+			<svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 5.25a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm1.15 9.5h-2.3v-5.5h2.3v5.5Z"/></svg>
+		</div>
+
+		<p class="dle-eyebrow"><?php echo esc_html( $view['eyebrow'] ); ?></p>
+		<h1 id="dle-title"><?php echo esc_html( $view['title'] ); ?></h1>
+		<p class="dle-detail" id="dle-detail"><?php echo esc_html( $view['detail'] ); ?></p>
+
+		<?php if ( '' !== $view['signed_in_label'] ) : ?>
+			<p class="dle-user">
+				<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-5.33 0-8 2.67-8 5v1.5h16V19c0-2.33-2.67-5-8-5Z"/></svg>
+				<?php echo esc_html( $view['signed_in_label'] ); ?>
+			</p>
+		<?php endif; ?>
+
+		<nav class="dle-actions" aria-label="<?php echo esc_attr( $view['eyebrow'] ); ?>">
+			<?php foreach ( $view['actions'] as $error_action ) : ?>
+				<a class="dle-button<?php echo ! empty( $error_action['primary'] ) ? ' is-primary' : ''; ?>" href="<?php echo esc_url( $error_action['url'] ?? '' ); ?>">
+					<?php echo esc_html( $error_action['label'] ?? '' ); ?>
+				</a>
+			<?php endforeach; ?>
+		</nav>
+
+		<footer class="dle-footer">
+			<span><?php echo esc_html( $view['reference_label'] ); ?></span>
+			<code dir="ltr"><?php echo esc_html( $view['code'] ); ?></code>
+		</footer>
+	</section>
+</main>

--- a/includes/panel/views/error.php
+++ b/includes/panel/views/error.php
@@ -9,7 +9,11 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-?><!doctype html>
+
+$is_embedded = Digitalogic_Panel_Error_Page::MODE_ADMIN_EMBEDDED === $view['mode'];
+
+if ( ! $is_embedded ) :
+	?><!doctype html>
 <html lang="<?php echo esc_attr( $view['locale'] ); ?>" dir="<?php echo esc_attr( $view['direction'] ); ?>">
 <head>
 	<meta charset="UTF-8">
@@ -19,42 +23,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php wp_print_styles( $view['style_handle'] ); ?>
 </head>
 <body class="digitalogic-error-body">
-	<main class="dle-shell">
-		<section class="dle-card" aria-labelledby="dle-title" aria-describedby="dle-detail">
-			<div class="dle-brand">
-				<span class="dle-logo"><img src="<?php echo esc_url( $view['logo_url'] ); ?>" alt=""></span>
-				<span><strong>Digitalogic</strong><small><?php echo esc_html( $view['site_name'] ); ?></small></span>
-			</div>
-
-			<div class="dle-status" aria-hidden="true">
-				<span class="dle-status-code"><?php echo esc_html( $view['status'] ); ?></span>
-				<svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 5.25a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm1.15 9.5h-2.3v-5.5h2.3v5.5Z"/></svg>
-			</div>
-
-			<p class="dle-eyebrow"><?php echo esc_html( $view['eyebrow'] ); ?></p>
-			<h1 id="dle-title"><?php echo esc_html( $view['title'] ); ?></h1>
-			<p class="dle-detail" id="dle-detail"><?php echo esc_html( $view['detail'] ); ?></p>
-
-			<?php if ( '' !== $view['signed_in_label'] ) : ?>
-				<p class="dle-user">
-					<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 2c-5.33 0-8 2.67-8 5v1.5h16V19c0-2.33-2.67-5-8-5Z"/></svg>
-					<?php echo esc_html( $view['signed_in_label'] ); ?>
-				</p>
-			<?php endif; ?>
-
-			<nav class="dle-actions" aria-label="<?php echo esc_attr( $view['eyebrow'] ); ?>">
-				<?php foreach ( $view['actions'] as $error_action ) : ?>
-					<a class="dle-button<?php echo ! empty( $error_action['primary'] ) ? ' is-primary' : ''; ?>" href="<?php echo esc_url( $error_action['url'] ?? '' ); ?>">
-						<?php echo esc_html( $error_action['label'] ?? '' ); ?>
-					</a>
-				<?php endforeach; ?>
-			</nav>
-
-			<footer class="dle-footer">
-				<span><?php echo esc_html( $view['reference_label'] ); ?></span>
-				<code dir="ltr"><?php echo esc_html( $view['code'] ); ?></code>
-			</footer>
-		</section>
-	</main>
+	<?php include DIGITALOGIC_PLUGIN_DIR . 'includes/panel/views/error-content.php'; ?>
 </body>
 </html>
+	<?php
+else :
+	wp_print_styles( $view['style_handle'] );
+	?>
+<div class="wrap digitalogic-error-embedded" lang="<?php echo esc_attr( $view['locale'] ); ?>" dir="<?php echo esc_attr( $view['direction'] ); ?>">
+	<?php include DIGITALOGIC_PLUGIN_DIR . 'includes/panel/views/error-content.php'; ?>
+</div>
+	<?php
+endif;

--- a/tests/PanelAccessControlTest.php
+++ b/tests/PanelAccessControlTest.php
@@ -23,6 +23,14 @@ final class PanelAccessControlTest extends TestCase {
 	}
 
 	/**
+	 * Prevent an extensibility filter from leaking into unrelated tests.
+	 */
+	protected function tearDown(): void {
+		remove_all_filters( 'digitalogic_panel_access_capabilities' );
+		remove_all_filters( 'digitalogic_panel_access_allowed' );
+	}
+
+	/**
 	 * WooCommerce managers retain panel access.
 	 */
 	public function test_woocommerce_manager_can_access_panel(): void {

--- a/tests/PanelErrorPageTest.php
+++ b/tests/PanelErrorPageTest.php
@@ -86,4 +86,120 @@ final class PanelErrorPageTest extends TestCase {
 		$this->assertSame( 'ltr', $view['direction'] );
 		$this->assertStringContainsString( 'not ready', $view['title'] );
 	}
+
+	/**
+	 * Each protected browser surface gets specific copy and a safe admin route.
+	 */
+	public function test_protected_admin_contexts_have_specific_copy_and_recovery_actions(): void {
+		$GLOBALS['digitalogic_test_current_user_id'] = 18;
+
+		$contexts = array(
+			Digitalogic_Panel_Error_Page::CONTEXT_PATRIS_REPORTS      => 'Patris reports',
+			Digitalogic_Panel_Error_Page::CONTEXT_PRODUCT_DIAGNOSTICS => 'Product diagnostics',
+			Digitalogic_Panel_Error_Page::CONTEXT_UI_SETTINGS         => 'Digitalogic interface settings',
+		);
+
+		foreach ( $contexts as $context => $expected_title ) {
+			$view = Digitalogic_Panel_Error_Page::view_model(
+				403,
+				$context . '-access-denied',
+				'',
+				array( 'context' => $context )
+			);
+
+			$this->assertSame( $context, $view['context'] );
+			$this->assertStringContainsString( $expected_title, $view['title'] );
+			$this->assertSame( 'https://digitalogic.test/wp-admin/', $view['actions'][0]['url'] );
+			$this->assertTrue( $view['actions'][0]['primary'] );
+		}
+	}
+
+	/**
+	 * Public comment blocks do not suggest authentication or reveal guard details.
+	 */
+	public function test_comment_guard_context_has_localized_public_recovery_action(): void {
+		$GLOBALS['digitalogic_test_locale'] = 'fa_IR';
+
+		$view = Digitalogic_Panel_Error_Page::view_model(
+			403,
+			'comment-network-blocked',
+			'',
+			array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_COMMENT_GUARD )
+		);
+
+		$this->assertSame( Digitalogic_Panel_Error_Page::CONTEXT_COMMENT_GUARD, $view['context'] );
+		$this->assertSame( 'امکان پذیرش این دیدگاه نبود', $view['title'] );
+		$this->assertSame( 'ارسال دیدگاه از این شبکه پذیرفته نشد.', $view['detail'] );
+		$this->assertCount( 1, $view['actions'] );
+		$this->assertSame( 'بازگشت به فروشگاه', $view['actions'][0]['label'] );
+		$this->assertSame( 'https://digitalogic.test/', $view['actions'][0]['url'] );
+	}
+
+	/**
+	 * Admin callbacks render a card without nesting a second HTML document.
+	 */
+	public function test_admin_mode_is_embedded_in_the_existing_document(): void {
+		$GLOBALS['digitalogic_test_current_user_id'] = 18;
+
+		ob_start();
+		Digitalogic_Panel_Error_Page::render_admin(
+			403,
+			'patris-reports-access-denied',
+			'',
+			array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_PATRIS_REPORTS )
+		);
+		$html = (string) ob_get_clean();
+
+		$this->assertSame( array(), $GLOBALS['digitalogic_test_status_headers'] );
+		$this->assertSame( 0, $GLOBALS['digitalogic_test_nocache_headers'] );
+		$this->assertStringContainsString( 'class="wrap digitalogic-error-embedded"', $html );
+		$this->assertStringContainsString( 'DG-PATRIS-REPORTS-ACCESS-DENIED', $html );
+		$this->assertStringNotContainsString( '<!doctype html>', $html );
+		$this->assertStringNotContainsString( '<html', $html );
+		$this->assertStringNotContainsString( '<body', $html );
+	}
+
+	/**
+	 * Private request downloads retain specific forbidden and missing responses.
+	 */
+	public function test_request_download_context_preserves_security_status_copy(): void {
+		$GLOBALS['digitalogic_test_current_user_id'] = 18;
+
+		$forbidden = Digitalogic_Panel_Error_Page::view_model(
+			403,
+			'request-download-access-denied',
+			'',
+			array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_REQUEST_DOWNLOAD )
+		);
+		$missing   = Digitalogic_Panel_Error_Page::view_model(
+			404,
+			'request-file-not-found',
+			'',
+			array( 'context' => Digitalogic_Panel_Error_Page::CONTEXT_REQUEST_DOWNLOAD )
+		);
+
+		$this->assertSame( 403, $forbidden['status'] );
+		$this->assertSame( 'This request file is protected', $forbidden['title'] );
+		$this->assertSame( 404, $missing['status'] );
+		$this->assertSame( 'This request file is no longer available', $missing['title'] );
+		$this->assertSame( 'https://digitalogic.test/wp-admin/', $missing['actions'][0]['url'] );
+	}
+
+	/**
+	 * Browser-facing plugin denials no longer invoke WordPress' raw die screen.
+	 */
+	public function test_browser_error_call_sites_do_not_use_raw_wp_die(): void {
+		$paths = array(
+			dirname( __DIR__ ) . '/includes/admin/class-admin.php',
+			dirname( __DIR__ ) . '/includes/integrations/class-comment-guard.php',
+			dirname( __DIR__ ) . '/includes/integrations/class-storefront-order-forms.php',
+		);
+
+		foreach ( $paths as $path ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source audit.
+			$source = file_get_contents( $path );
+			$this->assertIsString( $source );
+			$this->assertDoesNotMatchRegularExpression( '/\\bwp_die\\s*\\(/', $source, $path );
+		}
+	}
 }

--- a/tests/PanelErrorPageTest.php
+++ b/tests/PanelErrorPageTest.php
@@ -202,4 +202,26 @@ final class PanelErrorPageTest extends TestCase {
 			$this->assertDoesNotMatchRegularExpression( '/\\bwp_die\\s*\\(/', $source, $path );
 		}
 	}
+
+	/**
+	 * Embedded admin denials return control so WordPress can render its footer.
+	 */
+	public function test_admin_error_callbacks_do_not_terminate_the_admin_document(): void {
+		$path = dirname( __DIR__ ) . '/includes/admin/class-admin.php';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local source audit.
+		$source = file_get_contents( $path );
+
+		$this->assertIsString( $source );
+		foreach ( array( 'render_patris_reports_page', 'render_product_diagnostics_page', 'render_ui_settings_page' ) as $callback ) {
+			$start = strpos( $source, 'function ' . $callback . '(' );
+			$this->assertNotFalse( $start, $callback );
+			$next = strpos( $source, "\n    public function ", $start + 1 );
+			$next = false === $next ? strlen( $source ) : $next;
+			$body = substr( $source, $start, $next - $start );
+
+			$this->assertStringContainsString( 'Digitalogic_Panel_Error_Page::render_admin(', $body, $callback );
+			$this->assertDoesNotMatchRegularExpression( '/render_admin\([\s\S]*?\);\s*exit\s*;/', $body, $callback );
+			$this->assertMatchesRegularExpression( '/render_admin\([\s\S]*?\);\s*return\s*;/', $body, $callback );
+		}
+	}
 }

--- a/tests/StorefrontOrderFormsCapabilitiesTest.php
+++ b/tests/StorefrontOrderFormsCapabilitiesTest.php
@@ -7,32 +7,6 @@
 
 use PHPUnit\Framework\TestCase;
 
-if ( ! function_exists( 'register_post_type' ) ) {
-	/**
-	 * Capture post-type arguments and model WordPress's object meta-cap map.
-	 *
-	 * @param string $post_type Post-type key.
-	 * @param array  $args      Registration arguments.
-	 * @return object
-	 */
-	function register_post_type( $post_type, $args = array() ) {
-		$GLOBALS['digitalogic_test_registered_post_types'][ $post_type ] = $args;
-
-		if ( ! empty( $args['map_meta_cap'] ) ) {
-			foreach ( array( 'edit_post', 'read_post', 'delete_post' ) as $meta_cap ) {
-				$capability = $args['capabilities'][ $meta_cap ] ?? '';
-				if ( '' !== $capability ) {
-					$GLOBALS['digitalogic_test_post_type_meta_caps'][ $capability ] = $meta_cap;
-				}
-			}
-		}
-
-		return (object) array(
-			'name' => $post_type,
-		);
-	}
-}
-
 require_once dirname( __DIR__ ) . '/includes/integrations/class-storefront-order-forms.php';
 
 /**
@@ -45,7 +19,7 @@ final class StorefrontOrderFormsCapabilitiesTest extends TestCase {
 	 */
 	protected function setUp(): void {
 		$GLOBALS['digitalogic_test_registered_post_types'] = array();
-		$GLOBALS['digitalogic_test_post_type_meta_caps']    = array();
+		$GLOBALS['digitalogic_test_post_type_meta_caps']   = array();
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -66,6 +66,8 @@ $GLOBALS['digitalogic_test_transients'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_transient_deletes'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_rewrite_rules'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_rewrite_flushes'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_registered_post_types'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_post_type_meta_caps'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_locale'] = 'en_US';
 $GLOBALS['digitalogic_test_shortcodes'] = array();
 $GLOBALS['digitalogic_test_enqueued_styles'] = array();
@@ -286,6 +288,21 @@ function current_user_can($capability) {
     $GLOBALS['digitalogic_test_current_user_can_calls']++;
 
     return !empty($GLOBALS['digitalogic_test_capabilities'][$capability]);
+}
+
+function register_post_type($post_type, $args = array()) {
+    $GLOBALS['digitalogic_test_registered_post_types'][$post_type] = $args;
+
+    if (!empty($args['map_meta_cap'])) {
+        foreach (array('edit_post', 'read_post', 'delete_post') as $meta_cap) {
+            $capability = $args['capabilities'][$meta_cap] ?? '';
+            if ($capability !== '') {
+                $GLOBALS['digitalogic_test_post_type_meta_caps'][$capability] = $meta_cap;
+            }
+        }
+    }
+
+    return (object) array('name' => $post_type);
 }
 
 function get_current_user_id() {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,10 +11,10 @@ define('ARRAY_A', 'ARRAY_A');
 define('MINUTE_IN_SECONDS', 60);
 define('HOUR_IN_SECONDS', 3600);
 define('DAY_IN_SECONDS', 86400);
-define('DIGITALOGIC_VERSION', 'test');
-define('DIGITALOGIC_PLUGIN_DIR', dirname(__DIR__) . '/');
-define('DIGITALOGIC_PLUGIN_URL', 'https://digitalogic.test/wp-content/plugins/digitalogic-wp/');
 // phpcs:enable
+define( 'DIGITALOGIC_VERSION', 'test' );
+define( 'DIGITALOGIC_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+define( 'DIGITALOGIC_PLUGIN_URL', 'https://digitalogic.test/wp-content/plugins/digitalogic-wp/' );
 
 // phpcs:disable Generic.Formatting.MultipleStatementAlignment -- Preserve the intentionally simple test-global registry.
 $GLOBALS['digitalogic_test_capabilities'] = array();
@@ -25,9 +25,9 @@ $GLOBALS['digitalogic_test_rest_url_calls'] = 0;
 $GLOBALS['digitalogic_test_current_user_can_calls'] = 0;
 $GLOBALS['digitalogic_test_current_user_id'] = 0;
 $GLOBALS['digitalogic_test_current_user'] = (object) array(
-    'ID' => 0,
-    'user_login' => '',
-    'display_name' => '',
+	'ID'           => 0,
+	'user_login'   => '',
+	'display_name' => '',
 );
 $GLOBALS['digitalogic_test_status_headers'] = array();
 $GLOBALS['digitalogic_test_nocache_headers'] = 0;
@@ -290,64 +290,136 @@ function current_user_can($capability) {
     return !empty($GLOBALS['digitalogic_test_capabilities'][$capability]);
 }
 
-function register_post_type($post_type, $args = array()) {
-    $GLOBALS['digitalogic_test_registered_post_types'][$post_type] = $args;
+/**
+ * Capture post-type arguments and model WordPress's object meta-cap map.
+ *
+ * @param string $post_type Post-type key.
+ * @param array  $args      Registration arguments.
+ * @return object
+ */
+function register_post_type( $post_type, $args = array() ) {
+	$GLOBALS['digitalogic_test_registered_post_types'][ $post_type ] = $args;
 
-    if (!empty($args['map_meta_cap'])) {
-        foreach (array('edit_post', 'read_post', 'delete_post') as $meta_cap) {
-            $capability = $args['capabilities'][$meta_cap] ?? '';
-            if ($capability !== '') {
-                $GLOBALS['digitalogic_test_post_type_meta_caps'][$capability] = $meta_cap;
-            }
-        }
-    }
+	if ( ! empty( $args['map_meta_cap'] ) ) {
+		foreach ( array( 'edit_post', 'read_post', 'delete_post' ) as $meta_cap ) {
+			$capability = $args['capabilities'][ $meta_cap ] ?? '';
+			if ( '' !== $capability ) {
+				$GLOBALS['digitalogic_test_post_type_meta_caps'][ $capability ] = $meta_cap;
+			}
+		}
+	}
 
-    return (object) array('name' => $post_type);
+	return (object) array(
+		'name' => $post_type,
+	);
 }
 
+/**
+ * Return the current test user ID.
+ *
+ * @return int
+ */
 function get_current_user_id() {
-    return (int) $GLOBALS['digitalogic_test_current_user_id'];
+	return (int) $GLOBALS['digitalogic_test_current_user_id'];
 }
 
+/**
+ * Return the current test user object.
+ *
+ * @return object
+ */
 function wp_get_current_user() {
-    return $GLOBALS['digitalogic_test_current_user'];
+	return $GLOBALS['digitalogic_test_current_user'];
 }
 
+/**
+ * Determine whether a test user is signed in.
+ *
+ * @return bool
+ */
 function is_user_logged_in() {
-    return get_current_user_id() > 0;
+	return 0 < get_current_user_id();
 }
 
-function wp_login_url($redirect = '', $force_reauth = false) {
-    $url = 'https://digitalogic.test/wp-login.php';
-    return $redirect !== '' ? $url . '?redirect_to=' . rawurlencode((string) $redirect) : $url;
+/**
+ * Build a test login URL.
+ *
+ * @param string $redirect     Redirect URL after login.
+ * @param bool   $force_reauth Whether reauthentication is requested.
+ * @return string
+ */
+function wp_login_url( $redirect = '', $force_reauth = false ) {
+	$url = 'https://digitalogic.test/wp-login.php';
+	unset( $force_reauth );
+
+	return '' !== $redirect ? $url . '?redirect_to=' . rawurlencode( (string) $redirect ) : $url;
 }
 
-function wp_logout_url($redirect = '') {
-    $url = 'https://digitalogic.test/wp-login.php?action=logout';
-    return $redirect !== '' ? $url . '&redirect_to=' . rawurlencode((string) $redirect) : $url;
+/**
+ * Build a test logout URL.
+ *
+ * @param string $redirect Redirect URL after logout.
+ * @return string
+ */
+function wp_logout_url( $redirect = '' ) {
+	$url = 'https://digitalogic.test/wp-login.php?action=logout';
+
+	return '' !== $redirect ? $url . '&redirect_to=' . rawurlencode( (string) $redirect ) : $url;
 }
 
-function status_header($status_code) {
-    $GLOBALS['digitalogic_test_status_headers'][] = (int) $status_code;
+/**
+ * Capture a test response status.
+ *
+ * @param int $status_code HTTP response status.
+ * @return void
+ */
+function status_header( $status_code ) {
+	$GLOBALS['digitalogic_test_status_headers'][] = (int) $status_code;
 }
 
+/**
+ * Record a no-cache header request.
+ *
+ * @return void
+ */
 function nocache_headers() {
-    $GLOBALS['digitalogic_test_nocache_headers']++;
+	++$GLOBALS['digitalogic_test_nocache_headers'];
 }
 
-function wp_enqueue_style($handle, $src = '', $dependencies = array(), $version = false, $media = 'all') {
-    $GLOBALS['digitalogic_test_enqueued_styles'][$handle] = compact('src', 'dependencies', 'version', 'media');
+/**
+ * Capture an enqueued test stylesheet.
+ *
+ * @param string       $handle       Stylesheet handle.
+ * @param string       $src          Stylesheet URL.
+ * @param array        $dependencies Dependency handles.
+ * @param string|false $version      Stylesheet version.
+ * @param string       $media        Stylesheet media target.
+ * @return void
+ */
+function wp_enqueue_style( $handle, $src = '', $dependencies = array(), $version = false, $media = 'all' ) {
+	$GLOBALS['digitalogic_test_enqueued_styles'][ $handle ] = array(
+		'src'          => $src,
+		'dependencies' => $dependencies,
+		'version'      => $version,
+		'media'        => $media,
+	);
 }
 
-function wp_print_styles($handles = false) {
-    $handles = false === $handles ? array_keys($GLOBALS['digitalogic_test_enqueued_styles']) : (array) $handles;
-    foreach ($handles as $handle) {
-        if (!isset($GLOBALS['digitalogic_test_enqueued_styles'][$handle])) {
-            continue;
-        }
-        $style = $GLOBALS['digitalogic_test_enqueued_styles'][$handle];
-        echo '<link rel="stylesheet" href="' . esc_url($style['src']) . '">';
-    }
+/**
+ * Print captured test stylesheet tags.
+ *
+ * @param string|array|false $handles Stylesheet handles.
+ * @return void
+ */
+function wp_print_styles( $handles = false ) {
+	$handles = false === $handles ? array_keys( $GLOBALS['digitalogic_test_enqueued_styles'] ) : (array) $handles;
+	foreach ( $handles as $handle ) {
+		if ( ! isset( $GLOBALS['digitalogic_test_enqueued_styles'][ $handle ] ) ) {
+			continue;
+		}
+		$style = $GLOBALS['digitalogic_test_enqueued_styles'][ $handle ];
+		echo '<link rel="stylesheet" href="' . esc_url( $style['src'] ) . '">';
+	}
 }
 
 function add_filter($hook_name, $callback, $priority = 10, $accepted_args = 1) {
@@ -2113,8 +2185,8 @@ require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-date-forma
 require_once dirname(__DIR__) . '/includes/class-digitalogic-currency-shortcodes.php';
 require_once dirname(__DIR__) . '/includes/class-unit-converter.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-woocommerce-currency-status.php';
-require_once dirname(__DIR__) . '/includes/class-digitalogic-access-control.php';
-require_once dirname(__DIR__) . '/includes/panel/class-digitalogic-panel-error-page.php';
+require_once dirname( __DIR__ ) . '/includes/class-digitalogic-access-control.php';
+require_once dirname( __DIR__ ) . '/includes/panel/class-digitalogic-panel-error-page.php';
 require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-query.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-metadata-inspector.php'; // phpcs:ignore


### PR DESCRIPTION
## Summary

This is the owner-reviewable follow-up to #109, which GitHub automatically closed when #113 merged. GitHub refused to reopen #109 after the branch was rebased onto the new `main`, so this PR preserves the remaining work without hiding or dropping it.

- replace every executable plugin-owned browser `wp_die()` call with the Digitalogic renderer
- provide English/Persian, RTL/LTR, responsive, accessible error states for panel/admin/comment/private-file flows
- render WordPress-admin failures as an embedded branded card without a nested document or late header mutation
- keep standalone errors as complete no-cache documents with correct 403/404 status and stable support codes
- reuse the central WordPress-session capability policy for store-management pages and request-file downloads
- keep UI settings restricted to `manage_options`
- consolidate the storefront capability test harness and isolate access-policy filters so test order cannot change results
- include the latest Patris publication safeguards from merged #112 without conflicts

## Validation

- full PHPUnit: 266 tests, 1,640 assertions passed; 5 expected Windows skips and 1 existing warning
- focused PHPUnit: 14 tests, 79 assertions passed in deliberately adversarial file order
- renderer PHPUnit: 9 tests, 65 assertions passed
- focused WordPress Coding Standards: clean
- repository PHPCS baseline: 38,743 errors / 2,607 warnings, below enforced limits
- embedded admin denials return normally so WordPress prints the footer and scripts
- touched PHP syntax: clean
- `git diff --check`: clean
- executable plugin-owned raw `wp_die()` audit: none remain

## Review status

Implementation is complete and intentionally remains a draft with `review: pending-owner-approval`. Please approve when satisfied, or comment `@codex` with required corrections.

Tracks #108. Supersedes the automatically closed #109 and #111. Builds on merged #113 and #112.

