### PR TITLE
Keep Digitalogic TCI routing direct to extension 101

### DIFF
--- a/ops/pbx/DEPLOYMENT.md
+++ b/ops/pbx/DEPLOYMENT.md
@@ -1,8 +1,8 @@
 # Deployment and validation
 
-This is a reviewed runbook, not an automatic installer. Do not mutate Asterisk
-or enable the feature until the WordPress pending endpoint, 120-second challenge
-TTL, browser consumption, and login redirect have been deployed and tested.
+This is a reviewed runbook, not an automatic installer. The verification assets
+may be installed, but Digitalogic's public TCI routes remain direct-to-101 until a
+separate IVR design is approved and tested.
 
 ## 1. Preflight and backups
 
@@ -64,16 +64,18 @@ Listen to every output and verify the BGM remains below speech, `*` can interrup
 the pending prompt, and both 8 kHz/16 kHz files are mono PCM. The installer creates
 an immutable release and atomically switches `current`.
 
-## 4. Merge the dialplan
+## 4. Keep the public dialplan direct to extension 101
 
-Manually merge `asterisk/digitalogic-pending-shortcut.conf` into both exact
-`[from-tci]` s/_X paths. Recheck the live checksum immediately before install.
+Install only the dormant helper contexts from
+`asterisk/digitalogic-pending-shortcut.conf`. Do not add its `preflight` or
+`shortcut` calls to either `[from-tci]` entry path. Recheck the live checksum
+immediately before install.
 
-Mandatory ordering is: initialize fail-open variables; snapshot ANI/DID; signed
-preflight; conditional shortcut (which alone answers the channel); verified
-hangup; then the untouched
-`prefix-tci-callerid` → `record-call` → operator flow. Remove the former
-`digitalogic-call-verification-menu` and its public digit 2 completely.
+Both the `s` and `_X.` routes must contain only their existing inbound `NoOp`, then
+`prefix-tci-callerid` → `record-call` →
+`Dial(PJSIP/${OPERATOR_EXT},30,Tt)` → `Hangup(19)`. Keep `OPERATOR_EXT=101`.
+Remove the former `digitalogic-call-verification-menu`, public digit 2, pending
+lookup, and conditional shortcut from those public priorities completely.
 
 Do not add a public fallback digit. The private `verify` context is intentionally
 unrouted until a separate Digitalogic IVR is designed and approved.
@@ -94,20 +96,13 @@ asterisk -rx 'agi set debug off'
 
 Use real PSTN ANI and redacted evidence:
 
-- No active challenge: no verification audio or early `Answer()`; original operator
-  flow and caller-ID prefix remain unchanged.
-- Pending exact ANI: the private «دوست عزیزم…» BGM prompt plays immediately.
-- Star during the prompt or between digits cancels immediately; no input times out
-  once, then operator flow begins, with no callback and no verification DTMF in
-  recordings or logs.
-- Correct six-digit code: one confirm callback marks the challenge verified and the
-  call terminates after the success prompt.
-- A rejected six-digit typo gets one retry, then falls back to the operator;
-  wrong/expired codes and wrong/withheld ANI cannot verify.
-- Pending endpoint timeout, malformed JSON, extra response keys, bad signature,
-  replay, or HTTP failure reaches the operator within the bounded timeout.
-- Confirm endpoint failures remain closed and generic.
+- Every call, including one whose ANI has a pending website challenge, bypasses
+  the verification HTTP endpoint and AGI and rings extension 101 immediately.
+- Asterisk shows the paired TCI and `PJSIP/101` channels, with no verification
+  audio, early `Answer()`, prompt, or DTMF collection.
 - Both s and _X inbound paths behave identically.
+- The dormant helper contexts remain loaded but unreachable from public and
+  internal dialplan paths.
 
-Only after these pass should inbound verification be enabled for test accounts.
-Outbound voice remains a separate opt-in, authenticated trust boundary.
+Inbound verification can be revisited only as part of the approved Digitalogic
+IVR pass. Outbound voice remains a separate opt-in, authenticated trust boundary.

--- a/ops/pbx/README.md
+++ b/ops/pbx/README.md
@@ -1,12 +1,12 @@
 # Digitalogic PBX operational assets
 
 Version 1.1.0 provides a dependency-free Node 18+ AGI helper for caller-aware
-phone verification at `+982166754123`. Digitalogic historically had no public
-inbound IVR, so this release removes the first-audio digit-2 menu and does not
-invent a replacement digit. A caller with an unexpired challenge is offered a
-private shortcut; every other caller continues to the existing operator path.
+phone verification at `+982166754123`. Digitalogic has no public inbound IVR, so
+the current production DID bypasses every verification helper and rings extension
+101 directly. The helper and its BGM-mixed prompts remain installed but dormant
+for the next, separately approved IVR pass. No public verification digit exists.
 
-The wrapper forwards one reviewed mode to the helper:
+The dormant wrapper forwards one reviewed mode to the helper:
 
 - `preflight`: signed ANI lookup with no audio. It sets only
   `PBX_VERIFY_PENDING=0|1`.
