### PR TITLE
fix(auth): complete secure accessible login experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an idempotent professional Google Sheets control-center builder with live catalog KPIs, charts, a landed-price calculator, bilingual guidance, editable non-secret settings, protected reference tabs, and one-command synchronization and scheduling.
 
 ### Security
+- Native Digits captcha controls now remain required and visible unless the configured reCAPTCHA replacement is successfully prepared; the branding layer no longer disables an unconfigured challenge.
 - Google Sheets writeback uses exact-decimal optimistic revisions, idempotent requests, a shared WooCommerce product lock, and transactional shipping compare-and-set apply/compensation so concurrent changes are preserved.
 
 ### Fixed
+- Consolidated the login identity normalizer, preserved password selections through visibility toggles, localized username-step controls, added keyboard-complete language selection, and removed the duplicate checkbox glyph across RTL/LTR light/dark login states.
 - Styled the reserved `Changes` and `Audit` support rows as professional workflow panels while preserving staged values, append-only audit data, legacy layouts, and frozen table headers.
 - Made the n8n Google Sheets writeback template return the actual Digitalogic JSON envelope on n8n 2.x instead of ending the webhook early with an empty HTTP 200 response.
 - Repaired critical `/panel/` rendering and inline-edit regressions: title direction is always callable, pointer edits place a collapsed caret at the clicked text position, Patris currency uses a canonical clearable selector, and render/bootstrap failures now show a localized recovery screen with structured, deduplicated console diagnostics.

--- a/README.md
+++ b/README.md
@@ -268,6 +268,19 @@ guessing product ownership or creating new variable families. See
 
 ### Authentication
 
+Interactive customers use the canonical same-origin `/login/` flow. Safe GET
+requests to `wp-login.php` retain their supported action and redirect arguments
+while redirecting to that route; login POSTs still terminate in WordPress so
+WordPress and Digits remain the only authentication authorities. The first
+field accepts username, e-mail, or mobile, normalizes Persian/Arabic digits for
+machine values, and keeps registration in the configured Digits OTP flow.
+
+The branding layer never disables a native Digits captcha. When a configured
+Digits reCAPTCHA site key is available it prepares that supported replacement;
+otherwise the native challenge remains visible, required, and submitted by
+Digits. OAuth values, service credentials, and account-linking rules remain
+outside the repository and are not copied into the client configuration.
+
 The plugin uses WooCommerce REST API authentication:
 
 1. Go to WooCommerce → Settings → Advanced → REST API

--- a/assets/css/branding/admin-branding.css
+++ b/assets/css/branding/admin-branding.css
@@ -525,8 +525,27 @@ body.login .dg-digits-login-shell.dg-digits-auto-identity .digits-form_tab_body.
     display: block !important;
 }
 
