### PR TITLE
Restore PBX verification in the Digits login sidebar

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,7 +80,9 @@ jobs:
         node --check assets/js/currency-postboxes.js
         node --check assets/js/branding/admin-branding.js
         node --check assets/js/call-verification.js
+        node --check assets/js/sidebar-login.js
         node --test tests/call-verification-ui.test.js
+        node --test tests/sidebar-login-style.test.js
         node --test tests/product-query.test.js
         node --test tests/admin-branding-auth-nav.test.js
         node --test tests/product-identity.test.js

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -54,8 +54,10 @@ jobs:
           node --check assets/js/panel-app.js
           node --check assets/js/currency-postboxes.js
           node --check assets/js/branding/admin-branding.js
+          node --check assets/js/sidebar-login.js
           node --test tests/product-query.test.js
           node --test tests/admin-branding-auth-nav.test.js
+          node --test tests/sidebar-login-style.test.js
 
       - name: Run PHPUnit tests
         run: composer test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shipping amounts, minimums, divisors, and tier bounds/rates now remain canonical decimal strings through storage and every outward projection, without exponent notation or binary-float loss.
 - Product sync preserves missing versus explicitly null freight fields, and the one-time installed-data migration bypasses stale option caches and verifies persistence before marking completion.
 
+## [1.6.5] - 2026-07-21
+
+### Fixed
+- Restored the narrowly scoped Woodmart/Digits sidebar compatibility layer so only the active login step is visible and the singleton call-verification control mounts immediately beneath the OTP resend action.
+- Restored Persian caller-ID guidance, keyboard semantics, RTL/mobile containment, scoped notice styling, and cache-busted sidebar assets without duplicating forms or verification widgets.
+
 ## [1.6.4] - 2026-07-21
 
 ### Fixed

--- a/assets/css/call-verification.css
+++ b/assets/css/call-verification.css
@@ -8,6 +8,8 @@
 	background: #fff;
 }
 
