### PR TITLE
Fix catalog code column alignment

### DIFF
--- a/assets/css/storefront-catalog.css
+++ b/assets/css/storefront-catalog.css
@@ -223,10 +223,14 @@
 }
 
 .dgl-catalog-product-cell {
+	display: table-cell;
+	min-width: 310px;
+}
+
+.dgl-catalog-product-layout {
 	align-items: center;
 	display: flex;
 	gap: 12px;
-	min-width: 310px;
 }
 
 .dgl-catalog-thumb {
@@ -293,13 +297,20 @@
 }
 
 .dgl-catalog-code {
-	align-items: flex-start;
 	color: #67778d;
-	display: flex;
-	flex-direction: column;
+	display: table-cell;
 	font-size: 10px;
-	gap: 3px;
 	text-align: right !important;
+}
+
+.dgl-catalog-code > span,
+.dgl-catalog-code > b,
+.dgl-catalog-code > a {
+	display: block;
+}
+
+.dgl-catalog-code > * + * {
+	margin-block-start: 3px;
 }
 
 .dgl-catalog-code span {

--- a/includes/integrations/class-storefront-product-table.php
+++ b/includes/integrations/class-storefront-product-table.php
@@ -624,25 +624,27 @@ final class Digitalogic_Storefront_Product_Table {
 		?>
 		<tr data-product-id="<?php echo esc_attr( $product->get_id() ); ?>">
 			<td class="dgl-catalog-product-cell">
-				<a class="dgl-catalog-thumb" href="<?php echo esc_url( $url ); ?>" aria-label="<?php echo esc_attr( $name ); ?>">
-					<?php if ( $product->get_image_id() ) : ?>
-						<?php echo wp_get_attachment_image( $product->get_image_id(), 'woocommerce_thumbnail', false, array( 'loading' => 'lazy', 'alt' => $name ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					<?php else : ?>
-						<span class="dgl-catalog-no-image" aria-hidden="true"><i></i><b>DL</b></span>
-					<?php endif; ?>
-				</a>
-				<div>
-					<a class="dgl-catalog-product-name" href="<?php echo esc_url( $url ); ?>"><?php echo esc_html( $name ); ?></a>
-					<span class="dgl-catalog-mobile-meta">
-						<?php if ( $code ) : ?>
-							<?php echo esc_html( $code_label ); ?> <b dir="ltr"><?php echo esc_html( $code ); ?></b> ·
-						<?php elseif ( $child_codes ) : ?>
-							کدهای ثبت‌شده برای مدل‌ها <b dir="ltr"><?php echo esc_html( implode( ' · ', $child_codes ) ); ?></b> ·
-						<?php elseif ( $is_variable ) : ?>
-							کد کالا بعد از انتخاب مدل ·
+				<div class="dgl-catalog-product-layout">
+					<a class="dgl-catalog-thumb" href="<?php echo esc_url( $url ); ?>" aria-label="<?php echo esc_attr( $name ); ?>">
+						<?php if ( $product->get_image_id() ) : ?>
+							<?php echo wp_get_attachment_image( $product->get_image_id(), 'woocommerce_thumbnail', false, array( 'loading' => 'lazy', 'alt' => $name ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php else : ?>
+							<span class="dgl-catalog-no-image" aria-hidden="true"><i></i><b>DL</b></span>
 						<?php endif; ?>
-						<?php echo wp_kses_post( $categories ); ?>
-					</span>
+					</a>
+					<div>
+						<a class="dgl-catalog-product-name" href="<?php echo esc_url( $url ); ?>"><?php echo esc_html( $name ); ?></a>
+						<span class="dgl-catalog-mobile-meta">
+							<?php if ( $code ) : ?>
+								<?php echo esc_html( $code_label ); ?> <b dir="ltr"><?php echo esc_html( $code ); ?></b> ·
+							<?php elseif ( $child_codes ) : ?>
+								کدهای ثبت‌شده برای مدل‌ها <b dir="ltr"><?php echo esc_html( implode( ' · ', $child_codes ) ); ?></b> ·
+							<?php elseif ( $is_variable ) : ?>
+								کد کالا بعد از انتخاب مدل ·
+							<?php endif; ?>
+							<?php echo wp_kses_post( $categories ); ?>
+						</span>
+					</div>
 				</div>
 			</td>
 			<td class="dgl-catalog-code">

--- a/tests/StorefrontCatalogTest.php
+++ b/tests/StorefrontCatalogTest.php
@@ -44,6 +44,17 @@ final class StorefrontCatalogTest extends TestCase {
 		add_filter( 'digitalogic_is_public_storefront_request', static fn() => true );
 	}
 
+	/** Table cells must retain table formatting; flex belongs to an inner wrapper. */
+	public function test_catalog_code_and_product_cells_keep_table_column_layout(): void {
+		$css = file_get_contents( dirname( __DIR__ ) . '/assets/css/storefront-catalog.css' );
+
+		$this->assertIsString( $css );
+		$this->assertMatchesRegularExpression( '/\.dgl-catalog-product-cell\s*\{[^}]*display:\s*table-cell;/s', $css );
+		$this->assertMatchesRegularExpression( '/\.dgl-catalog-product-layout\s*\{[^}]*display:\s*flex;/s', $css );
+		$this->assertMatchesRegularExpression( '/\.dgl-catalog-code\s*\{[^}]*display:\s*table-cell;/s', $css );
+		$this->assertDoesNotMatchRegularExpression( '/\.dgl-catalog-code\s*\{[^}]*display:\s*flex;/s', $css );
+	}
+
 	public function test_forces_empty_category_hiding_only_for_product_categories(): void {
 		$catalog = ( new ReflectionClass( Digitalogic_Storefront_Catalog::class ) )->newInstanceWithoutConstructor();
 
@@ -273,6 +284,9 @@ final class StorefrontCatalogTest extends TestCase {
 		$this->assertStringContainsString( '>کد کالا</span>', $html );
 		$this->assertStringContainsString( 'CODE-49', $html );
 		$this->assertStringNotContainsString( 'کد پاتریس', $html );
+		$this->assertSame( 6, substr_count( $html, '<td' ) );
+		$this->assertStringContainsString( 'class="dgl-catalog-product-layout"', $html );
+		$this->assertMatchesRegularExpression( '/<td class="dgl-catalog-product-cell">.*<\/td>\s*<td class="dgl-catalog-code">/s', $html );
 	}
 
 	/** Ensure an unrelated WooCommerce SKU keeps its own label. */


### PR DESCRIPTION
## Summary

- keep catalog product and code cells in the table formatting context
- move the product cell's flex layout to a dedicated inner wrapper
- preserve the stacked code details within the code column
- add DOM and CSS regression coverage for the six-column catalog layout

Closes #120

## Root cause

The product and code `<td>` elements were both assigned `display: flex`. CSS table-box repair grouped those consecutive non-table-cell boxes into an anonymous table cell, which made the code appear as a separate row under the product instead of in the code column.

## Validation

- `vendor/bin/phpunit --testdox tests/StorefrontCatalogTest.php` — 9 tests, 31 assertions
- `vendor/bin/phpunit` — 273 tests, 1688 assertions; 5 skipped, 1 existing warning
- `php -l includes/integrations/class-storefront-product-table.php`
- `node --check assets/js/storefront-catalog.js`
- `node --test tests/product-query.test.js` — 7 tests passed
- `git diff --check`

## Live verification plan

- verify every desktop catalog row has six aligned table cells
- verify the code cell aligns with its category, stock, price, and action siblings
- verify the responsive view still hides the dedicated code column and shows the compact metadata
