### PR TITLE
Normalize incoming TCI mobile caller IDs

### DIFF
--- a/ops/pbx/DEPLOYMENT.md
+++ b/ops/pbx/DEPLOYMENT.md
@@ -77,6 +77,11 @@ Both the `s` and `_X.` routes must contain only their existing inbound `NoOp`, t
 Remove the former `digitalogic-call-verification-menu`, public digit 2, pending
 lookup, and conditional shortcut from those public priorities completely.
 
+Inside the existing `[prefix-tci-callerid]` subroutine, normalize `00989…` first
+and `0989…` second, replacing either prefix with `09`. Only after normalization
+may the existing internal callback access prefix `9` be added. This ordering maps
+both variants to the same callable mobile number without changing any other ANI.
+
 Do not add a public fallback digit. The private `verify` context is intentionally
 unrouted until a separate Digitalogic IVR is designed and approved.
 
@@ -100,6 +105,8 @@ Use real PSTN ANI and redacted evidence:
   the verification HTTP endpoint and AGI and rings extension 101 immediately.
 - Asterisk shows the paired TCI and `PJSIP/101` channels, with no verification
   audio, early `Answer()`, prompt, or DTMF collection.
+- `0989123456789` and `00989123456789` both normalize to `09123456789` before
+  the internal callback access prefix is added; an existing `09…` ANI is unchanged.
 - Both s and _X inbound paths behave identically.
 - The dormant helper contexts remain loaded but unreachable from public and
   internal dialplan paths.

--- a/ops/pbx/README.md
+++ b/ops/pbx/README.md
@@ -5,6 +5,8 @@ phone verification at `+982166754123`. Digitalogic has no public inbound IVR, so
 the current production DID bypasses every verification helper and rings extension
 101 directly. The helper and its BGM-mixed prompts remain installed but dormant
 for the next, separately approved IVR pass. No public verification digit exists.
+Before the existing internal callback prefix is added, inbound caller IDs beginning
+with `0989` or `00989` are canonicalized to the Iranian local `09` form.
 
 The dormant wrapper forwards one reviewed mode to the helper:
 

--- a/ops/pbx/asterisk/digitalogic-pending-shortcut.conf
+++ b/ops/pbx/asterisk/digitalogic-pending-shortcut.conf
@@ -9,6 +9,17 @@
 ; The contexts remain installed as dormant, reviewed building blocks so the next
 ; IVR pass can enable verification deliberately without recovering old code. They
 ; MUST NOT be merged into the current [from-tci] priorities.
+;
+; In the existing [prefix-tci-callerid] context, normalize the two TCI variants
+; immediately before adding the internal callback access prefix:
+;
+;   same => n,ExecIf($["${CALLERID(num):0:5}"="00989"]?Set(CALLERID(num)=09${CALLERID(num):5}))
+;   same => n,ExecIf($["${CALLERID(num):0:4}"="0989"]?Set(CALLERID(num)=09${CALLERID(num):4}))
+;   same => n,ExecIf($["${CALLERID(num)}"!=""]?Set(CALLERID(num)=9${CALLERID(num)}))
+;
+; This maps 0989XXXXXXXXX and 00989XXXXXXXXX to the same canonical
+; 09XXXXXXXXX number. All other caller IDs pass through unchanged before the
+; existing callback access prefix is added.
 
 [pbx-call-verification-pending-digitalogic]
 exten => preflight,1,AGI(/usr/local/libexec/pbx-verification-digitalogic,preflight)

--- a/ops/pbx/test/pbx-assets.test.js
+++ b/ops/pbx/test/pbx-assets.test.js
@@ -23,6 +23,34 @@ test('Digitalogic keeps verification dormant while the public DID routes directl
 	assert.doesNotMatch(dialplan, /^\s*same => n\([^)]+\)/m);
 });
 
+test('TCI international-style mobile caller IDs normalize before callback prefixing', () => {
+	const dialplan = read('asterisk/digitalogic-pending-shortcut.conf');
+	const from00989 = '${CALLERID(num):0:5}"="00989';
+	const from0989 = '${CALLERID(num):0:4}"="0989';
+	const callbackPrefix = 'Set(CALLERID(num)=9${CALLERID(num)})';
+	assert.notEqual(dialplan.indexOf(from00989), -1);
+	assert.notEqual(dialplan.indexOf(from0989), -1);
+	assert.notEqual(dialplan.indexOf(callbackPrefix), -1);
+	assert.ok(dialplan.indexOf(from00989) < dialplan.indexOf(from0989));
+	assert.ok(dialplan.indexOf(from0989) < dialplan.indexOf(callbackPrefix));
+	assert.match(dialplan, /00989[^\n]+CALLERID\(num\)=09\$\{CALLERID\(num\):5\}/);
+	assert.match(dialplan, /0989[^\n]+CALLERID\(num\)=09\$\{CALLERID\(num\):4\}/);
+
+	const normalize = (number) => {
+		if (number.startsWith('00989')) {
+			return `09${number.slice(5)}`;
+		}
+		if (number.startsWith('0989')) {
+			return `09${number.slice(4)}`;
+		}
+		return number;
+	};
+	assert.equal(normalize('0989123456789'), '09123456789');
+	assert.equal(normalize('00989123456789'), '09123456789');
+	assert.equal(normalize('09123456789'), '09123456789');
+	assert.equal(normalize('02166754123'), '02166754123');
+});
+
 test('private code collection stays inside AGI and wrapper forwards its mode', () => {
 	const dialplan = read('asterisk/digitalogic-pending-shortcut.conf');
 	const wrapper = read('bin/pbx-verification-digitalogic');


### PR DESCRIPTION
## What changed

- Documents the live Digitalogic TCI caller-ID normalization order.
- Maps inbound `0989…` and `00989…` forms to canonical `09…` before callback prefixing.
- Leaves all other caller-ID formats unchanged.
- Adds regression coverage for rule presence, ordering, examples, and pass-through behavior.

## Why

TCI can present Iranian mobile caller IDs with an extra international-style prefix. Without normalization, the internal callback prefix is added to a malformed number and extension 101 receives an unusable caller ID.

## Production validation

- The Asterisk dialplan reloaded successfully with the longer `00989` rule first.
- `0989123456789` and `00989123456789` both map to `09123456789`.
- Extension 101 remains registered and available.
- Direct TCI routing to extension 101 is unchanged.

## Checks

- `npm test` — 25/25 passing
- `npm run check`
- `git diff --check`

Closes #136
