### PR TITLE
Expose PBX verification in the login sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.3
+
+- Expose the existing inbound-call login verification beneath the active Digits OTP resend control in the Woodmart sidebar, with singleton AJAX remounting, Persian/RTL and mobile containment, keyboard disclosure semantics, and live dial/IVR instructions.
+
 ## 1.6.2
 
 - Restore the Digits password/verification-code layout in the guest Woodmart login sidebar, including scoped RTL, responsive, OTP-help, loading, error, honeypot, and keyboard-accessibility safeguards.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - Non-blocking async delivery
 
 ### ☎️ Phone verification and PBX notifications
-- Login or add an Iranian mobile/landline contact by calling `021-66754123` and choosing IVR option `2`
+- From the Digits OTP sidebar, choose **Verify by calling**, or add an Iranian mobile/landline contact from My Account, then call `021-66754123` and choose IVR option `2`
 - Six-digit, 10-minute challenge with exact caller-ID matching and single-use browser-bound consumption
 - Multiple supplemental emails and verified phone contacts in WooCommerce My Account
 - Per-number customer/admin consent controls for voice order updates

--- a/assets/css/call-verification.css
+++ b/assets/css/call-verification.css
@@ -8,6 +8,8 @@
 	background: #fff;
 }
 
+.digitalogic-call-parking[hidden],
+.digitalogic-call-verification[hidden],
 .digitalogic-call-panel[hidden],
 .digitalogic-call-instructions[hidden],
 .digitalogic-call-error[hidden] {

--- a/assets/css/sidebar-login.css
+++ b/assets/css/sidebar-login.css
@@ -353,6 +353,167 @@ body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_popdismiss:focus-vi
 	overflow: hidden !important;
 }
 