@@ -40,8 +40,8 @@ v1\nPOST\n<exact path>\n<timestamp>\n<nonce>\n<sha256(raw JSON body)>
 ```
 
 The HMAC key is the decoded random bytes in the root-owned base64 secret file.
-Redirects are refused and response size/time are bounded. Preflight errors fail
-open to the historical call flow; code confirmation remains fail closed.
+Redirects are refused and response size/time are bounded. If preflight is enabled
+in a future IVR, its errors fail open; code confirmation remains fail closed.
 Every dedicated verification prompt uses the established filtered, limited BGM
 mix so retries, success, invalid-code, and failure audio remain stylistically
 consistent without masking the speech.

--- a/ops/pbx/ROLLBACK.md
+++ b/ops/pbx/ROLLBACK.md
@@ -2,12 +2,13 @@
 
 1. Disable inbound call verification and outbound voice in WordPress.
 2. Restore the dated static dialplan backup, or remove only the pending/shortcut
-   steps and helper contexts from both `[from-tci]` paths. Ensure the original
-   prefix → recording → operator priorities are byte-for-byte unchanged.
+   calls from both `[from-tci]` paths. Dormant helper contexts may remain installed.
+   Ensure the original prefix → recording → direct extension-101 priorities are
+   byte-for-byte unchanged.
 3. If overlapping realtime rows were changed, restore their exported snapshot in
    the same transaction. Verify static/realtime parity before reload.
-4. Reload and confirm no public digit-2 menu exists and all callers follow the
-   original operator path.
+4. Reload and confirm no public digit-2 menu or pending preflight exists and all
+   callers ring extension 101 directly.
 5. If only helper or audio is faulty, atomically repoint its `current` symlink to
    the previous immutable release instead of deleting releases.
 6. Revoke/rotate the affected HMAC key if confidentiality is in doubt. Rotate

--- a/ops/pbx/SECURITY.md
+++ b/ops/pbx/SECURITY.md
@@ -1,10 +1,11 @@
 # Security invariants
 
-1. Only authoritative TCI s/_X inbound paths may invoke preflight. Snapshot ANI
-   before `prefix-tci-callerid` mutates it and use trusted literal DID
-   `+982166754123`.
-2. Initialize `PBX_VERIFY_PENDING=0` before AGI. Any lookup/config/network/protocol
-   failure must reach the historical operator flow without verification audio.
+1. Current TCI s/_X inbound paths must not invoke preflight; they route directly
+   to extension 101. A future approved IVR must snapshot ANI before
+   `prefix-tci-callerid` mutates it and use trusted literal DID `+982166754123`.
+2. The dormant helper must remain unreachable from public and internal paths. If
+   enabled in the future, initialize `PBX_VERIFY_PENDING=0` before AGI and make
+   every lookup/config/network/protocol failure reach the operator without audio.
 3. Pending lookup is a separate, path-bound signed POST. Its request has exactly
    `schema`, `site_id`, `event_id`, `call_id`, `called_number`, `caller_number`, and
    `occurred_at`; schema is `phone-verification-pending.v1`. Its successful response
@@ -14,10 +15,9 @@
 5. Shortcut DTMF is collected only through AGI `STREAM FILE`/`WAIT FOR DIGIT`;
    normal private verification uses AGI `GET DATA`. Never place a code in a channel
    variable, wrapper argument, `NoOp`, `Verbose`, `System`, CDR, URL, or log.
-6. Answer only inside the positive-pending shortcut, then run `StopMixMonitor()`
-   before private collection. A no-challenge call must keep the historical
-   unanswered operator path. Keep AGI/DTMF debug off and begin ordinary recording
-   only after shortcut fallback.
+6. No current inbound path answers for verification. If the shortcut is enabled
+   in a future IVR, answer only after a positive pending result, then run
+   `StopMixMonitor()` before private collection. Keep AGI/DTMF debug off.
 7. The helper contexts must not be included from `from-internal` or exposed as a
    SIP feature code. Digitalogic has no approved public IVR digit.
 8. Keep the per-site HMAC key root-owned, non-symlinked, inaccessible to others,

--- a/ops/pbx/asterisk/digitalogic-pending-shortcut.conf
+++ b/ops/pbx/asterisk/digitalogic-pending-shortcut.conf
@@ -1,23 +1,14 @@
 ; Reviewed merge fragment for /etc/asterisk/extensions.conf. Take a dated backup,
 ; verify its checksum, and merge deliberately; never #include this file blindly.
 ;
-; Digitalogic had no main IVR before phone verification was introduced. Do not
-; invent a public menu digit here. In BOTH [from-tci] s and _X paths, replace the
-; former digitalogic-call-verification-menu Gosub with these steps, before
-; prefix-tci-callerid, record-call, and the existing operator Dial:
+; CURRENT PRODUCTION ROUTING: Digitalogic has no public IVR yet. Both [from-tci]
+; s and _X paths must go directly through prefix-tci-callerid, record-call, and
+; Dial(PJSIP/${OPERATOR_EXT},30,Tt), where OPERATOR_EXT=101. Do not invoke either
+; helper context below from the public DID until a separate IVR design is approved.
 ;
-;   same => n,Set(__PBX_VERIFY_PENDING=0)
-;   same => n,Set(__PBX_VERIFY_RESULT=fallback)
-;   same => n,Set(__PBX_VERIFY_ANI=${FILTER(0-9+,${CALLERID(num)})})
-;   same => n,Set(__PBX_VERIFY_DID=+982166754123)
-;   same => n,Gosub(pbx-call-verification-pending-digitalogic,preflight,1)
-;   same => n,GosubIf($["${PBX_VERIFY_PENDING}"="1"]?pbx-call-verification-pending-digitalogic,shortcut,1)
-;   same => n,ExecIf($["${PBX_VERIFY_RESULT}"="verified"]?Hangup())
-;   ; Existing prefix-tci-callerid / record-call / operator flow follows.
-;
-; The signed lookup is fail-open: false, timeout, or any protocol failure leaves
-; PBX_VERIFY_PENDING=0 and reaches the historical operator flow. Only a currently
-; pending challenge for the exact ANI receives the private shortcut prompt.
+; The contexts remain installed as dormant, reviewed building blocks so the next
+; IVR pass can enable verification deliberately without recovering old code. They
+; MUST NOT be merged into the current [from-tci] priorities.
 
 [pbx-call-verification-pending-digitalogic]
 exten => preflight,1,AGI(/usr/local/libexec/pbx-verification-digitalogic,preflight)
@@ -38,7 +29,8 @@ exten => s,1,StopMixMonitor()
  same => n,Return()
 
 ; Privacy invariants:
-; - ANI is snapshotted before prefix-tci-callerid mutates CALLERID(num).
+; - No current public path performs ANI lookup or verification collection.
+; - A future IVR must snapshot ANI before prefix-tci-callerid mutates CALLERID(num).
 ; - STREAM FILE / WAIT FOR DIGIT remain inside AGI; no code enters a channel
 ;   variable, argument, NoOp, Verbose, System, CDR, or recording.
-; - Keep AGI/DTMF debug disabled. Recording starts only after shortcut fallback.
+; - Keep AGI/DTMF debug disabled. Current inbound recording starts before Dial(101).

--- a/ops/pbx/test/pbx-assets.test.js
+++ b/ops/pbx/test/pbx-assets.test.js
@@ -8,18 +8,17 @@ const test = require('node:test');
 const root = path.resolve(__dirname, '..');
 const read = (name) => fs.readFileSync(path.join(root, name), 'utf8');
 
-test('Digitalogic uses an ANI-gated shortcut without inventing a public IVR digit', () => {
+test('Digitalogic keeps verification dormant while the public DID routes directly', () => {
 	const dialplan = read('asterisk/digitalogic-pending-shortcut.conf');
 	assert.equal(fs.existsSync(path.join(root, 'asterisk/digitalogic-digit-2.conf')), false);
 	assert.doesNotMatch(dialplan, /^exten\s*=>\s*2,/m);
 	assert.doesNotMatch(dialplan, /menu-option-2/);
-	assert.match(dialplan, /Set\(__PBX_VERIFY_PENDING=0\)/);
-	assert.match(dialplan, /,preflight,1\)/);
-	assert.match(dialplan, /,shortcut,1\)/);
-	assert.match(dialplan, /PBX_VERIFY_RESULT.*verified.*Hangup/);
-	assert.match(dialplan, /prefix-tci-callerid \/ record-call \/ operator flow follows/);
 	const mergeInstructions = dialplan.split('[pbx-call-verification-pending-digitalogic]')[0];
 	assert.doesNotMatch(mergeInstructions, /Answer\(\)/);
+	assert.doesNotMatch(mergeInstructions, /Gosub\([^\n]*(preflight|shortcut)/);
+	assert.match(mergeInstructions, /Dial\(PJSIP\/\$\{OPERATOR_EXT\},30,Tt\)/);
+	assert.match(mergeInstructions, /OPERATOR_EXT=101/);
+	assert.match(dialplan, /^exten => preflight,1,AGI\([^\n]+,preflight\)$/m);
 	assert.match(dialplan, /^exten => shortcut,1,Answer\(\)\s*\n same => n,StopMixMonitor\(\)/m);
 	assert.doesNotMatch(dialplan, /^\s*same => n\([^)]+\)/m);
 });


### PR DESCRIPTION
## What changed

- Documents the temporary direct-to-extension-101 inbound mode.
- Prevents the dormant pending-verification preflight from being merged into either public `[from-tci]` path.
- Keeps the verification contexts installed but unreachable until the future Digitalogic IVR pass.
- Updates PBX security, deployment, rollback, and asset tests accordingly.

## Root cause

The public TCI routes invoked the website-verification AGI before dialing the operator. This extra preflight prevented the current no-IVR service from reliably reaching registered extension 101.

## Production validation

A real PSTN call placed with the official MicroSIP command-line interface reached Digitalogic and created the paired `PJSIP/tci` and `PJSIP/101` channels. The test call was then terminated, and MicroSIP was restored to its original Yekta account.

## Checks

- `npm test` — 24/24 passing
- `npm run check`
- Shell syntax checks for the wrapper and prompt scripts
- `git diff --check`

Closes #134
