### PR TITLE
Complete the Google Sheets control center and n8n writeback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a persisted, optional sticky first product column that follows the first visible/reordered column in RTL and LTR while keeping the selection control frozen beside it.
 - Added reusable Digitalogic browser error pages with responsive light/dark styling, English and Persian copy, RTL/LTR layout, safe recovery actions, and stable support references.
 - Added an opt-in Google Sheets product/pricing control workspace with bounded preview/apply writeback, exact Patris identity and revisions, append-only audit rows, guarded WooCommerce product writes, and an inactive credential-placeholder n8n proxy template.
+- Added an idempotent professional Google Sheets control-center builder with live catalog KPIs, charts, a landed-price calculator, bilingual guidance, editable non-secret settings, protected reference tabs, and one-command synchronization and scheduling.
 
 ### Security
 - Google Sheets writeback uses exact-decimal optimistic revisions, idempotent requests, a shared WooCommerce product lock, and transactional shipping compare-and-set apply/compensation so concurrent changes are preserved.
 
 ### Fixed
+- Made the n8n Google Sheets writeback template return the actual Digitalogic JSON envelope on n8n 2.x instead of ending the webhook early with an empty HTTP 200 response.
 - Repaired critical `/panel/` rendering and inline-edit regressions: title direction is always callable, pointer edits place a collapsed caret at the clicked text position, Patris currency uses a canonical clearable selector, and render/bootstrap failures now show a localized recovery screen with structured, deduplicated console diagnostics.
 - Corrected Persian product-table geometry, including the `Ctrl+K` hint, exact checkbox centering, compact/mobile metadata containment, stable action-column sizing, and removal of the empty row tail caused by responsive column tracks.
 - Made the current Patris reconciliation report usable across warning and price-list views with bounded 50-row pages, category filters, request deduplication, stale-response protection, client-language labels, visible generation details, catalog-generation invalidation that cannot republish stale in-flight data, and a server-side build lock against concurrent forced refreshes.