+.login-form-side .digitalogic-call-verification--sidebar,
+.login-form-side .digitalogic-call-verification--sidebar * {
+	box-sizing: border-box;
+	max-width: 100%;
+	min-width: 0;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar {
+	--digitalogic-call-accent: #873800;
+
+	width: 100%;
+	margin: .25rem 0 0;
+	padding: 0;
+	border: 0;
+	background: transparent;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	min-height: 44px;
+	margin: .25rem 0 0;
+	padding: .65rem .5rem;
+	border: 1px solid var(--digitalogic-call-accent) !important;
+	border-radius: var(--wd-brd-radius, 4px);
+	background: #fff7f0 !important;
+	background: color-mix(in srgb, var(--wd-primary-color, #f58220) 9%, #fff) !important;
+	color: var(--digitalogic-call-accent) !important;
+	font-size: .875rem;
+	font-weight: 700;
+	line-height: 1.5;
+	text-align: center;
+	box-shadow: none !important;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-toggle:hover,
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-toggle[aria-expanded="true"] {
+	background: #ffefe2 !important;
+	background: color-mix(in srgb, var(--wd-primary-color, #f58220) 15%, #fff) !important;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-toggle:focus-visible,
+.login-form-side .digitalogic-call-verification--sidebar button:focus-visible,
+.login-form-side .digitalogic-call-verification--sidebar input:focus-visible,
+.login-form-side .digitalogic-call-verification--sidebar a:focus-visible {
+	outline: 2px solid var(--digitalogic-call-accent);
+	outline-offset: 2px;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-panel {
+	display: grid;
+	gap: .75rem;
+	width: 100%;
+	margin: .5rem 0 0;
+	padding: .75rem;
+	border: 1px solid var(--brdcolor-gray-300, #d7d7d7);
+	border-inline-start: 3px solid var(--wd-primary-color, #f58220);
+	border-radius: var(--wd-brd-radius, 4px);
+	background: var(--bgcolor-gray-100, #f7f7f7);
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-panel label {
+	display: grid;
+	gap: .35rem;
+	margin: 0;
+	font-size: .8125rem;
+	line-height: 1.65;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-phone] {
+	width: 100%;
+	min-height: 44px;
+	margin: 0;
+	direction: ltr;
+	text-align: left;
+	unicode-bidi: isolate;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-start] {
+	width: 100%;
+	min-height: 44px;
+	margin: 0;
+	border-color: var(--digitalogic-call-accent) !important;
+	background: var(--digitalogic-call-accent) !important;
+	color: #fff !important;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-start]:hover:not(:disabled) {
+	border-color: #672900 !important;
+	background: #672900 !important;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-match-note {
+	margin: 0;
+	color: var(--color-gray-600, #666);
+	font-size: .75rem;
+	line-height: 1.65;
+	overflow-wrap: anywhere;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-instructions {
+	width: 100%;
+	padding: .75rem;
+	border-inline-start: 3px solid var(--wd-primary-color, #f58220);
+	background: #fff;
+	font-size: .8125rem;
+	line-height: 1.75;
+	overflow-wrap: anywhere;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-instructions p {
+	margin: 0 0 .5rem;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-instructions p:last-of-type {
+	margin-bottom: 0;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-dial],
+.login-form-side .digitalogic-call-verification--sidebar [data-call-ivr],
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-code {
+	direction: ltr;
+	unicode-bidi: isolate;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-dial] {
+	display: inline-block;
+	color: var(--digitalogic-call-accent) !important;
+	font-weight: 700;
+	text-decoration: underline;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-code {
+	display: block;
+	width: 100%;
+	margin: .65rem 0;
+	font-size: clamp(1.4rem, 8vw, 2rem);
+	letter-spacing: .16em;
+	text-align: center;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-cancel] {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 44px;
+	padding: .5rem;
+	color: var(--digitalogic-call-accent) !important;
+	text-decoration: underline;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-error {
+	margin: 0;
+	color: #b32d2e;
+	font-size: .8125rem;
+	line-height: 1.65;
+	overflow-wrap: anywhere;
+}
+
 @media (max-width: 380px) {
 	.login-form-side .digits-form_tab-bar {
 		gap: .375rem;
@@ -361,6 +522,16 @@ body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_popdismiss:focus-vi
 	.login-form-side .digits-form_tab-bar .digits-form_tab-item {
 		padding-inline: .2rem;
 		font-size: .8125rem;
+	}
+
+	.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-panel,
+	.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-instructions {
+		padding: .625rem;
+	}
+
+	.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-code {
+		font-size: 1.45rem;
+		letter-spacing: .1em;
 	}
 
 	body > .dig_popmessage.digitalogic-sidebar-login-notice {

--- a/assets/js/call-verification.js
+++ b/assets/js/call-verification.js
@@ -36,7 +36,11 @@
 		return result;
 	}
 
-	document.querySelectorAll('[data-digitalogic-call-widget]').forEach((widget) => {
+	function initializeWidget(widget) {
+		if (!(widget instanceof HTMLElement) || widget.dataset.digitalogicCallInitialized === 'true') {
+			return;
+		}
+
 		const toggle = widget.querySelector('.digitalogic-call-toggle');
 		const panel = widget.querySelector('.digitalogic-call-panel');
 		const phone = widget.querySelector('[data-call-phone]');
@@ -46,11 +50,19 @@
 		const status = widget.querySelector('[data-call-status]');
 		const cancel = widget.querySelector('[data-call-cancel]');
 		const error = widget.querySelector('[data-call-error]');
+		const dial = widget.querySelector('[data-call-dial]');
+		const ivr = widget.querySelector('[data-call-ivr]');
+		if (!panel || !phone || !start || !instructions || !code || !status || !error) {
+			return;
+		}
+
+		widget.dataset.digitalogicCallInitialized = 'true';
 		const purpose = widget.dataset.purpose || 'login';
 		let challengeId = '';
 		let csrfToken = '';
 		let pollTimer = 0;
 		let stopped = false;
+		let attemptGeneration = 0;
 
 		function showError(value) {
 			error.textContent = value || messages.error || 'Verification failed.';
@@ -64,20 +76,32 @@
 
 		function resetForRetry(message) {
 			stopPolling();
+			attemptGeneration += 1;
 			challengeId = '';
 			csrfToken = '';
 			code.textContent = '';
 			instructions.hidden = true;
 			start.disabled = false;
+			if (cancel) {
+				cancel.disabled = false;
+			}
+			widget.removeAttribute('aria-busy');
 			showError(message);
 		}
 
-		async function consume() {
-			const data = await request(`${config.challengeUrl}/${encodeURIComponent(challengeId)}/consume`, {
+		async function consume(expectedGeneration, expectedChallengeId, expectedCsrfToken) {
+			const data = await request(`${config.challengeUrl}/${encodeURIComponent(expectedChallengeId)}/consume`, {
 				method: 'POST',
-				headers: headers(csrfToken, purpose === 'add_contact'),
+				headers: headers(expectedCsrfToken, purpose === 'add_contact'),
 				body: '{}',
 			});
+			if (
+				stopped
+				|| expectedGeneration !== attemptGeneration
+				|| expectedChallengeId !== challengeId
+			) {
+				return;
+			}
 			status.textContent = messages.verified || 'Verified.';
 			if (data.redirect_url) {
 				window.location.assign(data.redirect_url);
@@ -86,20 +110,46 @@
 			}
 		}
 
-		async function poll() {
-			if (stopped || !challengeId) {
+		async function poll(expectedGeneration) {
+			if (
+				stopped
+				|| expectedGeneration !== attemptGeneration
+				|| !challengeId
+				|| !widget.isConnected
+			) {
+				stopPolling();
 				return;
 			}
+			const expectedChallengeId = challengeId;
+			const expectedCsrfToken = csrfToken;
 			try {
-				const data = await request(`${config.challengeUrl}/${encodeURIComponent(challengeId)}`, {
+				const data = await request(`${config.challengeUrl}/${encodeURIComponent(expectedChallengeId)}`, {
 					method: 'GET',
-					headers: headers(csrfToken),
+					headers: headers(expectedCsrfToken),
 				});
+				if (
+					stopped
+					|| expectedGeneration !== attemptGeneration
+					|| expectedChallengeId !== challengeId
+				) {
+					return;
+				}
 				if (data.status === 'verified') {
-					stopPolling();
+					window.clearTimeout(pollTimer);
+					if (cancel) {
+						cancel.disabled = true;
+					}
+					widget.setAttribute('aria-busy', 'true');
 					try {
-						await consume();
+						await consume(expectedGeneration, expectedChallengeId, expectedCsrfToken);
 					} catch (consumeError) {
+						if (
+							stopped
+							|| expectedGeneration !== attemptGeneration
+							|| expectedChallengeId !== challengeId
+						) {
+							return;
+						}
 						resetForRetry(consumeError.message);
 					}
 					return;
@@ -110,14 +160,26 @@
 					return;
 				}
 			} catch (pollError) {
+				if (
+					stopped
+					|| expectedGeneration !== attemptGeneration
+					|| expectedChallengeId !== challengeId
+				) {
+					return;
+				}
 				resetForRetry(pollError.message);
 				return;
 			}
-			pollTimer = window.setTimeout(poll, 2000);
+			pollTimer = window.setTimeout(() => poll(expectedGeneration), 2000);
+		}
+
+		if (toggle) {
+			toggle.setAttribute('aria-expanded', panel.hidden ? 'false' : 'true');
 		}
 
 		toggle?.addEventListener('click', () => {
 			panel.hidden = !panel.hidden;
+			toggle.setAttribute('aria-expanded', panel.hidden ? 'false' : 'true');
 			if (!panel.hidden) {
 				phone.focus();
 			}
@@ -125,48 +187,99 @@
 
 		start?.addEventListener('click', async () => {
 			stopPolling();
+			attemptGeneration += 1;
+			const expectedGeneration = attemptGeneration;
 			stopped = false;
 			error.hidden = true;
 			instructions.hidden = true;
 			code.textContent = '';
 			start.disabled = true;
+			if (cancel) {
+				cancel.disabled = false;
+			}
+			widget.setAttribute('aria-busy', 'true');
 			try {
 				const data = await request(config.challengeUrl, {
 					method: 'POST',
 					headers: headers('', purpose === 'add_contact'),
 					body: JSON.stringify({ phone: phone.value, purpose }),
 				});
+				if (stopped || expectedGeneration !== attemptGeneration) {
+					return;
+				}
 				challengeId = data.challenge_id;
 				csrfToken = data.csrf_token;
 				code.textContent = data.code;
+				if (dial && data.dial) {
+					const display = String(data.dial.display || '');
+					const tel = String(data.dial.tel || '');
+					dial.textContent = display;
+					if (/^\+?[0-9]+$/.test(tel)) {
+						dial.setAttribute('href', `tel:${tel}`);
+					}
+				}
+				if (ivr) {
+					ivr.textContent = String(data.ivr_option || '');
+				}
 				status.textContent = messages.waiting || 'Waiting for your call…';
 				instructions.hidden = false;
-				pollTimer = window.setTimeout(poll, 1200);
+				widget.removeAttribute('aria-busy');
+				pollTimer = window.setTimeout(() => poll(expectedGeneration), 1200);
 			} catch (startError) {
+				if (stopped || expectedGeneration !== attemptGeneration) {
+					return;
+				}
 				start.disabled = false;
+				widget.removeAttribute('aria-busy');
 				showError(startError.message);
 			}
 		});
 
 		cancel?.addEventListener('click', async () => {
 			stopPolling();
-			if (challengeId) {
-				try {
-					await request(`${config.challengeUrl}/${encodeURIComponent(challengeId)}`, {
-						method: 'DELETE',
-						headers: headers(csrfToken),
-					});
-				} catch (_error) {
-					// Cancellation is best effort; the server expiry remains authoritative.
-				}
-			}
+			attemptGeneration += 1;
+			const cancelledChallengeId = challengeId;
+			const cancelledCsrfToken = csrfToken;
 			challengeId = '';
 			csrfToken = '';
 			code.textContent = '';
 			instructions.hidden = true;
 			start.disabled = false;
+			widget.removeAttribute('aria-busy');
+			if (cancelledChallengeId) {
+				try {
+					await request(`${config.challengeUrl}/${encodeURIComponent(cancelledChallengeId)}`, {
+						method: 'DELETE',
+						headers: headers(cancelledCsrfToken),
+					});
+				} catch (_error) {
+					// Cancellation is best effort; the server expiry remains authoritative.
+				}
+			}
+			phone.focus();
+		});
+	}
+
+	function initializeWidgets(root = document) {
+		if (root instanceof Element && root.matches('[data-digitalogic-call-widget]')) {
+			initializeWidget(root);
+		}
+		if (typeof root.querySelectorAll === 'function') {
+			root.querySelectorAll('[data-digitalogic-call-widget]').forEach(initializeWidget);
+		}
+	}
+
+	initializeWidgets();
+	const widgetObserver = new MutationObserver((records) => {
+		records.forEach((record) => {
+			record.addedNodes.forEach((node) => {
+				if (node instanceof Element) {
+					initializeWidgets(node);
+				}
+			});
 		});
 	});
+	widgetObserver.observe(document.body, { childList: true, subtree: true });
 
 	const contacts = document.querySelector('[data-digitalogic-contacts]');
 	if (!contacts || !config.contactsUrl || !config.wpNonce) {

--- a/assets/js/sidebar-login.js
+++ b/assets/js/sidebar-login.js
@@ -9,8 +9,12 @@
     ].join(',');
     const keyboardAttribute = 'data-digitalogic-keyboard-control';
     const noticeClass = 'digitalogic-sidebar-login-notice';
+    const callWidgetSelector = '[data-digitalogic-sidebar-call-widget]';
+    const callParkingSelector = '[data-digitalogic-sidebar-call-parking]';
     let sidebarNoticePending = false;
     let sidebarNoticeTimer = 0;
+    let sidebarCallWidget = null;
+    let sidebarCallParking = null;
 
     const isNativeControl = (element) => element.matches(
         'a[href],button,input,select,textarea,summary'
@@ -61,6 +65,61 @@
 
     const enhanceAll = () => {
         document.querySelectorAll(sidebarSelector).forEach(enhanceSidebar);
+    };
+
+    const toAsciiDigits = (value) => String(value || '')
+        .replace(/[۰-۹]/g, (digit) => String(digit.charCodeAt(0) - 1776))
+        .replace(/[٠-٩]/g, (digit) => String(digit.charCodeAt(0) - 1632));
+
+    const phoneLike = (value) => {
+        const compact = toAsciiDigits(value).replace(/[^+0-9]/g, '');
+        return /^(?:\+98|0098|98|0)[0-9]{10}$/.test(compact);
+    };
+
+    const prefillSidebarPhone = (widget, sidebar) => {
+        const input = widget.querySelector('[data-call-phone]');
+        if (!(input instanceof HTMLInputElement) || input.value.trim()) {
+            return;
+        }
+
+        const candidate = sidebar.querySelector('#username')?.value;
+        if (candidate) {
+            if (phoneLike(candidate)) {
+                input.value = candidate.trim();
+            }
+        }
+    };
+
+    const syncSidebarCallWidget = () => {
+        sidebarCallWidget = sidebarCallWidget || document.querySelector(callWidgetSelector);
+        sidebarCallParking = sidebarCallParking || document.querySelector(callParkingSelector);
+        if (!(sidebarCallWidget instanceof HTMLElement)) {
+            return;
+        }
+
+        const activeOtpBody = Array.from(document.querySelectorAll(
+            `${sidebarSelector} .digits-form_tab_body.digits-tab_active`
+        )).find((body) => body.querySelector('.digits-form_resend_otp'));
+        const resend = activeOtpBody?.querySelector('.digits-form_resend_otp');
+        const sidebar = activeOtpBody?.closest(sidebarSelector);
+
+        if (resend && sidebar) {
+            const mountAnchor = resend.closest('.digits-form_footer_content') || resend;
+            if (mountAnchor.nextElementSibling !== sidebarCallWidget) {
+                mountAnchor.insertAdjacentElement('afterend', sidebarCallWidget);
+            }
+            sidebarCallWidget.hidden = false;
+            prefillSidebarPhone(sidebarCallWidget, sidebar);
+            return;
+        }
+
+        sidebarCallWidget.hidden = true;
+        if (
+            sidebarCallParking instanceof HTMLElement
+            && sidebarCallWidget.parentElement !== sidebarCallParking
+        ) {
+            sidebarCallParking.append(sidebarCallWidget);
+        }
     };
 
     const expectSidebarNotice = () => {
@@ -163,6 +222,7 @@
 
     const start = () => {
         enhanceAll();
+        syncSidebarCallWidget();
 
         const observer = new MutationObserver((records) => {
             records.forEach((record) => {
@@ -176,6 +236,7 @@
                     markSidebarNotice(node);
                 });
             });
+            syncSidebarCallWidget();
         });
         observer.observe(document.body, {
             attributes: true,

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.6.2
+ * Version: 1.6.3
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.6.2' );
+define( 'DIGITALOGIC_VERSION', '1.6.3' );
 define( 'DIGITALOGIC_PBX_SCHEMA_VERSION', '3' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));

--- a/includes/integrations/class-call-verification.php
+++ b/includes/integrations/class-call-verification.php
@@ -70,6 +70,7 @@ final class Digitalogic_Call_Verification {
 		add_action( 'login_enqueue_scripts', array( $this, 'enqueue_assets' ), 40 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_account_assets' ), 40 );
 		add_action( 'login_footer', array( $this, 'render_login_verification' ) );
+		add_action( 'wp_footer', array( $this, 'render_sidebar_login_verification' ), 5 );
 		add_action( 'woocommerce_after_edit_account_form', array( $this, 'render_account_contacts' ) );
 		add_action( 'show_user_profile', array( $this, 'render_admin_contacts' ) );
 		add_action( 'edit_user_profile', array( $this, 'render_admin_contacts' ) );
@@ -1374,10 +1375,17 @@ final class Digitalogic_Call_Verification {
 	}
 
 	/**
-	 * Enqueue assets only on WooCommerce account pages.
+	 * Enqueue assets on WooCommerce account pages and guest storefronts.
+	 *
+	 * The Woodmart login sidebar is available across public pages and Digits builds
+	 * its OTP step after an AJAX request. Loading the existing PBX controller here
+	 * lets the sidebar move one pre-initialized widget into that dynamic step.
 	 */
 	public function maybe_enqueue_account_assets(): void {
-		if ( function_exists( 'is_account_page' ) && is_account_page() ) {
+		$is_account_page = function_exists( 'is_account_page' ) && is_account_page();
+		$is_guest_page   = ! is_admin() && ! is_user_logged_in();
+
+		if ( $is_account_page || $is_guest_page ) {
 			$this->enqueue_assets();
 		}
 	}
@@ -1389,20 +1397,59 @@ final class Digitalogic_Call_Verification {
 		if ( ! self::is_configured() ) {
 			return;
 		}
+
+		$this->render_login_widget( false );
+	}
+
+	/**
+	 * Park one initialized login widget in the footer for the AJAX sidebar.
+	 *
+	 * The sidebar script moves this exact node rather than cloning it, preserving
+	 * its challenge id, CSRF proof, event listeners, and polling state when Digits
+	 * rebuilds or switches its password/OTP panels.
+	 */
+	public function render_sidebar_login_verification(): void {
+		if ( is_admin() || is_user_logged_in() || ! self::is_configured() ) {
+			return;
+		}
 		?>
-		<section class="digitalogic-call-verification" data-digitalogic-call-widget data-purpose="login">
-			<button type="button" class="button digitalogic-call-toggle"><?php esc_html_e( 'Verify by calling', 'digitalogic' ); ?></button>
-			<div class="digitalogic-call-panel" hidden>
+		<div class="digitalogic-call-parking" data-digitalogic-sidebar-call-parking hidden>
+			<?php $this->render_login_widget( true ); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the shared login-purpose call-verification controls.
+	 *
+	 * @param bool $sidebar Whether this is the singleton parked for Woodmart.
+	 */
+	private function render_login_widget( bool $sidebar ): void {
+		$toggle_id     = $sidebar ? 'digitalogic-sidebar-call-toggle' : 'digitalogic-login-call-toggle';
+		$panel_id      = $sidebar ? 'digitalogic-sidebar-call-panel' : 'digitalogic-login-call-panel';
+		$phone_help_id = $sidebar ? 'digitalogic-sidebar-call-phone-help' : 'digitalogic-login-call-phone-help';
+		?>
+		<section
+			class="<?php echo esc_attr( 'digitalogic-call-verification' . ( $sidebar ? ' digitalogic-call-verification--sidebar' : '' ) ); ?>"
+			data-digitalogic-call-widget
+			data-purpose="login"
+			<?php if ( $sidebar ) : ?>
+				data-digitalogic-sidebar-call-widget hidden
+			<?php endif; ?>
+		>
+			<button type="button" id="<?php echo esc_attr( $toggle_id ); ?>" class="button digitalogic-call-toggle" aria-expanded="false" aria-controls="<?php echo esc_attr( $panel_id ); ?>"><?php esc_html_e( 'Verify by calling', 'digitalogic' ); ?></button>
+			<div class="digitalogic-call-panel" id="<?php echo esc_attr( $panel_id ); ?>" role="region" aria-labelledby="<?php echo esc_attr( $toggle_id ); ?>" hidden>
 				<label>
-					<span><?php esc_html_e( 'Mobile or landline number', 'digitalogic' ); ?></span>
-					<input type="tel" inputmode="tel" autocomplete="tel" data-call-phone placeholder="02112345678">
+					<span><?php esc_html_e( 'Mobile or landline number (include area code)', 'digitalogic' ); ?></span>
+					<input type="tel" inputmode="tel" autocomplete="tel" dir="ltr" data-call-phone aria-describedby="<?php echo esc_attr( $phone_help_id ); ?>" placeholder="02112345678">
 				</label>
+				<p class="digitalogic-call-match-note" id="<?php echo esc_attr( $phone_help_id ); ?>"><?php esc_html_e( 'Place the call from the same phone number you entered so caller ID can confirm ownership.', 'digitalogic' ); ?></p>
 				<button type="button" class="button button-primary" data-call-start><?php esc_html_e( 'Create call code', 'digitalogic' ); ?></button>
-				<div class="digitalogic-call-instructions" data-call-instructions hidden aria-live="polite">
-					<p><?php esc_html_e( 'Call', 'digitalogic' ); ?> <a dir="ltr" href="tel:+982166754123">021-66754123</a>.</p>
-					<p><?php printf( esc_html__( 'Choose IVR option %s, then enter this six-digit code:', 'digitalogic' ), '<strong dir="ltr">2</strong>' ); ?></p>
-					<output class="digitalogic-call-code" data-call-code dir="ltr"></output>
-					<p data-call-status><?php esc_html_e( 'Waiting for your call…', 'digitalogic' ); ?></p>
+				<div class="digitalogic-call-instructions" data-call-instructions hidden>
+					<p><?php esc_html_e( 'Call', 'digitalogic' ); ?> <a dir="ltr" data-call-dial href="tel:<?php echo esc_attr( self::DIAL_TEL ); ?>"><?php echo esc_html( self::DIAL_DISPLAY ); ?></a></p>
+					<p><?php printf( esc_html__( 'Choose IVR option %s, then enter this six-digit code:', 'digitalogic' ), '<strong dir="ltr" data-call-ivr>' . esc_html( self::IVR_OPTION ) . '</strong>' ); ?></p>
+					<output class="digitalogic-call-code" data-call-code dir="ltr" aria-live="polite"></output>
+					<p data-call-status role="status" aria-live="polite" aria-atomic="true"><?php esc_html_e( 'Waiting for your call…', 'digitalogic' ); ?></p>
 					<button type="button" class="button-link" data-call-cancel><?php esc_html_e( 'Cancel', 'digitalogic' ); ?></button>
 				</div>
 				<p class="digitalogic-call-error" data-call-error role="alert" hidden></p>

--- a/includes/integrations/class-digitalogic-sidebar-login.php
+++ b/includes/integrations/class-digitalogic-sidebar-login.php
@@ -45,7 +45,10 @@ final class Digitalogic_Sidebar_Login {
 			return;
 		}
 
-		$dependencies = self::enqueued_digits_styles();
+		$dependencies = array_merge(
+			array( 'digitalogic-call-verification' ),
+			self::enqueued_digits_styles()
+		);
 
 		wp_enqueue_style(
 			self::STYLE_HANDLE,
@@ -62,7 +65,7 @@ final class Digitalogic_Sidebar_Login {
 		wp_enqueue_script(
 			self::SCRIPT_HANDLE,
 			DIGITALOGIC_PLUGIN_URL . self::SCRIPT_FILE,
-			array(),
+			array( 'digitalogic-call-verification' ),
 			(string) filemtime( $script_path ),
 			true
 		);

--- a/languages/digitalogic-fa_IR.po
+++ b/languages/digitalogic-fa_IR.po
@@ -1792,6 +1792,10 @@ msgid "Mobile or landline number (include area code)"
 msgstr "شماره موبایل یا تلفن ثابت (همراه با کد شهر)"
 
 #: includes/integrations/class-call-verification.php
+msgid "Place the call from the same phone number you entered so caller ID can confirm ownership."
+msgstr "تماس را دقیقاً از همان شماره‌ای برقرار کنید که وارد کرده‌اید تا مالکیت آن از روی شماره تماس‌گیرنده تأیید شود."
+
+#: includes/integrations/class-call-verification.php
 msgid "Create call code"
 msgstr "دریافت کد تماس"
 

--- a/languages/digitalogic.pot
+++ b/languages/digitalogic.pot
@@ -1838,6 +1838,10 @@ msgid "Mobile or landline number (include area code)"
 msgstr ""
 
 #: includes/integrations/class-call-verification.php
+msgid "Place the call from the same phone number you entered so caller ID can confirm ownership."
+msgstr ""
+
+#: includes/integrations/class-call-verification.php
 msgid "Create call code"
 msgstr ""
 

--- a/tests/CallVerificationTest.php
+++ b/tests/CallVerificationTest.php
@@ -645,6 +645,31 @@ final class CallVerificationTest extends TestCase {
         $this->assertStringContainsString("'call-event'", $source);
     }
 
+	public function test_guest_sidebar_reuses_one_configured_login_widget_without_exposing_secrets(): void {
+		$source = file_get_contents( dirname( __DIR__ ) . '/includes/integrations/class-call-verification.php' );
+		$enqueue_start = strpos( $source, 'public function enqueue_assets' );
+		$enqueue_end = strpos( $source, 'public function maybe_enqueue_account_assets', $enqueue_start );
+		$this->assertIsInt( $enqueue_start );
+		$this->assertIsInt( $enqueue_end );
+		$localized_source = substr( $source, $enqueue_start, $enqueue_end - $enqueue_start );
+
+		$this->assertStringContainsString(
+			"add_action( 'wp_footer', array( \$this, 'render_sidebar_login_verification' ), 5 )",
+			$source
+		);
+		$this->assertStringContainsString( '$is_guest_page   = ! is_admin() && ! is_user_logged_in();', $source );
+		$this->assertStringContainsString( 'data-digitalogic-sidebar-call-parking hidden', $source );
+		$this->assertStringContainsString( 'data-digitalogic-sidebar-call-widget hidden', $source );
+		$this->assertStringContainsString( 'data-purpose="login"', $source );
+		$this->assertStringContainsString( 'aria-expanded="false"', $source );
+		$this->assertStringContainsString( 'aria-describedby="<?php echo esc_attr( $phone_help_id ); ?>"', $source );
+		$this->assertStringContainsString( 'Place the call from the same phone number you entered so caller ID can confirm ownership.', $source );
+		$this->assertStringContainsString( 'data-call-dial', $source );
+		$this->assertStringContainsString( 'data-call-ivr', $source );
+		$this->assertStringContainsString( 'self::IVR_OPTION', $source );
+		$this->assertStringNotContainsString( 'DIGITALOGIC_PBX_VERIFY_SECRET', $localized_source );
+	}
+
     private function validPayload(int $timestamp): array {
         return array(
             'schema' => 'phone-verification.v1',

--- a/tests/SidebarLoginTest.php
+++ b/tests/SidebarLoginTest.php
@@ -89,7 +89,7 @@ final class SidebarLoginTest extends TestCase {
 		$this->assertCount( 1, $styles );
 		$this->assertArrayHasKey( 'digitalogic-sidebar-login', $styles );
 		$this->assertSame(
-			array( 'digits-style', 'digits-login-style-rtl' ),
+			array( 'digitalogic-call-verification', 'digits-style', 'digits-login-style-rtl' ),
 			$styles['digitalogic-sidebar-login']['dependencies']
 		);
 
@@ -98,6 +98,10 @@ final class SidebarLoginTest extends TestCase {
 		$this->assertSame(
 			'https://digitalogic.test/wp-content/plugins/digitalogic-wp/assets/js/sidebar-login.js',
 			$scripts['digitalogic-sidebar-login']['src']
+		);
+		$this->assertSame(
+			array( 'digitalogic-call-verification' ),
+			$scripts['digitalogic-sidebar-login']['dependencies']
 		);
 		$this->assertTrue( $scripts['digitalogic-sidebar-login']['in_footer'] );
 	}
@@ -109,7 +113,7 @@ final class SidebarLoginTest extends TestCase {
 		Digitalogic_Sidebar_Login::enqueue_sidebar_assets();
 
 		$this->assertSame(
-			array( 'digits-style', 'digits-login-style-rtl' ),
+			array( 'digitalogic-call-verification', 'digits-style', 'digits-login-style-rtl' ),
 			$GLOBALS['digitalogic_test_enqueued_styles']['digitalogic-sidebar-login']['dependencies']
 		);
 	}
@@ -120,7 +124,7 @@ final class SidebarLoginTest extends TestCase {
 		Digitalogic_Sidebar_Login::enqueue_sidebar_assets();
 
 		$this->assertSame(
-			array( 'digits-style', 'digits-login-style-rtl' ),
+			array( 'digitalogic-call-verification', 'digits-style', 'digits-login-style-rtl' ),
 			$GLOBALS['digitalogic_test_enqueued_styles']['digitalogic-sidebar-login']['dependencies']
 		);
 	}

--- a/tests/call-verification-ui.test.js
+++ b/tests/call-verification-ui.test.js
@@ -15,8 +15,8 @@ test('poll and consume failures clear browser-held proof and permit a safe retry
 	assert.match(source, /challengeId = '';/);
 	assert.match(source, /csrfToken = '';/);
 	assert.match(source, /start\.disabled = false;/);
-	assert.match(source, /catch \(consumeError\) \{\s*resetForRetry\(consumeError\.message\);/);
-	assert.match(source, /catch \(pollError\) \{\s*resetForRetry\(pollError\.message\);/);
+	assert.match(source, /catch \(consumeError\) \{[\s\S]*?resetForRetry\(consumeError\.message\);/);
+	assert.match(source, /catch \(pollError\) \{[\s\S]*?resetForRetry\(pollError\.message\);/);
 });
 
 test('contact consent writes are serialized, complete snapshots, and reload on failure', () => {
@@ -27,4 +27,65 @@ test('contact consent writes are serialized, complete snapshots, and reload on f
 	assert.match(source, /voice_events: \{\}/);
 	assert.match(source, /window\.location\.reload\(\);/);
 	assert.doesNotMatch(source, /event\.target\.checked = !event\.target\.checked/);
+});
+
+test('call widgets initialize idempotently and support dynamic storefront insertion', () => {
+	assert.match(source, /function initializeWidget\(widget\)/);
+	assert.match(source, /widget\.dataset\.digitalogicCallInitialized === 'true'/);
+	assert.match(source, /widget\.dataset\.digitalogicCallInitialized = 'true'/);
+	assert.match(source, /function initializeWidgets\(root = document\)/);
+	assert.match(source, /new MutationObserver\(\(records\) =>/);
+});
+
+test('the call alternative is disclosure-safe and makes no request until start', () => {
+	const toggleHandler = source.indexOf("toggle?.addEventListener('click'");
+	const startHandler = source.indexOf("start?.addEventListener('click'");
+	const requestCall = source.indexOf('await request(config.challengeUrl', startHandler);
+
+	assert.ok(toggleHandler > -1);
+	assert.ok(startHandler > toggleHandler);
+	assert.ok(requestCall > startHandler);
+	assert.doesNotMatch(source.slice(toggleHandler, startHandler), /request\(/);
+	assert.match(source, /toggle\.setAttribute\('aria-expanded', panel\.hidden \? 'false' : 'true'\)/);
+});
+
+test('server-returned dial number, IVR option, and code populate the instructions', () => {
+	assert.match(source, /dial\.textContent = display/);
+	assert.match(source, /dial\.setAttribute\('href', `tel:\$\{tel\}`\)/);
+	assert.match(source, /ivr\.textContent = String\(data\.ivr_option \|\| ''\)/);
+	assert.match(source, /code\.textContent = data\.code/);
+	assert.match(source, /body: JSON\.stringify\(\{ phone: phone\.value, purpose \}\)/);
+});
+
+test('cancel invalidates in-flight polling before it can consume a stale proof', () => {
+	const pollRequest = source.indexOf('const data = await request', source.indexOf('async function poll'));
+	const postPollGuard = source.indexOf('expectedGeneration !== attemptGeneration', pollRequest);
+	const consumeCall = source.indexOf('await consume(expectedGeneration', pollRequest);
+	const cancelHandler = source.indexOf("cancel?.addEventListener('click'");
+	const invalidate = source.indexOf('attemptGeneration += 1;', cancelHandler);
+	const clearChallenge = source.indexOf("challengeId = '';", invalidate);
+	const cancelRequest = source.indexOf('await request', clearChallenge);
+
+	assert.ok(pollRequest > -1);
+	assert.ok(postPollGuard > pollRequest);
+	assert.ok(consumeCall > postPollGuard);
+	assert.ok(cancelHandler > -1);
+	assert.ok(invalidate > cancelHandler);
+	assert.ok(clearChallenge > invalidate);
+	assert.ok(cancelRequest > clearChallenge);
+	assert.match(source, /async function consume\(expectedGeneration, expectedChallengeId, expectedCsrfToken\)/);
+	assert.match(source, /expectedChallengeId !== challengeId/);
+});
+
+test('cancel is disabled once verified proof consumption becomes irreversible', () => {
+	const verifiedBranch = source.indexOf("if (data.status === 'verified')");
+	const disableCancel = source.indexOf('cancel.disabled = true;', verifiedBranch);
+	const consumeCall = source.indexOf('await consume(expectedGeneration', verifiedBranch);
+	const retryReset = source.indexOf('cancel.disabled = false;', source.indexOf('function resetForRetry'));
+
+	assert.ok(verifiedBranch > -1);
+	assert.ok(disableCancel > verifiedBranch);
+	assert.ok(consumeCall > disableCancel);
+	assert.ok(retryReset > -1);
+	assert.match(source.slice(disableCancel, consumeCall), /widget\.setAttribute\('aria-busy', 'true'\)/);
 });

--- a/tests/sidebar-login-style.test.js
+++ b/tests/sidebar-login-style.test.js
@@ -93,6 +93,36 @@ test('body-appended Digits notices are marked and styled only for sidebar reques
     assert.doesNotMatch(css, /\.login-form-side \.dig_popmessage/);
 });
 
+test('the PBX singleton mounts only after the active OTP resend control', () => {
+    assert.match(accessibilityScript, /const callWidgetSelector = '\[data-digitalogic-sidebar-call-widget\]'/);
+    assert.match(accessibilityScript, /\.digits-form_tab_body\.digits-tab_active/);
+    assert.match(accessibilityScript, /body\.querySelector\('\.digits-form_resend_otp'\)/);
+    assert.match(accessibilityScript, /const mountAnchor = resend\.closest\('\.digits-form_footer_content'\) \|\| resend/);
+    assert.match(accessibilityScript, /mountAnchor\.nextElementSibling !== sidebarCallWidget/);
+    assert.match(accessibilityScript, /mountAnchor\.insertAdjacentElement\('afterend', sidebarCallWidget\)/);
+    assert.doesNotMatch(accessibilityScript, /resend\.insertAdjacentElement\('afterend', sidebarCallWidget\)/);
+    assert.doesNotMatch(accessibilityScript, /cloneNode\(/);
+});
+
+test('the PBX singleton is parked through Digits rerenders and only prefills phone-like input', () => {
+    assert.match(accessibilityScript, /const callParkingSelector = '\[data-digitalogic-sidebar-call-parking\]'/);
+    assert.match(accessibilityScript, /sidebarCallParking\.append\(sidebarCallWidget\)/);
+    assert.match(accessibilityScript, /sidebarCallWidget\.hidden = true/);
+    assert.match(accessibilityScript, /\^\(\?:\\\+98\|0098\|98\|0\)\[0-9\]\{10\}\$/);
+    assert.match(accessibilityScript, /const candidate = sidebar\.querySelector\('#username'\)\?\.value/);
+    assert.doesNotMatch(accessibilityScript, /querySelector\('input\[name="digits_phone"\]'\)/);
+    assert.match(accessibilityScript, /input\.value = candidate\.trim\(\)/);
+});
+
+test('the sidebar PBX panel remains bounded, RTL-safe, and touch friendly', () => {
+    assert.match(css, /\.login-form-side \.digitalogic-call-verification--sidebar\s*\{[^}]*width:\s*100%/s);
+    assert.match(css, /\.login-form-side \.digitalogic-call-verification--sidebar \*\s*\{[^}]*max-width:\s*100%;[^}]*min-width:\s*0;/s);
+    assert.match(css, /\.digitalogic-call-toggle\s*\{[^}]*min-height:\s*44px/s);
+    assert.match(css, /\[data-call-phone\]\s*\{[^}]*width:\s*100%;[^}]*min-height:\s*44px;[^}]*direction:\s*ltr;/s);
+    assert.match(css, /\.digitalogic-call-code\s*\{[^}]*unicode-bidi:\s*isolate;/s);
+    assert.match(css, /@media \(max-width:\s*380px\)/);
+});
+
 test('critical Digits rules cannot leak outside the Woodmart sidebar', () => {
     assert.doesNotMatch(css, /(?:^|\})\s*\.digits-form_tab_body\b/m);
     assert.doesNotMatch(css, /(?:^|\})\s*\.digits-form_tab-bar\b/m);


### PR DESCRIPTION
## Outcome
Adds the existing PBX inbound-call verification as a Persian-friendly alternative directly beneath the active Digits OTP resend area in the Woodmart sidebar.

## Changes
- moves one stateful PBX widget into the active OTP step without cloning it
- shows an accessible disclosure before any challenge is created
- renders server-returned dial number, IVR option 2, and six-digit code
- supports mobile/landline caller-ID matching instructions and safe phone prefill
- contains RTL/mobile styling and accessible contrast/focus states
- prevents cancel/poll/consume races across Digits AJAX rerenders
- bumps the plugin to 1.6.3 and updates Persian translations

## Verification
- 275 PHP tests / 2,097 assertions
- 33 Node tests
- changed-file PHPCS, PHP/JS syntax, gettext format, Composer validation/audit, and diff checks
- independent security and UI review: no blockers

Closes #122