-body.login :is(.dg-digits-login-shell, .dg-digits-register-shell) :is(.digits_captcha_row, .dg_min_capt, .digits_reg_logincaptcha, .dig_captcha) {
+body.login :is(.dg-digits-login-shell, .dg-digits-register-shell) .digits_captcha_row[hidden] {
     display: none !important;
+}
+
+body.login :is(.dg-digits-login-shell, .dg-digits-register-shell) .digits_captcha_row:not([hidden]) {
+    display: grid !important;
+    gap: 10px;
+    margin-block: 12px !important;
+    padding: 12px !important;
+    border: 1px solid var(--dg-border) !important;
+    border-radius: 14px !important;
+    background: var(--dg-panel-soft) !important;
+    color: var(--dg-text) !important;
+}
+
+body.login :is(.dg-digits-login-shell, .dg-digits-register-shell) .digits_captcha_row:not([hidden]) input {
+    min-height: 44px;
+    border-color: var(--dg-border) !important;
+    border-radius: 12px !important;
+    background: var(--dg-input-bg) !important;
+    color: var(--dg-text) !important;
 }
 
 body.login :is(.dg-digits-login-shell, .dg-digits-register-shell) .digits-form_heading {
@@ -2096,12 +2115,10 @@ body.login .dg-digits-login-shell .digits-form_rememberme .digits_login_remember
 body.login #rememberme:checked {
     border-color: transparent !important;
     background-color: var(--dg-accent);
-    background-image:
-        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath fill='none' stroke='%23fff' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round' d='M5 10.4l3.2 3.2L15.4 6.5'/%3E%3C/svg%3E"),
-        linear-gradient(135deg, var(--dg-accent), var(--dg-accent-strong)) !important;
-    background-position: center, center !important;
-    background-repeat: no-repeat, no-repeat !important;
-    background-size: 15px 15px, 100% 100% !important;
+    background-image: linear-gradient(135deg, var(--dg-accent), var(--dg-accent-strong)) !important;
+    background-position: center !important;
+    background-repeat: no-repeat !important;
+    background-size: 100% 100% !important;
     box-shadow: 0 10px 24px color-mix(in srgb, var(--dg-accent-strong) 28%, transparent);
     transform: scale(1.06);
 }

--- a/assets/js/branding/admin-branding.js
+++ b/assets/js/branding/admin-branding.js
@@ -316,6 +316,7 @@
         trigger.setAttribute('aria-haspopup', 'listbox');
         trigger.setAttribute('aria-expanded', 'false');
         trigger.setAttribute('aria-controls', 'dg-language-menu');
+        trigger.setAttribute('aria-label', getLabel('language', 'Language'));
 
         var menu = document.createElement('div');
         menu.id = 'dg-language-menu';
@@ -323,16 +324,48 @@
         menu.setAttribute('role', 'listbox');
         menu.setAttribute('aria-hidden', 'true');
 
-        function closeMenu() {
+        function syncChevron(open) {
+            var chevron = trigger.querySelector('.dg-language-chevron');
+            if (!chevron) {
+                return;
+            }
+
+            chevron.classList.toggle('dashicons-arrow-up-alt2', open);
+            chevron.classList.toggle('dashicons-arrow-down-alt2', !open);
+        }
+
+        function closeMenu(restoreFocus) {
             picker.classList.remove('is-open');
             menu.setAttribute('aria-hidden', 'true');
             trigger.setAttribute('aria-expanded', 'false');
+            syncChevron(false);
+            if (restoreFocus) {
+                trigger.focus({ preventScroll: true });
+            }
         }
 
-        function openMenu() {
+        function optionButtons() {
+            return Array.prototype.slice.call(menu.querySelectorAll('.dg-language-option'));
+        }
+
+        function focusOption(index) {
+            var options = optionButtons();
+            if (!options.length) {
+                return;
+            }
+
+            var normalized = (index + options.length) % options.length;
+            options[normalized].focus({ preventScroll: true });
+        }
+
+        function openMenu(focusIndex) {
             picker.classList.add('is-open');
             menu.setAttribute('aria-hidden', 'false');
             trigger.setAttribute('aria-expanded', 'true');
+            syncChevron(true);
+            if (typeof focusIndex === 'number') {
+                focusOption(focusIndex);
+            }
         }
 
         function syncSelection() {
@@ -340,38 +373,82 @@
             var text = selected ? selected.text : 'فارسی';
             trigger.innerHTML = '<span class="dashicons dashicons-translation" aria-hidden="true"></span>' +
                 '<span class="dg-select-text">' + escapeHtml(text) + '</span>' +
-                '<span class="dashicons dashicons-arrow-up-alt2" aria-hidden="true"></span>';
+                '<span class="dashicons dg-language-chevron dashicons-arrow-down-alt2" aria-hidden="true"></span>';
 
             menu.querySelectorAll('.dg-language-option').forEach(function (option) {
                 var active = option.getAttribute('data-value') === select.value;
                 option.classList.toggle('is-active', active);
                 option.setAttribute('aria-selected', active ? 'true' : 'false');
+                option.setAttribute('tabindex', active ? '0' : '-1');
             });
+            syncChevron(picker.classList.contains('is-open'));
         }
 
         trigger.addEventListener('click', function () {
             if (!picker.classList.contains('is-open')) {
-                openMenu();
+                var selectedIndex = Math.max(0, select.selectedIndex);
+                openMenu(selectedIndex);
             } else {
-                closeMenu();
+                closeMenu(false);
             }
         });
 
-        Array.prototype.slice.call(select.options).forEach(function (option) {
+        trigger.addEventListener('keydown', function (event) {
+            if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+                event.preventDefault();
+                openMenu(event.key === 'ArrowUp' ? optionButtons().length - 1 : Math.max(0, select.selectedIndex));
+            } else if (event.key === 'Escape') {
+                event.preventDefault();
+                closeMenu(true);
+            }
+        });
+
+        Array.prototype.slice.call(select.options).forEach(function (option, index) {
             var item = document.createElement('button');
             item.type = 'button';
+            item.id = 'dg-language-option-' + index;
             item.className = 'dg-language-option';
             item.setAttribute('role', 'option');
             item.setAttribute('data-value', option.value);
+            item.setAttribute('tabindex', '-1');
             item.innerHTML = '<span class="dashicons dashicons-translation" aria-hidden="true"></span>' +
                 '<span>' + escapeHtml(option.text) + '</span>';
             item.addEventListener('click', function () {
                 select.value = option.value;
                 syncSelection();
-                closeMenu();
+                closeMenu(false);
                 submitLanguageForm();
             });
             menu.appendChild(item);
+        });
+
+        menu.addEventListener('keydown', function (event) {
+            var options = optionButtons();
+            var current = options.indexOf(document.activeElement);
+            var target = current;
+
+            if (event.key === 'ArrowDown') {
+                target = current + 1;
+            } else if (event.key === 'ArrowUp') {
+                target = current - 1;
+            } else if (event.key === 'Home') {
+                target = 0;
+            } else if (event.key === 'End') {
+                target = options.length - 1;
+            } else if (event.key === 'Escape') {
+                event.preventDefault();
+                closeMenu(true);
+                return;
+            } else if ((event.key === 'Enter' || event.key === ' ') && current >= 0) {
+                event.preventDefault();
+                options[current].click();
+                return;
+            } else {
+                return;
+            }
+
+            event.preventDefault();
+            focusOption(target);
         });
 
         select.addEventListener('change', submitLanguageForm);
@@ -389,7 +466,7 @@
 
         document.addEventListener('click', function (event) {
             if (!picker.contains(event.target)) {
-                closeMenu();
+                closeMenu(false);
             }
         });
 
@@ -406,7 +483,7 @@
         style.textContent = [
             'body.login .dg-digits-login-shell :is(form, .digits_form_index_section, .digits_secure_modal_box, .digits_ui, .digits-form_container, .digits-form_page, .digits-form_wrapper, .digits_modal_box, .digits2_box, .digits-form_login, .digits-form_body, .digits-form_body_wrapper, .digits-form_tab_wrapper, .digits-form_tab_container, .digits-form_tab_body, .digits_signup_form_step, .digits-form_footer){background:transparent!important;border:0!important;box-shadow:none!important;backdrop-filter:none!important;overflow:visible!important;}',
             'body.login .dg-digits-login-shell :is(form, .digits_form_index_section, .digits-form_wrapper, .digits_modal_box, .digits2_box){margin:0!important;padding:0!important;overflow:visible!important;}',
-            'body.login .dg-digits-login-shell :is(.digits-form_tabs, .digits-form_tab-bar, .digits_captcha_row, .dg_min_capt, .digits_reg_logincaptcha, .dig_captcha){display:none!important;}',
+            'body.login .dg-digits-login-shell :is(.digits-form_tabs, .digits-form_tab-bar),body.login :is(.dg-digits-login-shell,.dg-digits-register-shell) .digits_captcha_row[hidden]{display:none!important;}',
             'body.login .dg-digits-login-shell.dg-digits-auto-identity .digits-form_tab_body:not(.digits-tab_active),body.login .dg-digits-login-shell.dg-digits-auto-identity .digits-form_tab_body[hidden]{display:none!important;}',
             'body.login .dg-digits-login-shell.dg-digits-auto-identity .digits-form_tab_body.digits-tab_active{display:block!important;}',
             'body.login .dg-digits-login-shell.dg-digits-auto-identity:not([data-dg-identity="phone"]) .digits-form_countrycode{display:none!important;}',
@@ -421,7 +498,7 @@
             'body.login .dg-digits-login-shell .digits-form_rememberme .digits_login_remember_me{appearance:none!important;-webkit-appearance:none!important;display:inline-grid!important;place-items:center!important;visibility:visible!important;opacity:1!important;inline-size:22px!important;block-size:22px!important;width:22px!important;height:22px!important;min-width:22px!important;min-height:22px!important;max-width:22px!important;max-height:22px!important;flex:0 0 22px!important;margin:0!important;padding:0!important;line-height:1!important;border:1px solid var(--dg-border)!important;border-radius:8px!important;background:color-mix(in srgb,var(--dg-panel-soft) 72%,transparent)!important;box-shadow:inset 0 1px 0 color-mix(in srgb,#ffffff 10%,transparent),var(--dg-shadow-soft)!important;transform:scale(1)!important;transition:background-color .18s ease,background-image .18s ease,border-color .18s ease,box-shadow .18s ease,transform .18s cubic-bezier(.2,.8,.2,1)!important;}',
             'body.login .dg-digits-login-shell .digits-form_rememberme .digits_login_remember_me::before{content:""!important;display:block!important;visibility:visible!important;width:6px!important;height:11px!important;margin:-1px 0 0!important;border:solid #fff!important;border-width:0 2px 2px 0!important;opacity:0;transform:rotate(45deg) scale(.62);transform-origin:center;transition:opacity .16s ease,transform .18s cubic-bezier(.2,.8,.2,1);}',
             'body.login .dg-digits-login-shell .digits-form_rememberme .digits_login_remember_me:active,body.login #rememberme:active{transform:scale(.92)!important;}',
-            'body.login .dg-digits-login-shell .digits-form_rememberme .digits_login_remember_me:checked,body.login #rememberme:checked{border-color:transparent!important;background-color:var(--dg-accent)!important;background-image:url("data:image/svg+xml,%3Csvg xmlns=\\\'http://www.w3.org/2000/svg\\\' viewBox=\\\'0 0 20 20\\\'%3E%3Cpath fill=\\\'none\\\' stroke=\\\'%23fff\\\' stroke-width=\\\'2.4\\\' stroke-linecap=\\\'round\\\' stroke-linejoin=\\\'round\\\' d=\\\'M5 10.4l3.2 3.2L15.4 6.5\\\'/%3E%3C/svg%3E"),linear-gradient(135deg,var(--dg-accent),var(--dg-accent-strong))!important;background-position:center,center!important;background-repeat:no-repeat,no-repeat!important;background-size:15px 15px,100% 100%!important;box-shadow:0 10px 24px color-mix(in srgb,var(--dg-accent-strong) 28%,transparent)!important;transform:scale(1.06)!important;}',
+            'body.login .dg-digits-login-shell .digits-form_rememberme .digits_login_remember_me:checked,body.login #rememberme:checked{border-color:transparent!important;background-color:var(--dg-accent)!important;background-image:linear-gradient(135deg,var(--dg-accent),var(--dg-accent-strong))!important;background-position:center!important;background-repeat:no-repeat!important;background-size:100% 100%!important;box-shadow:0 10px 24px color-mix(in srgb,var(--dg-accent-strong) 28%,transparent)!important;transform:scale(1.06)!important;}',
             'body.login .dg-digits-login-shell .digits-form_rememberme .digits_login_remember_me:checked::before{opacity:1;transform:rotate(45deg) scale(1);}',
             'body.login .dg-digits-login-shell .digits-form_rememberme .digits_login_remember_me::after{content:none!important;display:none!important;}',
             'body.login .dg-digits-login-shell.dg-digits-auto-identity .digits-mobile_wrapper{direction:ltr!important;}',
@@ -441,35 +518,6 @@
             'body.login .dg-digits-login-shell .digits-social-btn:hover{transform:translateY(-1px)!important;border-color:var(--dg-border-strong)!important;background:var(--dg-panel-strong)!important;}'
         ].join('\n');
         document.head.appendChild(style);
-    }
-
-    function normalizeDigits(value) {
-        var source = '۰۱۲۳۴۵۶۷۸۹٠١٢٣٤٥٦٧٨٩';
-        var target = '01234567890123456789';
-
-        return String(value || '').replace(/[۰-۹٠-٩]/g, function (digit) {
-            return target.charAt(source.indexOf(digit));
-        });
-    }
-
-    function classifyIdentity(value) {
-        var normalized = normalizeDigits(value).trim();
-        var numeric = normalized.replace(/[^\d+]/g, '');
-        var digits = numeric.replace(/\D/g, '');
-
-        if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) {
-            return 'email';
-        }
-
-        if (/^(?:\+?98|0098|0)?9\d{9}$/.test(digits.length > 0 && numeric.indexOf('+') !== -1 ? numeric : digits)) {
-            return 'phone';
-        }
-
-        if (/^(?:98|0098|0)?9\d{9}$/.test(digits)) {
-            return 'phone';
-        }
-
-        return 'username';
     }
 
     function normalizeDigits(value) {
@@ -648,7 +696,7 @@
                     text: 'IR +98',
                     label: getLabel('phoneIdentity', 'موبایل ایران'),
                     inputMode: 'tel',
-                    autocomplete: 'tel'
+                    autocomplete: 'tel-national'
                 },
                 email: {
                     icon: 'dashicons-email-alt2',
@@ -777,7 +825,9 @@
         }
 
         var isVisible = input.type === 'text';
-        var label = isVisible ? 'پنهان کردن رمز عبور' : 'نمایش رمز عبور';
+        var label = isVisible
+            ? getLabel('hidePassword', 'Hide password')
+            : getLabel('showPassword', 'Show password');
         var icon = isVisible ? 'dashicons-hidden' : 'dashicons-visibility';
 
         button.classList.toggle('is-visible', isVisible);
@@ -1057,6 +1107,9 @@
         form.classList.add('dg-username-step-active');
 
         if (!step) {
+            var backIcon = isPersianLocale() ? 'dashicons-arrow-right-alt' : 'dashicons-arrow-left-alt';
+            var backLabel = getLabel('back', 'Back');
+            var loginLabel = getLabel('login', 'Log in');
             step = document.createElement('div');
             step.className = 'digits-form_tab_container dg-username-password-step';
             step.innerHTML = [
@@ -1072,8 +1125,8 @@
                 '<input class="dg-username-password-input" type="password" autocomplete="current-password" required placeholder="رمز عبور">',
                 '</div>',
                 '<div class="dg-username-login-actions">',
-                '<button type="button" class="button dg-username-login-back"><span class="dashicons dashicons-arrow-right-alt" aria-hidden="true"></span><span>بازگشت</span></button>',
-                '<button type="submit" class="digits-form_button digits-form_submit digits-form_submit-btn dg-username-login-submit"><span>ورود</span></button>',
+                '<button type="button" class="button dg-username-login-back"><span class="dashicons ' + backIcon + '" aria-hidden="true"></span><span>' + escapeHtml(backLabel) + '</span></button>',
+                '<button type="submit" class="digits-form_button digits-form_submit digits-form_submit-btn dg-username-login-submit"><span>' + escapeHtml(loginLabel) + '</span></button>',
                 '</div>',
                 '</div>',
                 '</div>'
@@ -1506,7 +1559,7 @@
     function submitDigitsSecureForm(form) {
         var button = digitsSubmitButton(form);
 
-        disableVisibleDigitsCaptcha();
+        prepareDigitsCaptchaProtection();
 
         if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
             clearLoading();
@@ -1859,40 +1912,14 @@
         syncFlag();
     }
 
-    function disableVisibleDigitsCaptcha() {
+    function prepareDigitsCaptchaProtection() {
         document.querySelectorAll(':is(.dg-digits-login-shell, .dg-digits-register-shell) .digits_captcha_row').forEach(function (row) {
-            if (prepareDigitsRecaptcha(row)) {
-                return;
-            }
-
-            row.hidden = true;
-            row.setAttribute('aria-hidden', 'true');
-
-            row.querySelectorAll('input').forEach(function (input) {
-                input.required = false;
-                input.removeAttribute('required');
-                input.disabled = true;
-            });
-        });
-
-        document.querySelectorAll(':is(.dg-digits-login-shell, .dg-digits-register-shell) :is(.dg_min_capt, .digits_reg_logincaptcha, .dig_captcha)').forEach(function (row) {
-            if (row.closest('.digits_captcha_row') && row.closest('.digits_captcha_row').querySelector('.invi-recaptcha')) {
-                return;
-            }
-
-            row.hidden = true;
-            row.setAttribute('aria-hidden', 'true');
-
-            row.querySelectorAll('input').forEach(function (input) {
-                input.required = false;
-                input.removeAttribute('required');
-                input.disabled = true;
-            });
+            prepareDigitsRecaptcha(row);
         });
     }
 
     function bindDigitsAutoIdentity() {
-        disableVisibleDigitsCaptcha();
+        prepareDigitsCaptchaProtection();
 
         var shell = document.querySelector('.dg-digits-login-shell');
         if (!shell || shell.dataset.dgAutoIdentityReady === 'true') {
@@ -1904,7 +1931,7 @@
         var countryCode = shell.querySelector('input[name="login_digt_countrycode"]');
 
         if (!phoneInput || !emailInput) {
-            disableVisibleDigitsCaptcha();
+            prepareDigitsCaptchaProtection();
             return;
         }
 
@@ -1913,7 +1940,7 @@
 
         if (shell.dataset.dgCaptchaObserverReady !== 'true') {
             shell.dataset.dgCaptchaObserverReady = 'true';
-            new MutationObserver(disableVisibleDigitsCaptcha).observe(shell, { childList: true, subtree: true });
+            new MutationObserver(prepareDigitsCaptchaProtection).observe(shell, { childList: true, subtree: true });
         }
 
         if (countryCode && !countryCode.value) {
@@ -1922,10 +1949,6 @@
 
         bindCountryCodePicker(shell);
 
-        phoneInput.placeholder = 'شماره موبایل یا ایمیل';
-        emailInput.placeholder = 'شماره موبایل یا ایمیل';
-        phoneInput.placeholder = 'نام کاربری، ایمیل یا شماره موبایل';
-        emailInput.placeholder = 'نام کاربری، ایمیل یا شماره موبایل';
         phoneInput.setAttribute('autocomplete', 'username');
         emailInput.setAttribute('autocomplete', 'username');
         phoneInput.setAttribute('dir', 'auto');
@@ -2012,7 +2035,7 @@
         });
 
         selectDigitsMode(classifyIdentity(phoneInput.value || emailInput.value), false);
-        disableVisibleDigitsCaptcha();
+        prepareDigitsCaptchaProtection();
     }
 
     function enforceDigitsRegisterMobile() {
@@ -2656,8 +2679,13 @@
     if (config.testHooks && typeof config.testHooks === 'object') {
         config.testHooks.authLinkAction = authLinkAction;
         config.testHooks.authPageAction = authPageAction;
+        config.testHooks.capturePasswordSelection = capturePasswordSelection;
+        config.testHooks.classifyIdentity = classifyIdentity;
         config.testHooks.enhanceLoginLabels = enhanceLoginLabels;
+        config.testHooks.normalizeDigits = normalizeDigits;
         config.testHooks.normalizeAuthChrome = normalizeAuthChrome;
+        config.testHooks.phonePartsFromValue = phonePartsFromValue;
+        config.testHooks.sanitizeIdentityValue = sanitizeIdentityValue;
     }
 
     function enableRipples() {

--- a/includes/integrations/class-admin-branding.php
+++ b/includes/integrations/class-admin-branding.php
@@ -488,6 +488,7 @@ JS;
                 'register' => 'Register',
                 'lostPassword' => 'Reset password',
                 'login' => 'Log in',
+                'back'                 => 'Back', // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed -- Preserve the legacy array indentation.
                 'recoveryIdentity' => 'Username or email address', // phpcs:ignore
             ];
         }
@@ -516,6 +517,7 @@ JS;
             'register' => 'ثبت نام',
             'lostPassword' => 'بازیابی رمز عبور',
             'login' => 'ورود',
+            'back'                 => 'بازگشت', // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed -- Preserve the legacy array indentation.
             'recoveryIdentity' => 'نام کاربری یا نشانی ایمیل', // phpcs:ignore
         ];
     }

--- a/tests/AdminBrandingAuthTest.php
+++ b/tests/AdminBrandingAuthTest.php
@@ -97,8 +97,10 @@ final class AdminBrandingAuthTest extends TestCase {
         $persian = $method->invoke(null);
 
         $this->assertSame('Username or email address', $english['recoveryIdentity']);
+        $this->assertSame('Back', $english['back']);
         $this->assertStringNotContainsString('mobile', strtolower($english['recoveryIdentity']));
         $this->assertSame('نام کاربری یا نشانی ایمیل', $persian['recoveryIdentity']);
+        $this->assertSame('بازگشت', $persian['back']);
         $this->assertStringNotContainsString('موبایل', $persian['recoveryIdentity']);
     }
 

--- a/tests/admin-branding-auth-nav.test.js
+++ b/tests/admin-branding-auth-nav.test.js
@@ -10,6 +10,10 @@ const brandingSource = fs.readFileSync(
     path.join(__dirname, '..', 'assets', 'js', 'branding', 'admin-branding.js'),
     'utf8'
 );
+const brandingCss = fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'css', 'branding', 'admin-branding.css'),
+    'utf8'
+);
 
 function fakeClassList(values) {
     const classes = new Set(values || []);
@@ -58,6 +62,7 @@ function createHarness(options) {
         }
     };
     const document = {
+        activeElement: null,
         body: {
             classList: fakeClassList(['login'].concat(options.bodyClasses || [])),
             dataset: {}
@@ -120,6 +125,7 @@ function createHarness(options) {
     vm.runInNewContext(brandingSource, context, { filename: 'admin-branding.js' });
 
     return {
+        document,
         hooks: config.testHooks,
         recoveryField,
         recoveryLabel
@@ -233,4 +239,70 @@ test('real startup order cannot restore mobile wording on WordPress recovery', (
 
     assert.match(harness.recoveryLabel.innerHTML, /نام کاربری یا نشانی ایمیل/);
     assert.doesNotMatch(harness.recoveryLabel.innerHTML, /موبایل/);
+});
+
+test('one canonical identity normalizer handles Persian and Arabic digits without spaces', () => {
+    const harness = createHarness({});
+
+    assert.equal((brandingSource.match(/function normalizeDigits\(/g) || []).length, 1);
+    assert.equal(harness.hooks.normalizeDigits('۰۹۱۲٣٤٥٦٧٨٩'), '09123456789');
+    assert.equal(harness.hooks.sanitizeIdentityValue('۰۹۱۲ ۳۴۵ ۶۷۸۹'), '09123456789');
+    assert.equal(harness.hooks.sanitizeIdentityValue(' mahdi+tag @ example.com '), 'mahdi+tag@example.com');
+    assert.equal(harness.hooks.classifyIdentity('mahdi@example.com'), 'email');
+    assert.equal(harness.hooks.classifyIdentity('09123456789'), 'phone');
+    assert.equal(harness.hooks.classifyIdentity('mahdi_user'), 'username');
+
+    const phone = harness.hooks.phonePartsFromValue('+989123456789');
+    assert.equal(phone.type, 'phone');
+    assert.equal(phone.national, '9123456789');
+    assert.equal(phone.countryCode, '+98');
+    assert.equal(phone.valid, true);
+});
+
+test('password visibility restoration preserves the user-selected range and direction', () => {
+    const harness = createHarness({});
+    const restored = [];
+    const input = {
+        selectionStart: 2,
+        selectionEnd: 7,
+        selectionDirection: 'backward',
+        focus() {},
+        setSelectionRange(start, end, direction) {
+            restored.push({ start, end, direction });
+        }
+    };
+    harness.document.activeElement = input;
+
+    const restore = harness.hooks.capturePasswordSelection(input);
+    input.selectionStart = 0;
+    input.selectionEnd = 0;
+    restore();
+
+    assert.deepEqual(restored, [{ start: 2, end: 7, direction: 'backward' }]);
+});
+
+test('native Digits captcha remains active unless a configured replacement is prepared', () => {
+    const start = brandingSource.indexOf('function prepareDigitsCaptchaProtection');
+    const end = brandingSource.indexOf('function bindDigitsAutoIdentity', start);
+    const protection = brandingSource.slice(start, end);
+
+    assert.ok(start > 0 && end > start);
+    assert.match(protection, /prepareDigitsRecaptcha\(row\)/);
+    assert.doesNotMatch(protection, /input\.disabled\s*=\s*true/);
+    assert.doesNotMatch(protection, /removeAttribute\('required'\)/);
+    assert.match(brandingCss, /\.digits_captcha_row\[hidden\]\s*\{\s*display:\s*none\s*!important;/s);
+    assert.doesNotMatch(brandingCss, /:is\(\.digits_captcha_row,\s*\.dg_min_capt,[^}]+display:\s*none/s);
+});
+
+test('checkbox, localized step controls, and language picker use one accessible implementation', () => {
+    assert.doesNotMatch(brandingSource + brandingCss, /M5 10\.4l3\.2 3\.2L15\.4 6\.5/);
+    assert.match(brandingCss, /digits_login_remember_me:checked::before/);
+    assert.match(brandingSource, /getLabel\('back', 'Back'\)/);
+    assert.match(brandingSource, /getLabel\('login', 'Log in'\)/);
+    assert.match(brandingSource, /trigger\.addEventListener\('keydown'/);
+    assert.match(brandingSource, /menu\.addEventListener\('keydown'/);
+    assert.match(brandingSource, /event\.key === 'ArrowDown'/);
+    assert.match(brandingSource, /event\.key === 'Escape'/);
+    assert.match(brandingSource, /dashicons-arrow-down-alt2/);
+    assert.match(brandingSource, /dashicons-arrow-up-alt2/);
 });


### PR DESCRIPTION
## Outcome

Completes the remaining secure, accessible /login/ UX work tracked in #54 without changing WordPress/Digits authentication authority.

- preserves native Digits captcha requirements unless a configured reCAPTCHA replacement is successfully prepared
- consolidates username/email/mobile normalization, including Persian and Arabic digits
- preserves password selection and cursor direction across visibility toggles
- localizes username-step navigation and makes language selection keyboard-complete
- removes the duplicate remember-me glyph and keeps RTL/LTR theme states consistent
- documents the canonical same-origin login and credential boundaries

## Validation

- PHPUnit: 318 tests, 1,985 assertions (5 expected skips, 1 existing warning)
- Node: 70 tests passed
- PHP syntax: passed
- diff whitespace check: passed
- PHPCS debt gate: 39,828 errors / 3,008 warnings, exactly matching current main

Relates to #54. The issue remains pending owner approval after merge.