--- a/assets/integrations/google-apps-script/Code.gs
+++ b/assets/integrations/google-apps-script/Code.gs
@@ -582,7 +582,16 @@ function setupEditableWorkspace() {
     const config = getConfig_();
     const spreadsheet = getSpreadsheet_(config);
     const workspace = ensureWritebackWorkspace_(spreadsheet, config.locale);
-    updateDashboard_(workspace.dashboard, getStateProperties_(config));
+    const stateProperties = getStateProperties_(config);
+    if (config.n8nWritebackBase
+      && !stateProperties.getProperty('DIGITALOGIC_LAST_WRITEBACK_TRANSPORT')) {
+      stateProperties.setProperties({
+        DIGITALOGIC_LAST_WRITEBACK_STATUS: 'ready',
+        DIGITALOGIC_LAST_WRITEBACK_TRANSPORT: 'n8n',
+        DIGITALOGIC_LAST_WRITEBACK_MESSAGE: 'Preview/apply bridge configured; no request has run yet.',
+      });
+    }
+    updateDashboard_(workspace.dashboard, stateProperties);
     spreadsheet.toast('Changes, Audit, and Dashboard are ready.', 'Digitalogic', 6);
     return {
       changes: workspace.changes.getName(),

--- a/assets/integrations/google-apps-script/ProfessionalDashboard.gs
+++ b/assets/integrations/google-apps-script/ProfessionalDashboard.gs
@@ -1,0 +1,442 @@
+/**
+ * Professional workbook presentation for the Digitalogic / Patris control center.
+ *
+ * This file intentionally contains no credentials. Run
+ * initializeDigitalogicControlCenter() after the required Script Properties have
+ * been configured. The function is idempotent and preserves the managed catalog,
+ * editable change queue, and audit contracts implemented by Code.gs.
+ */
+
+const DIGITALOGIC_DASHBOARD_COLORS = Object.freeze({
+  navy: '#0f172a',
+  navyLight: '#1e293b',
+  blue: '#0284c7',
+  teal: '#0f766e',
+  green: '#16a34a',
+  greenSoft: '#dcfce7',
+  amber: '#d97706',
+  amberSoft: '#fef3c7',
+  red: '#dc2626',
+  redSoft: '#fee2e2',
+  cyanSoft: '#e0f2fe',
+  slate: '#475569',
+  gray: '#e2e8f0',
+  graySoft: '#f1f5f9',
+  white: '#ffffff',
+});
+
+/** Build, synchronize, protect, and schedule the complete workbook. */
+function initializeDigitalogicControlCenter() {
+  syncCatalog();
+  buildProfessionalDashboard();
+  setupEditableWorkspace();
+  installScheduledSync();
+
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  const dashboard = spreadsheet.getSheetByName('Dashboard');
+  const state = getStateProperties_(getConfig_());
+  updateDashboard_(dashboard, state);
+  spreadsheet.setActiveSheet(dashboard);
+  spreadsheet.toast(
+    'Control center is live. Use the Changes queue to preview and apply reviewed edits.',
+    'Digitalogic & Patris',
+    10
+  );
+  return {
+    status: 'ready',
+    products: Math.max((spreadsheet.getSheetByName('Products') || dashboard).getLastRow() - 2, 0),
+    categories: Math.max((spreadsheet.getSheetByName('Categories') || dashboard).getLastRow() - 2, 0),
+  };
+}
+
+/** Rebuild only the designed, user-facing workbook tabs. */
+function buildProfessionalDashboard() {
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  const dashboard = digitalogicPrepareDesignedSheet_(spreadsheet, 'Dashboard', 50, 16, '#00acc1');
+  const calculator = digitalogicPrepareDesignedSheet_(spreadsheet, 'Pricing Calculator', 24, 10, '#16a34a');
+  const settings = digitalogicPrepareDesignedSheet_(spreadsheet, 'Settings', 28, 8, '#64748b');
+  const help = digitalogicPrepareDesignedSheet_(spreadsheet, 'Help', 24, 8, '#7c3aed');
+
+  digitalogicBuildDashboard_(dashboard);
+  digitalogicBuildCalculator_(calculator);
+  digitalogicBuildSettings_(settings);
+  digitalogicBuildHelp_(help);
+  const placeholder = spreadsheet.getSheetByName('Sheet1');
+  if (placeholder
+    && spreadsheet.getSheets().length > 1
+    && placeholder.getLastRow() <= 1
+    && placeholder.getLastColumn() <= 1
+    && placeholder.getRange('A1').isBlank()) {
+    spreadsheet.deleteSheet(placeholder);
+  }
+  SpreadsheetApp.flush();
+  return true;
+}
+
+function digitalogicPrepareDesignedSheet_(spreadsheet, name, minimumRows, minimumColumns, tabColor) {
+  let sheet = spreadsheet.getSheetByName(name);
+  if (!sheet) {
+    sheet = spreadsheet.insertSheet(name);
+  }
+  if (sheet.getMaxRows() < minimumRows) {
+    sheet.insertRowsAfter(sheet.getMaxRows(), minimumRows - sheet.getMaxRows());
+  }
+  if (sheet.getMaxColumns() < minimumColumns) {
+    sheet.insertColumnsAfter(sheet.getMaxColumns(), minimumColumns - sheet.getMaxColumns());
+  }
+  sheet.getCharts().forEach(function (chart) { sheet.removeChart(chart); });
+  sheet.getRange(1, 1, sheet.getMaxRows(), sheet.getMaxColumns()).breakApart();
+  sheet.clear();
+  sheet.setConditionalFormatRules([]);
+  sheet.setHiddenGridlines(true);
+  sheet.setTabColor(tabColor);
+  sheet.setFrozenRows(0);
+  sheet.setFrozenColumns(0);
+  return sheet;
+}
+
+function digitalogicTitle_(sheet, lastColumn, title, subtitle) {
+  const colors = DIGITALOGIC_DASHBOARD_COLORS;
+  sheet.getRange(1, 1, 2, lastColumn).merge()
+    .setValue(title)
+    .setBackground(colors.navy)
+    .setFontColor(colors.white)
+    .setFontFamily('Arial')
+    .setFontSize(20)
+    .setFontWeight('bold')
+    .setHorizontalAlignment('left')
+    .setVerticalAlignment('middle');
+  sheet.setRowHeights(1, 2, 28);
+  sheet.getRange(3, 1, 1, lastColumn).merge()
+    .setValue(subtitle)
+    .setBackground(colors.graySoft)
+    .setFontColor(colors.slate)
+    .setFontSize(10)
+    .setFontStyle('italic')
+    .setVerticalAlignment('middle');
+  sheet.setRowHeight(3, 26);
+}
+
+function digitalogicSection_(sheet, a1, label, fill) {
+  const colors = DIGITALOGIC_DASHBOARD_COLORS;
+  sheet.getRange(a1).merge()
+    .setValue(label)
+    .setBackground(fill || colors.teal)
+    .setFontColor(colors.white)
+    .setFontWeight('bold')
+    .setFontSize(11)
+    .setVerticalAlignment('middle');
+}
+
+function digitalogicHeader_(range, fill) {
+  const colors = DIGITALOGIC_DASHBOARD_COLORS;
+  range.setBackground(fill || colors.navyLight)
+    .setFontColor(colors.white)
+    .setFontWeight('bold')
+    .setFontSize(10)
+    .setHorizontalAlignment('center')
+    .setVerticalAlignment('middle')
+    .setWrap(true)
+    .setBorder(true, true, true, true, true, true, colors.gray, SpreadsheetApp.BorderStyle.SOLID);
+}
+
+function digitalogicKpi_(sheet, titleA1, valueA1, title, formula, accent) {
+  const colors = DIGITALOGIC_DASHBOARD_COLORS;
+  sheet.getRange(titleA1).merge()
+    .setValue(title)
+    .setBackground(colors.graySoft)
+    .setFontColor(colors.slate)
+    .setFontWeight('bold')
+    .setFontSize(9)
+    .setHorizontalAlignment('center')
+    .setVerticalAlignment('middle')
+    .setBorder(true, true, true, true, false, false, colors.gray, SpreadsheetApp.BorderStyle.SOLID);
+  sheet.getRange(valueA1).merge()
+    .setFormula(formula)
+    .setBackground(colors.white)
+    .setFontColor(accent)
+    .setFontWeight('bold')
+    .setFontSize(20)
+    .setHorizontalAlignment('center')
+    .setVerticalAlignment('middle')
+    .setBorder(true, true, true, true, false, false, colors.gray, SpreadsheetApp.BorderStyle.SOLID);
+}
+
+function digitalogicBuildDashboard_(sheet) {
+  const colors = DIGITALOGIC_DASHBOARD_COLORS;
+  digitalogicTitle_(
+    sheet,
+    16,
+    'DIGITALOGIC | PRODUCT & PRICING CONTROL CENTER',
+    'Patris Export + Digitalogic WordPress + Google Sheets + n8n | مرکز مدیریت کالا، قیمت و موجودی'
+  );
+
+  digitalogicKpi_(sheet, 'A5:D5', 'A6:D8', 'TOTAL PRODUCTS | کل کالاها', '=COUNTA(Products!$A$3:$A)', colors.blue);
+  digitalogicKpi_(sheet, 'E5:H5', 'E6:H8', 'PRICED PRODUCTS | کالاهای قیمت‌دار', '=COUNTIFS(Products!$A$3:$A,"<>",Products!$O$3:$O,">0")', colors.teal);
+  digitalogicKpi_(sheet, 'I5:L5', 'I6:L8', 'AVG EFFECTIVE PRICE | میانگین قیمت', '=IFERROR(AVERAGEIF(Products!$O$3:$O,">0"),0)', colors.green);
+  digitalogicKpi_(sheet, 'M5:P5', 'M6:P8', 'MISSING PATRIS CODE | کد پاتریس ناقص', '=COUNTIFS(Products!$A$3:$A,"<>",Products!$B$3:$B,"")', colors.amber);
+  sheet.getRange('I6:L8').setNumberFormat('#,##0 "IRT"');
+
+  digitalogicSection_(sheet, 'A10:D10', 'CATALOG HEALTH | سلامت فهرست', colors.blue);
+  sheet.getRange('A11:B16').setValues([
+    ['Metric', 'Count'],
+    ['Priced products', ''],
+    ['Missing Patris code', ''],
+    ['Draft products', ''],
+    ['Published products', ''],
+    ['Catalog errors', ''],
+  ]);
+  digitalogicHeader_(sheet.getRange('A11:B11'));
+  sheet.getRange('B12:B16').setFormulas([
+    ['=COUNTIFS(Products!$A$3:$A,"<>",Products!$O$3:$O,">0")'],
+    ['=COUNTIFS(Products!$A$3:$A,"<>",Products!$B$3:$B,"")'],
+    ['=COUNTIF(Products!$F$3:$F,"draft")'],
+    ['=COUNTIF(Products!$F$3:$F,"publish")'],
+    ['=COUNTIFS(Products!$A$3:$A,"<>",Products!$AL$3:$AL,"<>")'],
+  ]).setNumberFormat('#,##0');
+  sheet.getRange('A11:B16').setBorder(true, true, true, true, true, true, colors.gray, SpreadsheetApp.BorderStyle.SOLID);
+
+  digitalogicSection_(sheet, 'E10:H10', 'STOCK POSITION | وضعیت موجودی', colors.teal);
+  sheet.getRange('E11:F15').setValues([
+    ['Metric', 'Count'],
+    ['In stock', ''],
+    ['Out of stock', ''],
+    ['On backorder', ''],
+    ['Patris total stock', ''],
+  ]);
+  digitalogicHeader_(sheet.getRange('E11:F11'));
+  sheet.getRange('F12:F15').setFormulas([
+    ['=COUNTIF(Products!$S$3:$S,"instock")'],
+    ['=COUNTIF(Products!$S$3:$S,"outofstock")'],
+    ['=COUNTIF(Products!$S$3:$S,"onbackorder")'],
+    ['=SUM(Products!$T$3:$T)'],
+  ]).setNumberFormat('#,##0');
+  sheet.getRange('E11:F15').setBorder(true, true, true, true, true, true, colors.gray, SpreadsheetApp.BorderStyle.SOLID);
+
+  digitalogicSection_(sheet, 'J10:P10', 'LIVE WORKFLOW STATUS | وضعیت گردش کار', colors.navyLight);
+  sheet.getRange('J11:P17').setValues([
+    ['Component', 'Status / detail', 'Next action', '', '', '', ''],
+    ['Google owner', 'mahdielector@gmail.com', 'Owner-editable workbook; credentials are not stored in cells', '', '', '', ''],
+    ['Catalog sync', 'not run', 'not run', '', '', '', ''],
+    ['Writeback', 'not run', 'not run', '', '', '', ''],
+    ['Transport', 'not configured', 'No secrets in this workbook', '', '', '', ''],
+    ['Patris identity', 'Exact Code', 'SKU is display-only and never used as fallback identity', '', '', '', ''],
+    ['Owner review', 'Pending', 'Merged and deployed work remains open for owner review', '', '', '', ''],
+  ]);
+  digitalogicHeader_(sheet.getRange('J11:P11'));
+  sheet.getRange('J12:P17')
+    .setBackground(colors.graySoft)
+    .setFontColor(colors.navyLight)
+    .setFontSize(9)
+    .setWrap(true)
+    .setVerticalAlignment('middle')
+    .setBorder(true, true, true, true, true, true, colors.gray, SpreadsheetApp.BorderStyle.SOLID);
+
+  sheet.setRowHeights(11, 7, 34);
+  sheet.setRowHeight(11, 28);
+  sheet.getRange('A11:F16').setFontSize(9);
+
+  const healthChart = sheet.newChart()
+    .asPieChart()
+    .addRange(sheet.getRange('A11:B16'))
+    .setPosition(20, 1, 0, 0)
+    .setOption('title', 'Catalog quality gates')
+    .setOption('pieHole', 0.55)
+    .setOption('legend.position', 'right')
+    .setOption('backgroundColor', colors.white)
+    .setOption('colors', [colors.green, colors.amber, colors.slate, colors.blue, colors.red])
+    .build();
+  sheet.insertChart(healthChart);
+
+  const stockChart = sheet.newChart()
+    .asColumnChart()
+    .addRange(sheet.getRange('E11:F14'))
+    .setPosition(20, 9, 0, 0)
+    .setOption('title', 'Current stock status')
+    .setOption('legend.position', 'none')
+    .setOption('backgroundColor', colors.white)
+    .setOption('colors', [colors.teal])
+    .build();
+  sheet.insertChart(stockChart);
+
+  digitalogicSection_(sheet, 'A38:P38', 'SAFE DAILY WORKFLOW | روند امن روزانه', colors.blue);
+  sheet.getRange('A39:P45').merge()
+    .setValue(
+      '1. Refresh Products and Categories from Digitalogic Sync.   2. Review catalog and stock KPIs.   ' +
+      '3. Select exact Product rows and stage them into Changes.   4. Edit only allowlisted fields and tick Selected.   ' +
+      '5. Preview the revision-checked diff through n8n.   6. Apply only after review, then verify Audit and refresh.\n\n' +
+      'Products and Categories are protected reference snapshots. Changes, Pricing Calculator, and non-secret Settings remain editable. ' +
+      'Incomplete products remain draft; the workflow never mass-publishes them.'
+    )
+    .setBackground(colors.cyanSoft)
+    .setFontColor('#075985')
+    .setFontSize(11)
+    .setWrap(true)
+    .setVerticalAlignment('middle')
+    .setBorder(true, true, true, true, false, false, colors.blue, SpreadsheetApp.BorderStyle.SOLID);
+
+  sheet.setColumnWidths(1, 16, 96);
+  sheet.setColumnWidths(1, 4, 105);
+  sheet.setColumnWidths(5, 4, 115);
+  sheet.setColumnWidths(9, 8, 98);
+  sheet.setFrozenRows(3);
+}
+
+function digitalogicBuildCalculator_(sheet) {
+  const colors = DIGITALOGIC_DASHBOARD_COLORS;
+  digitalogicTitle_(
+    sheet,
+    10,
+    'DIGITALOGIC | LANDED PRICE CALCULATOR',
+    'Auditable Patris pricing scenario | محاسبه قیمت نهایی با ورودی‌های شفاف و قابل بررسی'
+  );
+  digitalogicSection_(sheet, 'A5:J5', 'SCENARIO INPUTS | ورودی‌های سناریو', colors.green);
+  sheet.getRange('A6:B15').setValues([
+    ['Input', 'Value'],
+    ['Sync Key', ''],
+    ['Product', ''],
+    ['Weight (g)', ''],
+    ['Foreign price (CNY)', ''],
+    ['Shipping / kg', ''],
+    ['Shipping currency', ''],
+    ['Profit margin', ''],
+    ['CNY to IRT', ''],
+    ['Calculated final price', ''],
+  ]);
+  digitalogicHeader_(sheet.getRange('A6:B6'));
+  sheet.getRange('B8').setFormula('=IFERROR(INDEX(Products!$A:$ZZ,MATCH($B$7,Products!$A:$A,0),MATCH("name",Products!$1:$1,0)),"")');
+  sheet.getRange('B9').setFormula('=IFERROR(INDEX(Products!$A:$ZZ,MATCH($B$7,Products!$A:$A,0),MATCH("weight_grams",Products!$1:$1,0)),"")');
+  sheet.getRange('B10').setFormula('=IFERROR(INDEX(Products!$A:$ZZ,MATCH($B$7,Products!$A:$A,0),MATCH("foreign_price",Products!$1:$1,0)),"")');
+  sheet.getRange('B11').setFormula('=IFERROR(IF(INDEX(Products!$A:$ZZ,MATCH($B$7,Products!$A:$A,0),MATCH("shipping_price_per_kg",Products!$1:$1,0))="",Settings!$B$8,INDEX(Products!$A:$ZZ,MATCH($B$7,Products!$A:$A,0),MATCH("shipping_price_per_kg",Products!$1:$1,0))),Settings!$B$8)');
+  sheet.getRange('B12').setFormula('=IFERROR(IF(INDEX(Products!$A:$ZZ,MATCH($B$7,Products!$A:$A,0),MATCH("shipping_price_per_kg_currency",Products!$1:$1,0))="",Settings!$B$9,UPPER(INDEX(Products!$A:$ZZ,MATCH($B$7,Products!$A:$A,0),MATCH("shipping_price_per_kg_currency",Products!$1:$1,0)))),Settings!$B$9)');
+  sheet.getRange('B13').setFormula('=IFERROR(IF(INDEX(Products!$A:$ZZ,MATCH($B$7,Products!$A:$A,0),MATCH("profit_percent",Products!$1:$1,0))="",Settings!$B$10,INDEX(Products!$A:$ZZ,MATCH($B$7,Products!$A:$A,0),MATCH("profit_percent",Products!$1:$1,0))/100),Settings!$B$10)');
+  sheet.getRange('B14').setFormula('=Settings!$B$7');
+  sheet.getRange('B15').setFormula('=IF(OR(B9<=0,B10<=0,B11<=0,B13<0,B14<=0,AND(B12<>"CNY",B12<>"IRR")),"INPUT REQUIRED",ROUND((B10*B14+(B9/1000)*IF(B12="CNY",B11*B14,B11/10))*(1+B13),0))');
+  sheet.getRange('B7:B12').setNumberFormat('@');
+  sheet.getRange('B9:B11').setNumberFormat('#,##0.########');
+  sheet.getRange('B13').setNumberFormat('0.0%');
+  sheet.getRange('B14:B15').setNumberFormat('#,##0 "IRT"');
+  sheet.getRange('B15')
+    .setBackground(colors.greenSoft)
+    .setFontColor(colors.green)
+    .setFontSize(16)
+    .setFontWeight('bold')
+    .setHorizontalAlignment('center')
+    .setBorder(true, true, true, true, false, false, colors.green, SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
+  sheet.getRange('D6:J15').merge()
+    .setValue(
+      'FORMULA\n\nROUND((Foreign price × CNY→IRT + Weight kg × freight in IRT) × (1 + Profit %), 0)\n\n' +
+      'CNY freight is converted by the FX rate. IRR freight is divided by 10 to reach IRT. ' +
+      'One final rounding step is applied after freight and profit. Missing or invalid inputs return INPUT REQUIRED.'
+    )
+    .setBackground(colors.cyanSoft)
+    .setFontColor('#075985')
+    .setFontSize(11)
+    .setWrap(true)
+    .setHorizontalAlignment('center')
+    .setVerticalAlignment('middle')
+    .setBorder(true, true, true, true, false, false, colors.blue, SpreadsheetApp.BorderStyle.SOLID);
+  sheet.setColumnWidth(1, 210);
+  sheet.setColumnWidth(2, 230);
+  sheet.setColumnWidth(3, 24);
+  sheet.setColumnWidths(4, 7, 100);
+  sheet.setFrozenRows(5);
+}
+
+function digitalogicBuildSettings_(sheet) {
+  const colors = DIGITALOGIC_DASHBOARD_COLORS;
+  digitalogicTitle_(
+    sheet,
+    8,
+    'DIGITALOGIC | CONTROL CENTER SETTINGS',
+    'Editable business assumptions only | اطلاعات محرمانه فقط در Script Properties و n8n Credentials'
+  );
+  digitalogicSection_(sheet, 'A5:H5', 'LIVE CONNECTIONS & BUSINESS ASSUMPTIONS | تنظیمات و اتصال‌ها', colors.slate);
+  sheet.getRange('A6:B14').setValues([
+    ['Setting', 'Value'],
+    ['CNY to IRT (editable)', 25300],
+    ['Scenario shipping / kg', ''],
+    ['Scenario shipping currency', 'CNY'],
+    ['Scenario profit margin', 0.30],
+    ['Sync locale (managed)', 'bilingual'],
+    ['Schedule (managed)', 'Every 6 hours'],
+    ['Writeback policy', 'Preview then explicit Apply'],
+    ['Publishing policy', 'Quality-gated; never automatic'],
+  ]);
+  digitalogicHeader_(sheet.getRange('A6:B6'));
+  sheet.getRange('B7:B8').setNumberFormat('#,##0.########');
+  sheet.getRange('B9').setDataValidation(SpreadsheetApp.newDataValidation().requireValueInList(['CNY', 'IRR'], true).setAllowInvalid(false).build());
+  sheet.getRange('B10').setNumberFormat('0.0%');
+  sheet.getRange('D6:H13').setValues([
+    ['Connection', 'Endpoint / identity', 'Mode', 'Owner', 'Status'],
+    ['Digitalogic WordPress', 'https://digitalogic.ir', 'Living catalog', 'Digitalogic', 'Connected'],
+    ['Catalog API', '/google-sheets/catalog', 'Read', 'WordPress', 'Live'],
+    ['Writeback API', 'n8n → guarded WordPress endpoint', 'Preview / Apply', 'Digitalogic', 'Guarded'],
+    ['Patris Export', 'Exact Code identity', 'Source + pricing', 'Patris', 'Connected'],
+    ['n8n', 'https://automation.digitalogic.ir', 'Approval bridge', 'Digitalogic', 'Active'],
+    ['Google owner', 'mahdielector@gmail.com', 'Editor', 'Mahdi Shokri', 'Signed in'],
+    ['Secrets', 'Never stored in cells', 'Protected', 'Apps Script / n8n', 'Configured'],
+  ]);
+  digitalogicHeader_(sheet.getRange('D6:H6'));
+  sheet.getRange('D7:H13')
+    .setFontSize(9)
+    .setWrap(true)
+    .setVerticalAlignment('middle')
+    .setBorder(true, true, true, true, true, true, colors.gray, SpreadsheetApp.BorderStyle.SOLID);
+  sheet.getRange('A16:H20').merge()
+    .setValue(
+      'Safety rule: Products and Categories are synchronized reference snapshots. Stage exact Products rows into Changes, ' +
+      'edit only allowlisted fields, tick Selected, run Preview, review the diff, then explicitly Apply. ' +
+      'Shipping assignment never implies catalog readiness, and incomplete products remain draft.'
+    )
+    .setBackground(colors.amberSoft)
+    .setFontColor('#92400e')
+    .setFontWeight('bold')
+    .setWrap(true)
+    .setVerticalAlignment('middle')
+    .setBorder(true, true, true, true, false, false, colors.amber, SpreadsheetApp.BorderStyle.SOLID);
+  sheet.setColumnWidth(1, 220);
+  sheet.setColumnWidth(2, 190);
+  sheet.setColumnWidth(3, 24);
+  sheet.setColumnWidth(4, 170);
+  sheet.setColumnWidth(5, 300);
+  sheet.setColumnWidths(6, 3, 130);
+  sheet.setFrozenRows(5);
+}
+
+function digitalogicBuildHelp_(sheet) {
+  const colors = DIGITALOGIC_DASHBOARD_COLORS;
+  digitalogicTitle_(
+    sheet,
+    8,
+    'DIGITALOGIC | OPERATING GUIDE',
+    'Safe daily operation, recovery, identity, and pricing reference | راهنمای بهره‌برداری'
+  );
+  const rows = [
+    ['Topic', 'Guidance'],
+    ['1. Refresh', 'Use Digitalogic Sync → Sync now. Products and Categories are replaced from the living sparse catalog and remain protected reference tabs.'],
+    ['2. Propose', 'Select exact rows in Products, use Digitalogic Changes → Stage selected Products, and edit only allowlisted fields in Changes.'],
+    ['3. Review', 'Tick Selected and run Preview selected changes. Check identity, current and proposed values, warnings, and expected record revision.'],
+    ['4. Apply', 'Run Apply previewed changes only after review and confirm the dialog. The request is bounded, idempotent, revision-checked, and audited.'],
+    ['5. Verify', 'Read Audit, refresh Products, and confirm the new record revision. On conflict, refresh and create a new proposal instead of forcing it.'],
+    ['6. Recover', 'If Google authorization expires, run syncCatalog and approve it again. Reinstall a stale trigger with removeScheduledSync then installScheduledSync.'],
+    ['Identity', 'Patris matching uses exact, case-sensitive Code. A woo:<id> display key keeps unmatched WooCommerce rows visible; SKU is never fallback identity.'],
+    ['Pricing', 'Final price combines foreign price, weight-based freight, FX conversion, and profit, then applies one final rounding step. Missing inputs stay visibly blocked.'],
+    ['Publishing', 'Shipping assignment does not mean readiness. Missing Code, weight, price, images, descriptions, categories, or variation review remains a stop condition.'],
+    ['Support', 'Digitalogic: https://digitalogic.ir  |  Automation: https://automation.digitalogic.ir  |  GitHub issue: atomicdeploy/digitalogic-wp#99'],
+  ];
+  digitalogicSection_(sheet, 'A5:H5', 'QUICK REFERENCE | راهنمای سریع', colors.blue);
+  sheet.getRange(6, 1, rows.length, 2).setValues(rows);
+  digitalogicHeader_(sheet.getRange('A6:B6'));
+  sheet.getRange(7, 1, rows.length - 1, 2)
+    .setFontColor(colors.navyLight)
+    .setFontSize(10)
+    .setWrap(true)
+    .setVerticalAlignment('top')
+    .setBorder(true, true, true, true, true, true, colors.gray, SpreadsheetApp.BorderStyle.SOLID);
+  sheet.getRange(7, 1, rows.length - 1, 1).setFontWeight('bold').setBackground(colors.graySoft);
+  sheet.setColumnWidth(1, 150);
+  sheet.setColumnWidth(2, 760);
+  sheet.setRowHeights(7, rows.length - 1, 52);
+  sheet.setFrozenRows(6);
+}

--- a/assets/integrations/n8n/digitalogic-google-sheets-writeback.json
+++ b/assets/integrations/n8n/digitalogic-google-sheets-writeback.json
@@ -37,13 +37,44 @@
     },
     {
       "parameters": {
-        "jsCode": "const body = $json.body && typeof $json.body === 'object' ? $json.body : {};\nconst headerKey = String(($json.headers || {})['idempotency-key'] || '');\nconst bodyKey = String(body.idempotency_key || '');\nif (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(bodyKey) || headerKey !== bodyKey) {\n  throw new Error('A matching bounded Idempotency-Key header and body value are required.');\n}\nif (!Array.isArray(body.changes) || body.changes.length < 1 || body.changes.length > 50) {\n  throw new Error('changes must contain 1 through 50 rows.');\n}\nfor (const [index, change] of body.changes.entries()) {\n  if (!change || change.sync_key !== change.patris_code || !/^sha256:[a-f0-9]{64}$/.test(String(change.expected_record_revision || '')) || !change.fields || typeof change.fields !== 'object' || Array.isArray(change.fields)) {\n    throw new Error(`Invalid revision-checked change at index ${index}.`);\n  }\n}\nreturn [{ json: { idempotency_key: bodyKey, request: { idempotency_key: bodyKey, changes: body.changes } } }];"
+        "jsCode": "const reject = (code, message) => [{ json: { validation_ok: false, statusCode: 400, body: { success: false, code, message } } }];\nconst body = $json.body && typeof $json.body === 'object' ? $json.body : {};\nconst headerKey = String(($json.headers || {})['idempotency-key'] || '');\nconst bodyKey = String(body.idempotency_key || '');\nif (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(bodyKey) || headerKey !== bodyKey) {\n  return reject('invalid_idempotency_key', 'A matching bounded Idempotency-Key header and body value are required.');\n}\nif (!Array.isArray(body.changes) || body.changes.length < 1 || body.changes.length > 50) {\n  return reject('invalid_change_count', 'changes must contain 1 through 50 rows.');\n}\nfor (const [index, change] of body.changes.entries()) {\n  if (!change || change.sync_key !== change.patris_code || !/^sha256:[a-f0-9]{64}$/.test(String(change.expected_record_revision || '')) || !change.fields || typeof change.fields !== 'object' || Array.isArray(change.fields)) {\n    return reject('invalid_change', `Invalid revision-checked change at index ${index}.`);\n  }\n}\nreturn [{ json: { validation_ok: true, idempotency_key: bodyKey, request: { idempotency_key: bodyKey, changes: body.changes } } }];"
       },
       "id": "d9bd58f2-5c42-4ba6-8f6c-b415f06ec7b8",
       "name": "Validate Preview Envelope",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [-620, -80]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "603d98c3-12d4-4e46-a7be-8b2aaed31ab8",
+              "leftValue": "={{ $json.validation_ok }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "8862491a-69a8-4bc8-b1bd-90525f7ccb12",
+      "name": "Preview Envelope Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [-480, -80]
     },
     {
       "parameters": {
@@ -61,13 +92,17 @@
             {
               "name": "Accept",
               "value": "application/json"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "identity"
             }
           ]
         },
         "sendBody": true,
-        "contentType": "raw",
-        "rawContentType": "application/json",
-        "body": "={{ JSON.stringify($json.request) }}",
+        "contentType": "json",
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.request }}",
         "options": {
           "response": {
             "response": {
@@ -130,13 +165,44 @@
     },
     {
       "parameters": {
-        "jsCode": "const headers = $json.headers || {};\nif (String(headers['x-digitalogic-confirm-apply'] || '') !== 'APPLY') {\n  throw new Error('Explicit X-Digitalogic-Confirm-Apply: APPLY header is required.');\n}\nconst body = $json.body && typeof $json.body === 'object' ? $json.body : {};\nconst headerKey = String(headers['idempotency-key'] || '');\nconst bodyKey = String(body.idempotency_key || '');\nif (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(bodyKey) || headerKey !== bodyKey) {\n  throw new Error('A matching bounded Idempotency-Key header and body value are required.');\n}\nif (!Array.isArray(body.changes) || body.changes.length < 1 || body.changes.length > 50) {\n  throw new Error('changes must contain 1 through 50 rows.');\n}\nfor (const [index, change] of body.changes.entries()) {\n  if (!change || change.sync_key !== change.patris_code || !/^sha256:[a-f0-9]{64}$/.test(String(change.expected_record_revision || '')) || !change.fields || typeof change.fields !== 'object' || Array.isArray(change.fields)) {\n    throw new Error(`Invalid revision-checked change at index ${index}.`);\n  }\n}\nreturn [{ json: { idempotency_key: bodyKey, request: { idempotency_key: bodyKey, changes: body.changes } } }];"
+        "jsCode": "const reject = (code, message) => [{ json: { validation_ok: false, statusCode: 400, body: { success: false, code, message } } }];\nconst headers = $json.headers || {};\nif (String(headers['x-digitalogic-confirm-apply'] || '') !== 'APPLY') {\n  return reject('explicit_apply_confirmation_required', 'Explicit X-Digitalogic-Confirm-Apply: APPLY header is required.');\n}\nconst body = $json.body && typeof $json.body === 'object' ? $json.body : {};\nconst headerKey = String(headers['idempotency-key'] || '');\nconst bodyKey = String(body.idempotency_key || '');\nif (!/^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/.test(bodyKey) || headerKey !== bodyKey) {\n  return reject('invalid_idempotency_key', 'A matching bounded Idempotency-Key header and body value are required.');\n}\nif (!Array.isArray(body.changes) || body.changes.length < 1 || body.changes.length > 50) {\n  return reject('invalid_change_count', 'changes must contain 1 through 50 rows.');\n}\nfor (const [index, change] of body.changes.entries()) {\n  if (!change || change.sync_key !== change.patris_code || !/^sha256:[a-f0-9]{64}$/.test(String(change.expected_record_revision || '')) || !change.fields || typeof change.fields !== 'object' || Array.isArray(change.fields)) {\n    return reject('invalid_change', `Invalid revision-checked change at index ${index}.`);\n  }\n}\nreturn [{ json: { validation_ok: true, idempotency_key: bodyKey, request: { idempotency_key: bodyKey, changes: body.changes } } }];"
       },
       "id": "aa38d5b7-1964-4163-bcc8-d380404a3801",
       "name": "Validate Explicit Apply",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [-620, 260]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "66bdf8d9-ee11-4a28-bbb9-924d73a01c47",
+              "leftValue": "={{ $json.validation_ok }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "28544d86-fcce-41d8-9915-27cd2c62261b",
+      "name": "Apply Envelope Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [-480, 260]
     },
     {
       "parameters": {
@@ -154,13 +220,17 @@
             {
               "name": "Accept",
               "value": "application/json"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "identity"
             }
           ]
         },
         "sendBody": true,
-        "contentType": "raw",
-        "rawContentType": "application/json",
-        "body": "={{ JSON.stringify($json.request) }}",
+        "contentType": "json",
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.request }}",
         "options": {
           "response": {
             "response": {
@@ -207,7 +277,13 @@
       "main": [[{"node": "Validate Preview Envelope", "type": "main", "index": 0}]]
     },
     "Validate Preview Envelope": {
-      "main": [[{"node": "Digitalogic Preview", "type": "main", "index": 0}]]
+      "main": [[{"node": "Preview Envelope Valid?", "type": "main", "index": 0}]]
+    },
+    "Preview Envelope Valid?": {
+      "main": [
+        [{"node": "Digitalogic Preview", "type": "main", "index": 0}],
+        [{"node": "Return Preview", "type": "main", "index": 0}]
+      ]
     },
     "Digitalogic Preview": {
       "main": [[{"node": "Return Preview", "type": "main", "index": 0}]]
@@ -216,7 +292,13 @@
       "main": [[{"node": "Validate Explicit Apply", "type": "main", "index": 0}]]
     },
     "Validate Explicit Apply": {
-      "main": [[{"node": "Digitalogic Apply", "type": "main", "index": 0}]]
+      "main": [[{"node": "Apply Envelope Valid?", "type": "main", "index": 0}]]
+    },
+    "Apply Envelope Valid?": {
+      "main": [
+        [{"node": "Digitalogic Apply", "type": "main", "index": 0}],
+        [{"node": "Return Apply", "type": "main", "index": 0}]
+      ]
     },
     "Digitalogic Apply": {
       "main": [[{"node": "Return Apply", "type": "main", "index": 0}]]

--- a/tests/google-sheets-apps-script.test.js
+++ b/tests/google-sheets-apps-script.test.js
@@ -6,6 +6,15 @@ const test = require('node:test');
 
 const sourcePath = path.join(__dirname, '..', 'assets', 'integrations', 'google-apps-script', 'Code.gs');
 const source = fs.readFileSync(sourcePath, 'utf8');
+const professionalDashboardPath = path.join(
+  __dirname,
+  '..',
+  'assets',
+  'integrations',
+  'google-apps-script',
+  'ProfessionalDashboard.gs'
+);
+const professionalDashboardSource = fs.readFileSync(professionalDashboardPath, 'utf8');
 const n8nPath = path.join(
   __dirname,
   '..',
@@ -649,30 +658,108 @@ test('idempotency keys survive uncertain retries and rotate after a completed at
   assert.match(nextAttempt, /^digitalogic:apply:[a-f0-9]{16}:[a-f0-9]{24}$/);
 });
 
+test('professional control center is credential-free, editable, and idempotently initialized', () => {
+  assert.match(professionalDashboardSource, /function initializeDigitalogicControlCenter\(\)/);
+  assert.match(professionalDashboardSource, /syncCatalog\(\);/);
+  assert.match(professionalDashboardSource, /setupEditableWorkspace\(\);/);
+  assert.match(professionalDashboardSource, /installScheduledSync\(\);/);
+  assert.match(professionalDashboardSource, /'Pricing Calculator'/);
+  assert.match(professionalDashboardSource, /'Settings'/);
+  assert.match(professionalDashboardSource, /'Help'/);
+  assert.match(professionalDashboardSource, /newChart\(\)[\s\S]*?\.asPieChart\(\)/);
+  assert.match(professionalDashboardSource, /newChart\(\)[\s\S]*?\.asColumnChart\(\)/);
+  assert.match(professionalDashboardSource, /=COUNTA\(Products!\$A\$3:\$A\)/);
+  assert.match(professionalDashboardSource, /Products!\$AL\$3:\$AL/);
+  assert.match(professionalDashboardSource, /placeholder\.getRange\('A1'\)\.isBlank\(\)/);
+  assert.match(professionalDashboardSource, /Preview then explicit Apply/);
+  assert.match(professionalDashboardSource, /محاسبه قیمت نهایی/);
+  assert.doesNotMatch(
+    professionalDashboardSource,
+    /\bck_[A-Za-z0-9]+\b|\bcs_[A-Za-z0-9]+\b|DIGITALOGIC_N8N_WRITEBACK_TOKEN\s*[:=]\s*['"][^'"]+/
+  );
+
+  assert.match(
+    source,
+    /if \(config\.n8nWritebackBase[\s\S]*?!stateProperties\.getProperty\('DIGITALOGIC_LAST_WRITEBACK_TRANSPORT'\)/
+  );
+  assert.match(source, /DIGITALOGIC_LAST_WRITEBACK_STATUS: 'ready'/);
+  assert.match(source, /DIGITALOGIC_LAST_WRITEBACK_TRANSPORT: 'n8n'/);
+});
+
 test('n8n template is inactive, importable, credential-only, and keeps apply explicit', () => {
   assert.equal(n8nWorkflow.active, false);
   assert.equal(n8nWorkflow.name, 'Digitalogic Google Sheets - Safe Writeback');
   assert.equal(n8nWorkflow.settings.saveDataErrorExecution, 'none');
   assert.equal(n8nWorkflow.settings.saveManualExecutions, false);
-  assert.equal(n8nWorkflow.nodes.length, 9);
+  assert.equal(n8nWorkflow.nodes.length, 11);
   const byName = Object.fromEntries(n8nWorkflow.nodes.map((node) => [node.name, node]));
   assert.equal(byName['Preview Webhook'].parameters.path, 'digitalogic-google-sheets/preview');
   assert.equal(byName['Apply Webhook'].parameters.path, 'digitalogic-google-sheets/apply');
+  assert.equal(byName['Preview Webhook'].parameters.responseMode, 'responseNode');
+  assert.equal(byName['Preview Webhook'].parameters.responseData, undefined);
+  assert.equal(byName['Apply Webhook'].parameters.responseMode, 'responseNode');
+  assert.equal(byName['Apply Webhook'].parameters.responseData, undefined);
   assert.match(byName['Validate Explicit Apply'].parameters.jsCode, /X-Digitalogic-Confirm-Apply/);
+  assert.match(byName['Validate Preview Envelope'].parameters.jsCode, /validation_ok: false/);
+  assert.match(byName['Validate Explicit Apply'].parameters.jsCode, /validation_ok: false/);
+  assert.doesNotMatch(byName['Validate Preview Envelope'].parameters.jsCode, /throw new Error/);
+  assert.doesNotMatch(byName['Validate Explicit Apply'].parameters.jsCode, /throw new Error/);
+  assert.equal(byName['Preview Envelope Valid?'].type, 'n8n-nodes-base.if');
+  assert.equal(byName['Apply Envelope Valid?'].type, 'n8n-nodes-base.if');
   assert.match(byName['Digitalogic Preview'].parameters.url, /writeback\/preview$/);
   assert.match(byName['Digitalogic Apply'].parameters.url, /writeback\/apply$/);
+  assert.deepEqual(
+    byName['Digitalogic Preview'].parameters.headerParameters.parameters.find(
+      (header) => header.name === 'Accept-Encoding',
+    ),
+    { name: 'Accept-Encoding', value: 'identity' },
+  );
+  assert.deepEqual(
+    byName['Digitalogic Apply'].parameters.headerParameters.parameters.find(
+      (header) => header.name === 'Accept-Encoding',
+    ),
+    { name: 'Accept-Encoding', value: 'identity' },
+  );
+  assert.equal(byName['Digitalogic Preview'].parameters.contentType, 'json');
+  assert.equal(byName['Digitalogic Preview'].parameters.specifyBody, 'json');
+  assert.equal(byName['Digitalogic Preview'].parameters.jsonBody, '={{ $json.request }}');
+  assert.equal(byName['Digitalogic Preview'].parameters.rawContentType, undefined);
+  assert.equal(byName['Digitalogic Preview'].parameters.body, undefined);
+  assert.equal(byName['Digitalogic Apply'].parameters.contentType, 'json');
+  assert.equal(byName['Digitalogic Apply'].parameters.specifyBody, 'json');
+  assert.equal(byName['Digitalogic Apply'].parameters.jsonBody, '={{ $json.request }}');
+  assert.equal(byName['Digitalogic Apply'].parameters.rawContentType, undefined);
+  assert.equal(byName['Digitalogic Apply'].parameters.body, undefined);
   assert.equal(byName['Digitalogic Preview'].parameters.options.response.response.fullResponse, true);
   assert.equal(byName['Digitalogic Preview'].parameters.options.response.response.neverError, true);
+  assert.equal(byName['Return Preview'].type, 'n8n-nodes-base.respondToWebhook');
   assert.equal(byName['Return Preview'].parameters.respondWith, 'json');
   assert.match(byName['Return Preview'].parameters.responseBody, /\$json\.body/);
   assert.match(byName['Return Preview'].parameters.options.responseCode, /statusCode/);
   assert.equal(byName['Digitalogic Apply'].parameters.options.response.response.fullResponse, true);
+  assert.equal(byName['Return Apply'].type, 'n8n-nodes-base.respondToWebhook');
   assert.equal(byName['Return Apply'].parameters.respondWith, 'json');
   assert.match(byName['Return Apply'].parameters.responseBody, /\$json\.body/);
   assert.match(byName['Return Apply'].parameters.options.responseCode, /statusCode/);
   assert.equal(
     n8nWorkflow.connections['Apply Webhook'].main[0][0].node,
     'Validate Explicit Apply'
+  );
+  assert.equal(
+    n8nWorkflow.connections['Preview Envelope Valid?'].main[0][0].node,
+    'Digitalogic Preview'
+  );
+  assert.equal(
+    n8nWorkflow.connections['Preview Envelope Valid?'].main[1][0].node,
+    'Return Preview'
+  );
+  assert.equal(
+    n8nWorkflow.connections['Apply Envelope Valid?'].main[0][0].node,
+    'Digitalogic Apply'
+  );
+  assert.equal(
+    n8nWorkflow.connections['Apply Envelope Valid?'].main[1][0].node,
+    'Return Apply'
   );
   assert.equal(byName['Scheduled Refresh'], undefined);
   assert.equal(byName['Manual Refresh'], undefined);


### PR DESCRIPTION
## Summary
- add an idempotent professional Google Sheets control-center builder with live KPIs, charts, editable pricing calculator/settings, bilingual guidance, protected catalog snapshots, and scheduled refresh
- expose an explicit n8n-ready workspace state without storing credentials in cells or source
- make the n8n 2.30.x writeback proxy return structured Digitalogic JSON using native JSON request bodies and guarded validation branches

## Verification
- `node --test tests/google-sheets-apps-script.test.js` (24/24)
- Apps Script syntax check and `git diff --check`
- private owner workbook initialized: 967 products, 115 categories, charts, calculator, Changes/Audit, six-hour trigger
- live catalog read with rotated dedicated key: HTTP 200, total 967
- live n8n probes: preview HTTP 200/zero writes; missing or invalid auth 403; invalid envelope 400; apply without confirmation 400

Refs #99