+.digitalogic-call-parking[hidden],
+.digitalogic-call-verification[hidden],
 .digitalogic-call-panel[hidden],
 .digitalogic-call-instructions[hidden],
 .digitalogic-call-error[hidden] {

--- a/assets/css/sidebar-login.css
+++ b/assets/css/sidebar-login.css
@@ -1,0 +1,561 @@
+/**
+ * Digits' AJAX login steps inside the Woodmart account sidebar.
+ *
+ * Form selectors are rooted at .login-form-side. Digits appends notices directly
+ * to body, so only notices explicitly marked by our sidebar script are global.
+ */
+
+.login-form-side .woocommerce-form-login.digits-tp_style,
+.login-form-side .digits-form_tab_wrapper,
+.login-form-side .digits-form_tab_container,
+.login-form-side .digits-form_tabs,
+.login-form-side .digits-form_body,
+.login-form-side .digits-form_body_wrapper,
+.login-form-side .digits-form_tab_body,
+.login-form-side .digits-form_input_row,
+.login-form-side .digits-form_input,
+.login-form-side .digits_secure_login_auth_wrapper {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 100%;
+	min-width: 0;
+}
+
+.login-form-side .digits-form_tab_container {
+	position: relative;
+}
+
+.login-form-side .digits-form_tab-bar {
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: stretch;
+	gap: .5rem;
+	width: 100%;
+	margin: 0 0 1rem;
+	padding: 0;
+	border: 0;
+	list-style: none;
+}
+
+.login-form-side .digits-form_tab-bar .digits-form_tab-item {
+	display: flex;
+	flex: 1 1 0;
+	align-items: center;
+	justify-content: center;
+	min-width: 0;
+	min-height: 44px;
+	padding: .55rem .35rem;
+	border: 1px solid var(--brdcolor-gray-300, #d7d7d7) !important;
+	border-radius: var(--wd-brd-radius, 4px);
+	background: var(--bgcolor-gray-100, #f7f7f7);
+	color: var(--color-gray-700, #4a4a4a);
+	font-size: .875rem;
+	font-weight: 600;
+	line-height: 1.45;
+	text-align: center;
+	opacity: .72;
+	cursor: pointer;
+}
+
+.login-form-side .digits-form_tab-bar .digits-form_tab-item.digits-tab_active {
+	border-color: var(--wd-primary-color, #f58220) !important;
+	background: #fff7f0;
+	background: color-mix(in srgb, var(--wd-primary-color, #f58220) 10%, #fff);
+	color: var(--color-gray-900, #242424);
+	box-shadow: inset 0 -2px 0 var(--wd-primary-color, #f58220) !important;
+	opacity: 1;
+}
+
+.login-form-side .digits-form_tab-bar .digits-form_tab-item:focus-visible,
+.login-form-side .digits-form_link:focus-visible,
+.login-form-side .digits_password_eye:focus-visible {
+	outline: 2px solid var(--wd-primary-color, #f58220);
+	outline-offset: 2px;
+}
+
+.login-form-side .digits-slider_line {
+	display: none !important;
+}
+
+.login-form-side .digits-form_body {
+	margin-top: 0;
+}
+
+.login-form-side .digits-form_tab_body:not(.digits-tab_active) {
+	display: none !important;
+}
+
+.login-form-side .digits-form_tab_body.digits-tab_active {
+	display: block !important;
+}
+
+.login-form-side .digits-form_input_row {
+	position: relative;
+	margin: 0 0 1rem;
+	border: 0;
+}
+
+.login-form-side .digits-form_input input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]),
+.login-form-side .digits-form_input textarea,
+.login-form-side .digits-form_input select {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 100%;
+	min-width: 0;
+	margin: 0;
+}
+
+.login-form-side .digits-form_input input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]) {
+	min-height: 44px;
+	line-height: normal;
+}
+
+.login-form-side .digits_password_inp_row input[type="password"] {
+	padding-inline-end: 2.75rem;
+}
+
+.login-form-side .digits_password_eye {
+	display: flex;
+	position: absolute;
+	align-items: center;
+	justify-content: center;
+	right: auto;
+	left: auto;
+	inset-block-start: 50%;
+	inset-inline-end: .75rem;
+	top: 50% !important;
+	bottom: auto;
+	width: 24px;
+	height: 24px;
+	transform: translateY(-50%);
+	opacity: 1;
+	pointer-events: auto;
+	cursor: pointer;
+}
+
+.login-form-side .digits-form_footer {
+	display: none !important;
+}
+
+.login-form-side .digits-form_tab_body .digits-form_footer_content {
+	display: block;
+	visibility: visible;
+	opacity: 1;
+}
+
+.login-form-side .digits-form_footer_content,
+.login-form-side .digits-form_link {
+	box-sizing: border-box;
+	max-width: 100%;
+}
+
+.login-form-side .digits-form_link {
+	min-height: 44px;
+	margin-top: .25rem;
+	padding: .7rem .25rem;
+	color: var(--wd-link-color, var(--wd-primary-color, #f58220));
+	font-size: .875rem;
+	line-height: 1.5;
+	text-align: center;
+	cursor: pointer;
+}
+
+.login-form-side .digits_otp_info {
+	position: static;
+	width: 100%;
+	max-width: 100%;
+	margin-top: .75rem;
+	padding: .75rem;
+	border-radius: var(--wd-brd-radius, 4px);
+	background: var(--bgcolor-gray-100, #f7f7f7);
+}
+
+.login-form-side .digits_otp_info_ic {
+	display: none;
+}
+
+.login-form-side .digits_otp_info_desc,
+.login-form-side .digits_otp_info_desc_text {
+	position: static;
+	display: block;
+	width: 100%;
+	max-width: 100%;
+	padding: 0;
+	font-size: .8125rem;
+	line-height: 1.65;
+	white-space: normal;
+	word-break: break-word;
+	opacity: 1;
+}
+
+.login-form-side .digits_otp_dest {
+	display: block;
+	margin-top: .25rem;
+	direction: ltr;
+	text-align: center;
+	unicode-bidi: isolate;
+}
+
+.login-form-side .digits-form_submit-btn {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 100%;
+	min-height: 44px;
+	margin-inline: 0;
+}
+
+.login-form-side .digits_loading_spinner {
+	display: inline-block;
+	flex: 0 0 auto;
+	box-sizing: border-box;
+	width: 1rem;
+	height: 1rem;
+	margin-inline: 0 .5rem;
+	color: #fff !important;
+	border: .15rem solid #fff;
+	border-top-color: transparent;
+	border-radius: 50%;
+	line-height: 1;
+	vertical-align: middle;
+	animation: digitalogic-sidebar-login-spin .6s linear infinite;
+}
+
+.login-form-side .digits_form_processing {
+	pointer-events: none;
+}
+
+.login-form-side .digits_form_processing .digits-form_tab-item,
+.login-form-side .digits_form_processing .digits-form_link,
+.login-form-side .digits_form_processing .digits-form_submit-btn {
+	cursor: wait;
+}
+
+.login-form-side .digits-form_message,
+.login-form-side .woocommerce-error,
+.login-form-side .woocommerce-message {
+	box-sizing: border-box;
+	width: calc(100% - 1.875rem);
+	max-width: 100%;
+	margin-inline: .9375rem;
+	overflow-wrap: anywhere;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice {
+	z-index: 9999999;
+	display: block;
+	position: fixed;
+	top: 1.5rem;
+	right: 1.5rem;
+	left: auto;
+	box-sizing: border-box;
+	width: min(320px, calc(100vw - 2rem));
+	min-height: 80px;
+	border-radius: 8px;
+	background: #fff;
+	box-shadow: 0 10px 32px rgb(0 0 0 / 18%);
+	line-height: 1.6;
+	overflow: hidden;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_popmessage_contents {
+	display: flex;
+	position: relative;
+	min-height: 80px;
+	padding: 1rem 1.25rem;
+	border: 1px solid #f0d5dc;
+	border-inline-start: 4px solid #d63638;
+	background: #fff7f8;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_firele {
+	display: none;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_lasele {
+	flex: 1 1 auto;
+	min-width: 0;
+	padding: 0;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_lase_snap,
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_lase_message {
+	display: block;
+	padding-inline-end: 1.75rem;
+	overflow-wrap: anywhere;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_lase_snap {
+	margin-bottom: .25rem;
+	color: #8a2424;
+	font-size: 1rem;
+	font-weight: 700;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_lase_message {
+	color: #5c1d1d;
+	font-size: .875rem;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice.dig_success_msg .dig_popmessage_contents {
+	border-color: #cce9dc;
+	border-inline-start-color: #008a52;
+	background: #f2fbf7;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice.dig_success_msg .dig_lase_snap,
+body > .dig_popmessage.digitalogic-sidebar-login-notice.dig_success_msg .dig_lase_message {
+	color: #006d41;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice.dig_notice_msg .dig_popmessage_contents {
+	border-color: #f0dfb1;
+	border-inline-start-color: #b07800;
+	background: #fffbef;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice.dig_notice_msg .dig_lase_snap,
+body > .dig_popmessage.digitalogic-sidebar-login-notice.dig_notice_msg .dig_lase_message {
+	color: #765100;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_popdismiss {
+	display: flex;
+	position: absolute;
+	top: .375rem;
+	inset-inline-end: .375rem;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	border-radius: 50%;
+	color: currentcolor;
+	font-size: 0;
+	cursor: pointer;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_popdismiss::before {
+	content: "\00d7";
+	font-size: 1.5rem;
+	line-height: 1;
+}
+
+body > .dig_popmessage.digitalogic-sidebar-login-notice .dig_popdismiss:focus-visible {
+	outline: 2px solid currentcolor;
+	outline-offset: 1px;
+}
+
+.login-form-side #altEmail_container {
+	position: absolute !important;
+	inset-inline-start: -10000px !important;
+	top: auto !important;
+	width: 1px !important;
+	height: 1px !important;
+	overflow: hidden !important;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar,
+.login-form-side .digitalogic-call-verification--sidebar * {
+	box-sizing: border-box;
+	max-width: 100%;
+	min-width: 0;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar {
+	--digitalogic-call-accent: #873800;
+
+	width: 100%;
+	margin: .25rem 0 0;
+	padding: 0;
+	border: 0;
+	background: transparent;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	min-height: 44px;
+	margin: .25rem 0 0;
+	padding: .65rem .5rem;
+	border: 1px solid var(--digitalogic-call-accent) !important;
+	border-radius: var(--wd-brd-radius, 4px);
+	background: #fff7f0 !important;
+	background: color-mix(in srgb, var(--wd-primary-color, #f58220) 9%, #fff) !important;
+	color: var(--digitalogic-call-accent) !important;
+	font-size: .875rem;
+	font-weight: 700;
+	line-height: 1.5;
+	text-align: center;
+	box-shadow: none !important;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-toggle:hover,
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-toggle[aria-expanded="true"] {
+	background: #ffefe2 !important;
+	background: color-mix(in srgb, var(--wd-primary-color, #f58220) 15%, #fff) !important;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-toggle:focus-visible,
+.login-form-side .digitalogic-call-verification--sidebar button:focus-visible,
+.login-form-side .digitalogic-call-verification--sidebar input:focus-visible,
+.login-form-side .digitalogic-call-verification--sidebar a:focus-visible {
+	outline: 2px solid var(--digitalogic-call-accent);
+	outline-offset: 2px;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-panel {
+	display: grid;
+	gap: .75rem;
+	width: 100%;
+	margin: .5rem 0 0;
+	padding: .75rem;
+	border: 1px solid var(--brdcolor-gray-300, #d7d7d7);
+	border-inline-start: 3px solid var(--wd-primary-color, #f58220);
+	border-radius: var(--wd-brd-radius, 4px);
+	background: var(--bgcolor-gray-100, #f7f7f7);
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-panel label {
+	display: grid;
+	gap: .35rem;
+	margin: 0;
+	font-size: .8125rem;
+	line-height: 1.65;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-phone] {
+	width: 100%;
+	min-height: 44px;
+	margin: 0;
+	direction: ltr;
+	text-align: left;
+	unicode-bidi: isolate;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-start] {
+	width: 100%;
+	min-height: 44px;
+	margin: 0;
+	border-color: var(--digitalogic-call-accent) !important;
+	background: var(--digitalogic-call-accent) !important;
+	color: #fff !important;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-start]:hover:not(:disabled) {
+	border-color: #672900 !important;
+	background: #672900 !important;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-match-note {
+	margin: 0;
+	color: var(--color-gray-600, #666);
+	font-size: .75rem;
+	line-height: 1.65;
+	overflow-wrap: anywhere;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-instructions {
+	width: 100%;
+	padding: .75rem;
+	border-inline-start: 3px solid var(--wd-primary-color, #f58220);
+	background: #fff;
+	font-size: .8125rem;
+	line-height: 1.75;
+	overflow-wrap: anywhere;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-instructions p {
+	margin: 0 0 .5rem;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-instructions p:last-of-type {
+	margin-bottom: 0;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-dial],
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-code {
+	direction: ltr;
+	unicode-bidi: isolate;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-dial] {
+	display: inline-block;
+	color: var(--digitalogic-call-accent) !important;
+	font-weight: 700;
+	text-decoration: underline;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-code {
+	display: block;
+	width: 100%;
+	margin: .65rem 0;
+	font-size: clamp(1.4rem, 8vw, 2rem);
+	letter-spacing: .16em;
+	text-align: center;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar [data-call-cancel] {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 44px;
+	padding: .5rem;
+	color: var(--digitalogic-call-accent) !important;
+	text-decoration: underline;
+}
+
+.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-error {
+	margin: 0;
+	color: #b32d2e;
+	font-size: .8125rem;
+	line-height: 1.65;
+	overflow-wrap: anywhere;
+}
+
+@media (max-width: 380px) {
+	.login-form-side .digits-form_tab-bar {
+		gap: .375rem;
+	}
+
+	.login-form-side .digits-form_tab-bar .digits-form_tab-item {
+		padding-inline: .2rem;
+		font-size: .8125rem;
+	}
+
+	.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-panel,
+	.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-instructions {
+		padding: .625rem;
+	}
+
+	.login-form-side .digitalogic-call-verification--sidebar .digitalogic-call-code {
+		font-size: 1.45rem;
+		letter-spacing: .1em;
+	}
+
+	body > .dig_popmessage.digitalogic-sidebar-login-notice {
+		top: 1rem;
+		right: 1rem;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.login-form-side .digits-form_tab-bar .digits-form_tab-item,
+	.login-form-side .digits_loading_spinner {
+		transition: none;
+	}
+
+	.login-form-side .digits_loading_spinner {
+		animation-duration: 1.2s;
+	}
+}
+
+@keyframes digitalogic-sidebar-login-spin {
+	from {
+		transform: rotate(0deg);
+	}
+
+	to {
+		transform: rotate(360deg);
+	}
+}

--- a/assets/js/sidebar-login.js
+++ b/assets/js/sidebar-login.js
@@ -1,0 +1,260 @@
+(() => {
+    'use strict';
+
+    const sidebarSelector = '.login-form-side';
+    const controlSelector = [
+        '.digits-form_tab-item',
+        '.digits-form_link',
+        '.digits_password_eye',
+    ].join(',');
+    const keyboardAttribute = 'data-digitalogic-keyboard-control';
+    const noticeClass = 'digitalogic-sidebar-login-notice';
+    const localizedMessages = window.DigitalogicSidebarLogin?.messages || {};
+    const callWidgetSelector = '[data-digitalogic-sidebar-call-widget]';
+    const callParkingSelector = '[data-digitalogic-sidebar-call-parking]';
+    let sidebarNoticePending = false;
+    let sidebarNoticeTimer = 0;
+    let sidebarCallWidget = null;
+    let sidebarCallParking = null;
+
+    const isNativeControl = (element) => element.matches(
+        'a[href],button,input,select,textarea,summary'
+    );
+
+    const enhanceControl = (control) => {
+        if (!(control instanceof HTMLElement) || !control.closest(sidebarSelector)) {
+            return;
+        }
+
+        if (control.classList.contains('digits-form_tab-item')) {
+            control.setAttribute('role', 'tab');
+            control.setAttribute(
+                'aria-selected',
+                control.classList.contains('digits-tab_active') ? 'true' : 'false'
+            );
+        } else if (!isNativeControl(control)) {
+            control.setAttribute('role', 'button');
+        }
+
+        if (!isNativeControl(control)) {
+            control.tabIndex = 0;
+            control.setAttribute(keyboardAttribute, 'true');
+        }
+
+        if (
+            control.classList.contains('digits_password_eye')
+            && !control.hasAttribute('aria-label')
+        ) {
+            const isPersian = document.documentElement.lang.toLowerCase().startsWith('fa');
+            control.setAttribute(
+                'aria-label',
+                localizedMessages.togglePassword
+                    || (isPersian ? 'نمایش یا پنهان کردن رمز عبور' : 'Show or hide password')
+            );
+        }
+    };
+
+    const enhanceSidebar = (sidebar) => {
+        if (!(sidebar instanceof HTMLElement)) {
+            return;
+        }
+
+        sidebar.querySelectorAll('.digits-form_tab-bar').forEach((tabList) => {
+            tabList.setAttribute('role', 'tablist');
+        });
+        sidebar.querySelectorAll(controlSelector).forEach(enhanceControl);
+    };
+
+    const enhanceAll = () => {
+        document.querySelectorAll(sidebarSelector).forEach(enhanceSidebar);
+    };
+
+    const toAsciiDigits = (value) => String(value || '')
+        .replace(/[۰-۹]/g, (digit) => String(digit.charCodeAt(0) - 1776))
+        .replace(/[٠-٩]/g, (digit) => String(digit.charCodeAt(0) - 1632));
+
+    const phoneLike = (value) => {
+        const compact = toAsciiDigits(value).replace(/[^+0-9]/g, '');
+        return /^(?:\+98|0098|98|0)[0-9]{10}$/.test(compact);
+    };
+
+    const prefillSidebarPhone = (widget, sidebar) => {
+        const input = widget.querySelector('[data-call-phone]');
+        if (!(input instanceof HTMLInputElement) || input.value.trim()) {
+            return;
+        }
+
+        const candidate = sidebar.querySelector('#username')?.value;
+        if (candidate) {
+            if (phoneLike(candidate)) {
+                input.value = candidate.trim();
+            }
+        }
+    };
+
+    const syncSidebarCallWidget = () => {
+        sidebarCallWidget = sidebarCallWidget || document.querySelector(callWidgetSelector);
+        sidebarCallParking = sidebarCallParking || document.querySelector(callParkingSelector);
+        if (!(sidebarCallWidget instanceof HTMLElement)) {
+            return;
+        }
+
+        const activeOtpBody = Array.from(document.querySelectorAll(
+            `${sidebarSelector} .digits-form_tab_body.digits-tab_active`
+        )).find((body) => body.querySelector('.digits-form_resend_otp'));
+        const resend = activeOtpBody?.querySelector('.digits-form_resend_otp');
+        const sidebar = activeOtpBody?.closest(sidebarSelector);
+
+        if (resend && sidebar) {
+            const mountAnchor = resend.closest('.digits-form_footer_content') || resend;
+            if (mountAnchor.nextElementSibling !== sidebarCallWidget) {
+                mountAnchor.insertAdjacentElement('afterend', sidebarCallWidget);
+            }
+            sidebarCallWidget.hidden = false;
+            prefillSidebarPhone(sidebarCallWidget, sidebar);
+            return;
+        }
+
+        sidebarCallWidget.hidden = true;
+        if (
+            sidebarCallParking instanceof HTMLElement
+            && sidebarCallWidget.parentElement !== sidebarCallParking
+        ) {
+            sidebarCallParking.append(sidebarCallWidget);
+        }
+    };
+
+    const expectSidebarNotice = () => {
+        sidebarNoticePending = true;
+        window.clearTimeout(sidebarNoticeTimer);
+        sidebarNoticeTimer = window.setTimeout(() => {
+            sidebarNoticePending = false;
+        }, 30000);
+    };
+
+    const makeKeyboardButton = (control, label) => {
+        control.setAttribute('role', 'button');
+        control.setAttribute('tabindex', '0');
+        control.setAttribute(keyboardAttribute, 'true');
+        if (label) {
+            control.setAttribute('aria-label', label);
+        }
+    };
+
+    const markSidebarNotice = (node) => {
+        if (!(node instanceof Element) || !sidebarNoticePending) {
+            return;
+        }
+
+        const notices = node.matches('.dig_popmessage')
+            ? [node]
+            : Array.from(node.querySelectorAll('.dig_popmessage'));
+        if (!notices.length) {
+            return;
+        }
+
+        const isPersian = document.documentElement.lang.toLowerCase().startsWith('fa');
+        notices.forEach((notice) => {
+            notice.classList.add(noticeClass);
+            notice.setAttribute('role', 'alert');
+            notice.setAttribute('aria-live', 'assertive');
+
+            const dismiss = notice.querySelector('.dig_popdismiss');
+            if (dismiss) {
+                makeKeyboardButton(
+                    dismiss,
+                    localizedMessages.dismissNotice
+                        || (isPersian ? 'بستن پیام' : 'Dismiss message')
+                );
+            }
+        });
+
+        sidebarNoticePending = false;
+        window.clearTimeout(sidebarNoticeTimer);
+    };
+
+    const enhanceWithin = (node) => {
+        if (!(node instanceof Element)) {
+            return;
+        }
+
+        const containingSidebar = node.closest(sidebarSelector);
+        if (containingSidebar) {
+            enhanceSidebar(containingSidebar);
+        }
+
+        node.querySelectorAll(sidebarSelector).forEach(enhanceSidebar);
+    };
+
+    document.addEventListener('keydown', (event) => {
+        const control = event.target instanceof Element
+            ? event.target.closest(`[${keyboardAttribute}="true"]`)
+            : null;
+        const inSidebar = control?.closest(sidebarSelector);
+        const inSidebarNotice = control?.closest(`.${noticeClass}`);
+        if (!control || (!inSidebar && !inSidebarNotice)) {
+            return;
+        }
+
+        if (event.key !== 'Enter' && event.key !== ' ') {
+            return;
+        }
+
+        event.preventDefault();
+        if (!event.repeat && (!inSidebar || !control.closest('.digits_form_processing'))) {
+            control.click();
+        }
+    });
+
+    document.addEventListener('submit', (event) => {
+        if (event.target instanceof Element && event.target.closest(sidebarSelector)) {
+            expectSidebarNotice();
+        }
+    }, true);
+
+    document.addEventListener('click', (event) => {
+        const trigger = event.target instanceof Element
+            ? event.target.closest([
+                `${sidebarSelector} .digits-form_submit-btn`,
+                `${sidebarSelector} .digits-form_otp_selector`,
+                `${sidebarSelector} .digits-form_resend_otp`,
+                `${sidebarSelector} .digits-form_show_forgot_password`,
+            ].join(','))
+            : null;
+        if (trigger) {
+            expectSidebarNotice();
+        }
+    }, true);
+
+    const start = () => {
+        enhanceAll();
+        syncSidebarCallWidget();
+
+        const observer = new MutationObserver((records) => {
+            records.forEach((record) => {
+                if (record.type === 'attributes') {
+                    enhanceWithin(record.target);
+                    return;
+                }
+
+                record.addedNodes.forEach((node) => {
+                    enhanceWithin(node);
+                    markSidebarNotice(node);
+                });
+            });
+            syncSidebarCallWidget();
+        });
+        observer.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['class'],
+            childList: true,
+            subtree: true,
+        });
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start, { once: true });
+    } else {
+        start();
+    }
+})();

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.6.4
+ * Version: 1.6.5
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.6.4' );
+define( 'DIGITALOGIC_VERSION', '1.6.5' );
 define( 'DIGITALOGIC_PBX_SCHEMA_VERSION', '3' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));
@@ -146,6 +146,7 @@ final class Digitalogic {
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-admin-branding.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-label-overrides.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-auth-page.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-digitalogic-sidebar-login.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-desktop-app.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-frontend-search.php';
 		require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-pbx-phone.php';
@@ -181,6 +182,7 @@ final class Digitalogic {
         Digitalogic_Label_Overrides::init();
         Digitalogic_Plugin_Admin_Branding::init();
         Digitalogic_Plugin_Auth_Routes::init();
+        Digitalogic_Sidebar_Login::init();
         Digitalogic_Desktop_App::init();
         Digitalogic_Frontend_Search::instance();
 		Digitalogic_Call_Verification::instance();

--- a/includes/integrations/class-digitalogic-sidebar-login.php
+++ b/includes/integrations/class-digitalogic-sidebar-login.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Digits compatibility for the Woodmart guest login sidebar.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Loads a sidebar-only Digits compatibility layer.
+ */
+final class Digitalogic_Sidebar_Login {
+	private const SCRIPT_HANDLE = 'digitalogic-sidebar-login';
+	private const SCRIPT_FILE   = 'assets/js/sidebar-login.js';
+	private const STYLE_HANDLE  = 'digitalogic-sidebar-login';
+	private const STYLE_FILE    = 'assets/css/sidebar-login.css';
+
+	/**
+	 * Register storefront asset hooks.
+	 */
+	public static function init(): void {
+		static $booted = false;
+
+		if ( $booted ) {
+			return;
+		}
+
+		$booted = true;
+		add_action( 'wp_enqueue_scripts', array( self::class, 'enqueue_sidebar_assets' ), 100 );
+	}
+
+	/**
+	 * Load the final, narrowly scoped Woodmart compatibility assets.
+	 */
+	public static function enqueue_sidebar_assets(): void {
+		if ( ! self::should_enqueue() ) {
+			return;
+		}
+
+		$path = DIGITALOGIC_PLUGIN_DIR . self::STYLE_FILE;
+		if ( ! is_readable( $path ) ) {
+			return;
+		}
+
+		$dependencies = array_merge(
+			array( 'digitalogic-call-verification' ),
+			self::enqueued_digits_styles()
+		);
+
+		wp_enqueue_style(
+			self::STYLE_HANDLE,
+			DIGITALOGIC_PLUGIN_URL . self::STYLE_FILE,
+			$dependencies,
+			(string) filemtime( $path )
+		);
+
+		$script_path = DIGITALOGIC_PLUGIN_DIR . self::SCRIPT_FILE;
+		if ( ! is_readable( $script_path ) ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			self::SCRIPT_HANDLE,
+			DIGITALOGIC_PLUGIN_URL . self::SCRIPT_FILE,
+			array( 'digitalogic-call-verification' ),
+			(string) filemtime( $script_path ),
+			true
+		);
+
+		wp_localize_script(
+			self::SCRIPT_HANDLE,
+			'DigitalogicSidebarLogin',
+			array(
+				'messages' => array(
+					'togglePassword' => __( 'Show or hide password', 'digitalogic' ),
+					'dismissNotice'  => __( 'Dismiss message', 'digitalogic' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * The sidebar exists only on public pages for signed-out visitors.
+	 */
+	private static function should_enqueue(): bool {
+		return ! is_admin() && ! is_user_logged_in();
+	}
+
+	/**
+	 * Return already-enqueued Digits main/RTL layers so this sheet loads last.
+	 *
+	 * Never depend on digits-login-style: this host temporarily queues that global
+	 * base file before Woodmart removes it later in the enqueue lifecycle. Making it
+	 * a dependency would force the intentionally omitted stylesheet back into output.
+	 *
+	 * @return array<string>
+	 */
+	private static function enqueued_digits_styles(): array {
+		$styles = wp_styles();
+		if ( ! is_object( $styles ) || ! isset( $styles->registered ) || ! is_array( $styles->registered ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				array( 'digits-style', 'digits-login-style-rtl' ),
+				static fn( string $handle ): bool => isset( $styles->registered[ $handle ] ) && wp_style_is( $handle, 'enqueued' )
+			)
+		);
+	}
+}

--- a/languages/digitalogic-fa_IR.po
+++ b/languages/digitalogic-fa_IR.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Digitalogic WooCommerce Extension 1.6.4\n"
+"Project-Id-Version: Digitalogic WooCommerce Extension 1.6.5\n"
 "Report-Msgid-Bugs-To: https://github.com/atomicdeploy/digitalogic-wp/issues\n"
 "POT-Creation-Date: 2026-07-21T02:00:49+00:00\n"
 "PO-Revision-Date: 2026-07-17 00:00+0000\n"
@@ -1857,6 +1857,18 @@ msgstr "افزودن و تأیید شماره تلفن از طریق تماس"
 #: includes/integrations/class-call-verification.php:1440
 msgid "Mobile or landline number (include area code)"
 msgstr "شماره موبایل یا تلفن ثابت (همراه با کد شهر)"
+
+#: includes/integrations/class-call-verification.php
+msgid "Place the call from the same phone number you entered so caller ID can confirm ownership."
+msgstr "تماس را دقیقاً از همان شماره‌ای برقرار کنید که وارد کرده‌اید تا مالکیت آن از روی شماره تماس‌گیرنده تأیید شود."
+
+#: includes/integrations/class-digitalogic-sidebar-login.php
+msgid "Show or hide password"
+msgstr "نمایش یا پنهان کردن رمز عبور"
+
+#: includes/integrations/class-digitalogic-sidebar-login.php
+msgid "Dismiss message"
+msgstr "بستن پیام"
 
 #: includes/integrations/class-call-verification.php:1470
 msgid "Voice order updates"

--- a/languages/digitalogic.pot
+++ b/languages/digitalogic.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Digitalogic 1.6.4\n"
+"Project-Id-Version: Digitalogic 1.6.5\n"
 "Report-Msgid-Bugs-To: https://github.com/atomicdeploy/digitalogic-wp/issues\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1906,6 +1906,18 @@ msgstr ""
 
 #: includes/integrations/class-call-verification.php:1440
 msgid "Mobile or landline number (include area code)"
+msgstr ""
+
+#: includes/integrations/class-call-verification.php
+msgid "Place the call from the same phone number you entered so caller ID can confirm ownership."
+msgstr ""
+
+#: includes/integrations/class-digitalogic-sidebar-login.php
+msgid "Show or hide password"
+msgstr ""
+
+#: includes/integrations/class-digitalogic-sidebar-login.php
+msgid "Dismiss message"
 msgstr ""
 
 #: includes/integrations/class-call-verification.php:1470

--- a/tests/SidebarLoginTest.php
+++ b/tests/SidebarLoginTest.php
@@ -1,0 +1,160 @@
+<?php // phpcs:ignoreFile -- Test stubs intentionally share one fixture file with the test case.
+/**
+ * Storefront sidebar asset regression tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'DIGITALOGIC_PLUGIN_URL' ) ) {
+	define( 'DIGITALOGIC_PLUGIN_URL', 'https://digitalogic.test/wp-content/plugins/digitalogic-wp/' );
+}
+
+if ( ! defined( 'DIGITALOGIC_PLUGIN_DIR' ) ) {
+	define( 'DIGITALOGIC_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! function_exists( 'is_admin' ) ) {
+	function is_admin() {
+		return ! empty( $GLOBALS['digitalogic_test_is_admin'] );
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in() {
+		return ! empty( $GLOBALS['digitalogic_test_is_user_logged_in'] );
+	}
+}
+
+if ( ! function_exists( 'wp_enqueue_style' ) ) {
+	function wp_enqueue_style( $handle, $src = '', $dependencies = array(), $version = false ) {
+		$GLOBALS['digitalogic_test_enqueued_styles'][ $handle ] = compact( 'src', 'dependencies', 'version' );
+	}
+}
+
+if ( ! function_exists( 'wp_enqueue_script' ) ) {
+	function wp_enqueue_script( $handle, $src = '', $dependencies = array(), $version = false, $in_footer = false ) {
+		$GLOBALS['digitalogic_test_enqueued_scripts'][ $handle ] = compact( 'src', 'dependencies', 'version', 'in_footer' );
+	}
+}
+
+if ( ! function_exists( 'wp_localize_script' ) ) {
+	function wp_localize_script( $handle, $object_name, $data ) {
+		$GLOBALS['digitalogic_test_localized_scripts'][ $handle ][ $object_name ] = $data;
+	}
+}
+
+if ( ! function_exists( 'wp_styles' ) ) {
+	function wp_styles() {
+		return $GLOBALS['digitalogic_test_styles_registry'];
+	}
+}
+
+if ( ! function_exists( 'wp_style_is' ) ) {
+	function wp_style_is( $handle, $status = 'enqueued' ) {
+		return 'enqueued' === $status && in_array( $handle, $GLOBALS['digitalogic_test_enqueued_style_handles'], true );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/integrations/class-digitalogic-sidebar-login.php';
+
+/**
+ * Verifies guest-only loading and deterministic ordering of the sidebar styles.
+ */
+final class SidebarLoginTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['digitalogic_test_is_admin']           = false;
+		$GLOBALS['digitalogic_test_is_user_logged_in']  = false;
+		$GLOBALS['digitalogic_test_current_user_id']    = 0;
+		$GLOBALS['digitalogic_test_enqueued_styles']    = array();
+		$GLOBALS['digitalogic_test_enqueued_scripts']   = array();
+		$GLOBALS['digitalogic_test_localized_scripts']  = array();
+		$GLOBALS['digitalogic_test_action_callbacks']   = array();
+		$GLOBALS['digitalogic_test_enqueued_style_handles'] = array( 'digits-style', 'digits-login-style-rtl' );
+		$GLOBALS['digitalogic_test_styles_registry']    = (object) array(
+			'registered' => array(
+				'digits-style'           => (object) array( 'deps' => array() ),
+				'digits-login-style-rtl' => (object) array( 'deps' => array() ),
+			),
+		);
+	}
+
+	public function test_registers_the_late_compatibility_hook_once(): void {
+		Digitalogic_Sidebar_Login::init();
+		Digitalogic_Sidebar_Login::init();
+
+		$callbacks = $GLOBALS['digitalogic_test_action_callbacks']['wp_enqueue_scripts'];
+		$this->assertCount( 1, $callbacks );
+		$this->assertSame( 100, $callbacks[0]['priority'] );
+		$this->assertSame( array( Digitalogic_Sidebar_Login::class, 'enqueue_sidebar_assets' ), $callbacks[0]['callback'] );
+	}
+
+	public function test_guest_frontend_enqueues_scoped_assets_after_homepage_digits_layers(): void {
+		Digitalogic_Sidebar_Login::enqueue_sidebar_assets();
+
+		$styles = $GLOBALS['digitalogic_test_enqueued_styles'];
+		$this->assertCount( 1, $styles );
+		$this->assertArrayHasKey( 'digitalogic-sidebar-login', $styles );
+		$this->assertSame(
+			array( 'digitalogic-call-verification', 'digits-style', 'digits-login-style-rtl' ),
+			$styles['digitalogic-sidebar-login']['dependencies']
+		);
+
+		$scripts = $GLOBALS['digitalogic_test_enqueued_scripts'];
+		$this->assertCount( 1, $scripts );
+		$this->assertSame(
+			'https://digitalogic.test/wp-content/plugins/digitalogic-wp/assets/js/sidebar-login.js',
+			$scripts['digitalogic-sidebar-login']['src']
+		);
+		$this->assertSame(
+			array( 'digitalogic-call-verification' ),
+			$scripts['digitalogic-sidebar-login']['dependencies']
+		);
+		$this->assertTrue( $scripts['digitalogic-sidebar-login']['in_footer'] );
+		$this->assertSame(
+			array(
+				'togglePassword' => 'Show or hide password',
+				'dismissNotice'  => 'Dismiss message',
+			),
+			$GLOBALS['digitalogic_test_localized_scripts']['digitalogic-sidebar-login']['DigitalogicSidebarLogin']['messages']
+		);
+	}
+
+	public function test_compatibility_style_never_forces_the_global_vendor_base_even_when_queued(): void {
+		$GLOBALS['digitalogic_test_styles_registry']->registered['digits-login-style'] = (object) array( 'deps' => array() );
+		array_unshift( $GLOBALS['digitalogic_test_enqueued_style_handles'], 'digits-login-style' );
+
+		Digitalogic_Sidebar_Login::enqueue_sidebar_assets();
+
+		$this->assertSame(
+			array( 'digitalogic-call-verification', 'digits-style', 'digits-login-style-rtl' ),
+			$GLOBALS['digitalogic_test_enqueued_styles']['digitalogic-sidebar-login']['dependencies']
+		);
+	}
+
+	public function test_a_registered_but_unqueued_vendor_base_is_not_forced_onto_the_homepage(): void {
+		$GLOBALS['digitalogic_test_styles_registry']->registered['digits-login-style'] = (object) array( 'deps' => array() );
+
+		Digitalogic_Sidebar_Login::enqueue_sidebar_assets();
+
+		$this->assertSame(
+			array( 'digitalogic-call-verification', 'digits-style', 'digits-login-style-rtl' ),
+			$GLOBALS['digitalogic_test_enqueued_styles']['digitalogic-sidebar-login']['dependencies']
+		);
+	}
+
+	public function test_assets_are_not_loaded_for_authenticated_visitors_and_keep_the_admin_guard(): void {
+		$source = file_get_contents( dirname( __DIR__ ) . '/includes/integrations/class-digitalogic-sidebar-login.php' );
+		$this->assertStringContainsString(
+			'return ! is_admin() && ! is_user_logged_in();',
+			$source
+		);
+
+		$GLOBALS['digitalogic_test_is_user_logged_in'] = true;
+		$GLOBALS['digitalogic_test_current_user_id']   = 42;
+		Digitalogic_Sidebar_Login::enqueue_sidebar_assets();
+		$this->assertSame( array(), $GLOBALS['digitalogic_test_enqueued_styles'] );
+		$this->assertSame( array(), $GLOBALS['digitalogic_test_enqueued_scripts'] );
+	}
+}

--- a/tests/sidebar-login-style.test.js
+++ b/tests/sidebar-login-style.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const css = fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'css', 'sidebar-login.css'),
+    'utf8'
+);
+const pluginSource = fs.readFileSync(
+    path.join(__dirname, '..', 'digitalogic.php'),
+    'utf8'
+);
+const accessibilityScript = fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'js', 'sidebar-login.js'),
+    'utf8'
+);
+
+test('the plugin boots the storefront sidebar integration', () => {
+    assert.match(
+        pluginSource,
+        /require_once DIGITALOGIC_PLUGIN_DIR \. 'includes\/integrations\/class-digitalogic-sidebar-login\.php';/
+    );
+    assert.match(pluginSource, /Digitalogic_Sidebar_Login::init\(\);/);
+});
+
+test('sidebar styles hide every inactive Digits step and show only the active step', () => {
+    assert.match(
+        css,
+        /\.login-form-side \.digits-form_tab_body:not\(\.digits-tab_active\)\s*\{[^}]*display:\s*none\s*!important/s
+    );
+    assert.match(
+        css,
+        /\.login-form-side \.digits-form_tab_body\.digits-tab_active\s*\{[^}]*display:\s*block\s*!important/s
+    );
+});
+
+test('sidebar tab and control layout remains bounded and touch friendly', () => {
+    assert.match(css, /\.login-form-side \.digits-form_tab-bar\s*\{[^}]*display:\s*flex/s);
+    assert.match(css, /\.login-form-side \.digits-form_tab-bar \.digits-form_tab-item\s*\{[^}]*min-height:\s*44px/s);
+    assert.match(css, /\.login-form-side \.digits-form_submit-btn\s*\{[^}]*width:\s*100%/s);
+    assert.match(css, /\.login-form-side \.digits_otp_dest\s*\{[^}]*direction:\s*ltr/s);
+    assert.match(css, /@media \(max-width:\s*380px\)/);
+});
+
+test('the RTL password-eye keeps its logical horizontal anchor', () => {
+    assert.match(
+        css,
+        /\.login-form-side \.digits_password_eye\s*\{[^}]*right:\s*auto;[^}]*left:\s*auto;[^}]*inset-inline-end:\s*\.75rem;/s
+    );
+    assert.match(css, /\.login-form-side \.digits_password_eye\s*\{[^}]*position:\s*absolute/s);
+});
+
+test('submissions retain a visible scoped loading indicator', () => {
+    assert.match(
+        css,
+        /\.login-form-side \.digits_loading_spinner\s*\{[^}]*color:\s*#fff\s*!important;[^}]*border:\s*\.15rem solid #fff;[^}]*border-top-color:\s*transparent;[^}]*animation:\s*digitalogic-sidebar-login-spin/s
+    );
+    assert.match(css, /@keyframes digitalogic-sidebar-login-spin/);
+    assert.match(
+        css,
+        /\.login-form-side \.digits_form_processing\s*\{[^}]*pointer-events:\s*none/s
+    );
+});
+
+test('dynamic Digits controls receive scoped keyboard semantics', () => {
+    assert.match(accessibilityScript, /\.digits-form_tab-item/);
+    assert.match(accessibilityScript, /\.digits-form_link/);
+    assert.match(accessibilityScript, /\.digits_password_eye/);
+    assert.match(
+        accessibilityScript,
+        /event\.key !== 'Enter' && event\.key !== ' '/
+    );
+    assert.match(
+        accessibilityScript,
+        /if \(!event\.repeat && \(!inSidebar \|\| !control\.closest\('\.digits_form_processing'\)\)\)\s*\{\s*control\.click\(\);/s
+    );
+    assert.match(accessibilityScript, /new MutationObserver\(\(records\) =>/);
+    assert.match(accessibilityScript, /control\.closest\(sidebarSelector\)/);
+    assert.match(accessibilityScript, /window\.DigitalogicSidebarLogin\?\.messages/);
+    assert.match(accessibilityScript, /localizedMessages\.togglePassword/);
+    assert.match(accessibilityScript, /localizedMessages\.dismissNotice/);
+});
+
+test('body-appended Digits notices are marked and styled only for sidebar requests', () => {
+    assert.match(accessibilityScript, /const noticeClass = 'digitalogic-sidebar-login-notice'/);
+    assert.match(accessibilityScript, /sidebarNoticePending/);
+    assert.match(accessibilityScript, /notice\.classList\.add\(noticeClass\)/);
+    assert.match(accessibilityScript, /notice\.setAttribute\('role', 'alert'\)/);
+    assert.match(
+        css,
+        /body > \.dig_popmessage\.digitalogic-sidebar-login-notice\s*\{[^}]*position:\s*fixed/s
+    );
+    assert.doesNotMatch(css, /\.login-form-side \.dig_popmessage/);
+});
+
+test('the PBX singleton mounts only after the active OTP resend control', () => {
+    assert.match(accessibilityScript, /const callWidgetSelector = '\[data-digitalogic-sidebar-call-widget\]'/);
+    assert.match(accessibilityScript, /\.digits-form_tab_body\.digits-tab_active/);
+    assert.match(accessibilityScript, /body\.querySelector\('\.digits-form_resend_otp'\)/);
+    assert.match(accessibilityScript, /const mountAnchor = resend\.closest\('\.digits-form_footer_content'\) \|\| resend/);
+    assert.match(accessibilityScript, /mountAnchor\.nextElementSibling !== sidebarCallWidget/);
+    assert.match(accessibilityScript, /mountAnchor\.insertAdjacentElement\('afterend', sidebarCallWidget\)/);
+    assert.doesNotMatch(accessibilityScript, /resend\.insertAdjacentElement\('afterend', sidebarCallWidget\)/);
+    assert.doesNotMatch(accessibilityScript, /cloneNode\(/);
+});
+
+test('the PBX singleton is parked through Digits rerenders and only prefills phone-like input', () => {
+    assert.match(accessibilityScript, /const callParkingSelector = '\[data-digitalogic-sidebar-call-parking\]'/);
+    assert.match(accessibilityScript, /sidebarCallParking\.append\(sidebarCallWidget\)/);
+    assert.match(accessibilityScript, /sidebarCallWidget\.hidden = true/);
+    assert.match(accessibilityScript, /\^\(\?:\\\+98\|0098\|98\|0\)\[0-9\]\{10\}\$/);
+    assert.match(accessibilityScript, /const candidate = sidebar\.querySelector\('#username'\)\?\.value/);
+    assert.doesNotMatch(accessibilityScript, /querySelector\('input\[name="digits_phone"\]'\)/);
+    assert.match(accessibilityScript, /input\.value = candidate\.trim\(\)/);
+});
+
+test('the sidebar PBX panel remains bounded, RTL-safe, and touch friendly', () => {
+    assert.match(css, /\.login-form-side \.digitalogic-call-verification--sidebar\s*\{[^}]*width:\s*100%/s);
+    assert.match(css, /\.login-form-side \.digitalogic-call-verification--sidebar \*\s*\{[^}]*max-width:\s*100%;[^}]*min-width:\s*0;/s);
+    assert.match(css, /\.digitalogic-call-toggle\s*\{[^}]*min-height:\s*44px/s);
+    assert.match(css, /\[data-call-phone\]\s*\{[^}]*width:\s*100%;[^}]*min-height:\s*44px;[^}]*direction:\s*ltr;/s);
+    assert.match(css, /\.digitalogic-call-code\s*\{[^}]*unicode-bidi:\s*isolate;/s);
+    assert.match(css, /@media \(max-width:\s*380px\)/);
+    assert.doesNotMatch(css, /data-call-ivr/);
+    assert.doesNotMatch(accessibilityScript, /ivr_option|data-call-ivr/);
+});
+
+test('critical Digits rules cannot leak outside the Woodmart sidebar', () => {
+    assert.doesNotMatch(css, /(?:^|\})\s*\.digits-form_tab_body\b/m);
+    assert.doesNotMatch(css, /(?:^|\})\s*\.digits-form_tab-bar\b/m);
+    assert.doesNotMatch(css, /(?:^|\})\s*\.digits-form_submit-btn\b/m);
+});


### PR DESCRIPTION
## What changed

- restores the dedicated Woodmart/Digits sidebar compatibility layer and boots it for signed-out storefront visitors
- mounts one existing PBX verification widget directly beneath the active OTP resend control, then safely reparks it across AJAX rerenders
- scopes the redesigned RTL/mobile CSS to the sidebar so inactive forms remain hidden and no styles leak into other Digits forms
- restores Persian caller-ID guidance and localized accessibility labels
- bumps the plugin to 1.6.5 so browsers cannot reuse the stale 1.6.4 verification controller
- restores CI/package checks for the sidebar JavaScript and CSS contract

## Root cause

The 1.6.4 PBX reconciliation preserved the hardened 120-second server/controller flow and parked widget markup, but omitted the separate sidebar loader, remount script, and scoped stylesheet from the earlier sidebar release. The backend therefore worked while the alternative remained invisible in the real OTP sidebar.

## Validation

- PHPUnit: 309 tests, 1,936 assertions (5 expected skips; one existing warning)
- Node/style: 64 tests passed
- PHP syntax: passed
- JavaScript syntax: passed
- WordPress PHPCS on the restored loader: passed
- `git diff --check`: passed
