### PR TITLE
Keep Digits global login CSS out of sidebar pages

### DIFF
--- a/includes/integrations/class-digitalogic-sidebar-login.php
+++ b/includes/integrations/class-digitalogic-sidebar-login.php
@@ -76,10 +76,11 @@ final class Digitalogic_Sidebar_Login {
 	}
 
 	/**
-	 * Return already-enqueued Digits layers so this compatibility sheet loads last.
+	 * Return already-enqueued Digits main/RTL layers so this sheet loads last.
 	 *
-	 * Depending on a merely registered handle would cause WordPress to print that
-	 * vendor stylesheet, including Digits' intentionally omitted global login CSS.
+	 * Never depend on digits-login-style: this host temporarily queues that global
+	 * base file before Woodmart removes it later in the enqueue lifecycle. Making it
+	 * a dependency would force the intentionally omitted stylesheet back into output.
 	 *
 	 * @return array<string>
 	 */
@@ -91,7 +92,7 @@ final class Digitalogic_Sidebar_Login {
 
 		return array_values(
 			array_filter(
-				array( 'digits-login-style', 'digits-style', 'digits-login-style-rtl' ),
+				array( 'digits-style', 'digits-login-style-rtl' ),
 				static fn( string $handle ): bool => isset( $styles->registered[ $handle ] ) && wp_style_is( $handle, 'enqueued' )
 			)
 		);

--- a/tests/SidebarLoginTest.php
+++ b/tests/SidebarLoginTest.php
@@ -102,14 +102,14 @@ final class SidebarLoginTest extends TestCase {
 		$this->assertTrue( $scripts['digitalogic-sidebar-login']['in_footer'] );
 	}
 
-	public function test_compatibility_style_loads_after_vendor_base_when_another_route_registered_it(): void {
+	public function test_compatibility_style_never_forces_the_global_vendor_base_even_when_queued(): void {
 		$GLOBALS['digitalogic_test_styles_registry']->registered['digits-login-style'] = (object) array( 'deps' => array() );
 		array_unshift( $GLOBALS['digitalogic_test_enqueued_style_handles'], 'digits-login-style' );
 
 		Digitalogic_Sidebar_Login::enqueue_sidebar_assets();
 
 		$this->assertSame(
-			array( 'digits-login-style', 'digits-style', 'digits-login-style-rtl' ),
+			array( 'digits-style', 'digits-login-style-rtl' ),
 			$GLOBALS['digitalogic_test_enqueued_styles']['digitalogic-sidebar-login']['dependencies']
 		);
 	}


### PR DESCRIPTION
## Production-found follow-up
The first production render showed that this host briefly marks `digits-login-style` as queued before Woodmart removes it later. Including that handle as a compatibility dependency therefore forced the 106 KB global Digits `login.css` back into the final page.

This follow-up:
- unconditionally excludes `digits-login-style` from sidebar dependencies
- preserves ordering against the already-loaded Digits main and RTL layers
- strengthens the regression test for both queued and merely registered base-handle states

## Verification
- focused PHPUnit: 5 tests / 15 assertions
- targeted PHPCS and PHP syntax: pass
- production evidence before follow-up: base link appeared after RTL solely because it was made a dependency
- `git diff --check`: pass

Follow-up to #116 and #110.