### PR TITLE
Guard office notification routing and slowlog alerts

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -93,6 +93,10 @@ jobs:
         bash -n ops/pbx/bin/pbx-verification-digitalogic
         bash -n ops/pbx/scripts/generate-prompts.sh
         bash -n ops/pbx/scripts/install-prompts.sh
+        npm --prefix ops/office-automation run check
+        npm --prefix ops/office-automation test
+        bash -n ops/office-automation/scripts/deploy.sh
+        bash -n ops/office-automation/scripts/rollback.sh
 
     - name: Reject non-synthetic mobile fixtures
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added an explicit Patris storefront pricing policy and non-mutating `wp digitalogic pricing audit` command that report canonical Patris, WooCommerce regular, promotion, and effective prices separately.
+- Added version-controlled, secret-free production sources and tests for the Apache/PHP-FPM watchdog, SIP notifier, gated n8n event workflow, and plan-first deploy/rollback procedures.
 - Added a persisted, optional sticky first product column that follows the first visible/reordered column in RTL and LTR while keeping the selection control frozen beside it.
 - Added reusable Digitalogic browser error pages with responsive light/dark styling, English and Persian copy, RTL/LTR layout, safe recovery actions, and stable support references.
 - Added an opt-in Google Sheets product/pricing control workspace with bounded preview/apply writeback, exact Patris identity and revisions, append-only audit rows, guarded WooCommerce product writes, and an inactive credential-placeholder n8n proxy template.
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Consolidated the login identity normalizer, preserved password selections through visibility toggles, localized username-step controls, added keyboard-complete language selection, and removed the duplicate checkbox glyph across RTL/LTR light/dark login states.
+- Enforced explicit notification channel allow-lists in both n8n routing and the notifier, kept endpoint/category preferences after the channel gate, and counted PHP-FPM slow requests by canonical request headers instead of stack lines.
 - Styled the reserved `Changes` and `Audit` support rows as professional workflow panels while preserving staged values, append-only audit data, legacy layouts, and frozen table headers.
 - Made the n8n Google Sheets writeback template return the actual Digitalogic JSON envelope on n8n 2.x instead of ending the webhook early with an empty HTTP 200 response.
 - Repaired critical `/panel/` rendering and inline-edit regressions: title direction is always callable, pointer edits place a collapsed caret at the clicked text position, Patris currency uses a canonical clearable selector, and render/bootstrap failures now show a localized recovery screen with structured, deduplicated console diagnostics.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - Currency rate change notifications
 - HMAC signature verification
 - Non-blocking async delivery
+- Secret-free production watchdog, notification routing, n8n workflow, and rollback assets: [`ops/office-automation/README.md`](ops/office-automation/README.md)
 
 ### ☎️ Phone verification and PBX notifications
 - From the Digits OTP sidebar, choose **Verify by calling**, or add an Iranian mobile/landline contact from My Account, then call `021-66754123` from the same number. A live caller-ID challenge collects the 120-second code immediately after «دوست عزیزم»; calls without one continue to the operator.

--- a/ops/office-automation/DEPLOYMENT.md
+++ b/ops/office-automation/DEPLOYMENT.md
@@ -1,0 +1,56 @@
+# Deployment runbook
+
+Deployment is intentionally split into two independently reversible changes: the notifier/watchdog scripts and the n8n workflow. The repository scripts never import, publish, or activate n8n and never change notification destinations.
+
+## 1. Prepare and verify
+
+1. Use an exact reviewed commit SHA as the release identifier.
+2. Run the checks in `README.md` on that checkout.
+3. Export the currently active n8n workflow through the host's supported UI or CLI, store the export outside the repository with owner-only permissions, and record its checksum privately.
+4. Confirm both current script services are active. Back up the root-owned environment files and current subscriber/preference data without printing their contents.
+5. Copy each `.env.example` to its documented root-owned location, mode `0600`, and supply all required values there. The notifier requires `HTTP_PORT`, `API_TOKEN`, `MESSAGE_FROM`, `AMI_PORT`, `AMI_USER`, and `AMI_SECRET`. If inter-office forwarding is configured, `INTEROFFICE_FORWARD_TARGET` is also required. The watchdog requires `WEBHOOK_URL`, `SITE_URLS`, and `NOTIFY_CHANNELS`.
+
+Keep `NOTIFY_CHANNELS=ntfy,telegram` when SIP is not intended. Never put populated configuration in a command line, shell history, issue, PR, workflow export committed to Git, or test fixture.
+
+## 2. Deploy notifier and watchdog sources
+
+Review the plan first:
+
+```sh
+sudo ops/office-automation/scripts/deploy.sh --plan <reviewed-commit-sha>
+```
+
+Then perform the owner-approved switch:
+
+```sh
+sudo ops/office-automation/scripts/deploy.sh --apply <reviewed-commit-sha>
+```
+
+The script validates syntax and configuration, creates an immutable release with a SHA-256 manifest, preserves legacy regular-file entrypoints on the first deployment, atomically switches `current`, restarts both existing services, and verifies both are active. A failed service check restores the prior release or first-deployment files automatically.
+
+This procedure assumes the existing systemd units already invoke the stable paths under `/opt/office-automation`. Override paths and service names only with the documented `OFFICE_AUTOMATION_*` and `APACHE_SITE_WATCHDOG_*` environment variables.
+
+## 3. Render and review n8n
+
+Load all `OFFICE_N8N_*` values from a protected owner-only environment and render to a protected absolute path outside the checkout:
+
+```sh
+node ops/office-automation/scripts/render-n8n-workflow.cjs --check
+node ops/office-automation/scripts/render-n8n-workflow.cjs --output /var/lib/office-automation/private/office-events.review.json
+```
+
+The renderer refuses repository destinations, unresolved placeholders, non-HTTP(S) endpoints, active workflows, a missing SIP gate, or a direct route-to-SIP bypass. It creates output mode `0600` and refuses overwrite unless `--force` is explicitly supplied.
+
+Diff topology and non-secret settings against the private export. Import the rendered file with the host's supported n8n procedure. It remains inactive after import; publish/activate it only after the owner verifies credentials, webhook ownership, and every node connection in the n8n UI. Preserve the old workflow until validation finishes.
+
+## 4. Production validation
+
+Use request bodies from protected files and read the bearer token from protected configuration so neither appears in shell history or logs.
+
+1. `POST /v1/route` with a synthetic `web_health` warning and `notify_channels: ["ntfy", "telegram"]`. Expect `channels.sip` to be `false`.
+2. `POST /v1/notify` with the same payload. Expect HTTP success, `skipped: true`, `reason: sip_channel_not_requested`, empty endpoints/results, and zero AMI send activity.
+3. Run the n8n workflow with the same negative fixture. Its execution view must show the SIP gate emitting zero items and the SIP notification node not executing.
+4. Verify a new slowlog batch reports the number of canonical request headers, not its stack-trace line count.
+5. The automated positive fixture proves explicit SIP reaches only subscribed/default endpoints. Perform any live positive SIP probe only with an owner-approved test destination, and keep its identity out of shared evidence.
+
+Record only timestamps, commit/workflow revision, checksums, boolean route outcomes, skip reasons, counts, and service health in the issue or PR. Do not paste payloads, endpoints, aliases, tokens, credential identifiers, private webhook paths, or notification destinations.

--- a/ops/office-automation/README.md
+++ b/ops/office-automation/README.md
@@ -1,0 +1,38 @@
+# Office automation notifications
+
+This directory is the secret-free source of truth for the production PHP-FPM/Apache watchdog, SIP notifier, and n8n event-routing workflow. Runtime credentials, webhook paths, chat identifiers, PBX destinations, aliases, and endpoint lists belong only in root-owned configuration outside the repository.
+
+## Routing contract
+
+The same channel decision is enforced twice:
+
+1. The watchdog writes its configured allow-list to both `channels` and `notify_channels`.
+2. n8n calls `POST /v1/route` and passes each notification node through its matching route gate. There is no direct edge from the routing-policy node to the SIP notification node.
+3. `POST /v1/notify` independently rejects SIP when an explicit channel list is present and does not contain `sip`. It returns a successful skipped result with `reason: sip_channel_not_requested` and performs zero sends. Successful responses expose counts and coarse route types, never destination identities.
+
+Payloads that omit both channel fields retain the legacy routing behavior. When SIP is explicitly requested, the notifier still applies the channel category policy, endpoint category/mute policy, and configured subscriber/default-endpoint eligibility before sending.
+
+The slowlog reader counts canonical PHP-FPM request headers. Stack frames and diagnostic lines remain available as bounded samples but never inflate the request count. Before the n8n workflow writes its audit, Redis, or Sheets records, it redacts credential-bearing and private phone-routing fields and bearer/query-style secrets.
+
+## Contents
+
+- `lib/apache-site-watchdog-to-n8n.cjs`: watchdog and canonical slowlog request parser.
+- `lib/office-automation-sip-notifier.cjs`: route policy, endpoint policy, HTTP API, and SIP sender.
+- `n8n/office-automation-events.template.json`: inactive workflow template with placeholders.
+- `scripts/render-n8n-workflow.cjs`: renders a populated workflow only to an absolute path outside the repository.
+- `scripts/deploy.sh` and `scripts/rollback.sh`: plan-first immutable script-release switches.
+- `config/*.env.example`: names and safe defaults only; sensitive values are deliberately blank.
+
+## Local verification
+
+```sh
+npm --prefix ops/office-automation run check
+npm --prefix ops/office-automation test
+bash -n ops/office-automation/scripts/deploy.sh
+bash -n ops/office-automation/scripts/rollback.sh
+node ops/office-automation/scripts/render-n8n-workflow.cjs --check
+```
+
+The renderer check requires every `OFFICE_N8N_*` variable listed in the renderer source. Use synthetic values in CI and a protected runtime environment in production. A rendered workflow is always inactive.
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) and [ROLLBACK.md](ROLLBACK.md) for the owner-run procedures.

--- a/ops/office-automation/ROLLBACK.md
+++ b/ops/office-automation/ROLLBACK.md
@@ -1,0 +1,29 @@
+# Rollback runbook
+
+Script and n8n rollback are separate operations. Decide which revision is faulty before changing either one.
+
+## Script release
+
+List the immutable release directories locally on the host, choose the last known-good reviewed release, and inspect the plan:
+
+```sh
+sudo ops/office-automation/scripts/rollback.sh --plan <known-good-release-id>
+```
+
+Apply only after the owner confirms the target:
+
+```sh
+sudo ops/office-automation/scripts/rollback.sh --apply <known-good-release-id>
+```
+
+The rollback verifies the stored SHA-256 manifest and both environment configurations before switching `current`. It restarts and checks both services. If the target fails, it restores the previously active link and restarts the services again.
+
+## n8n workflow
+
+1. Deactivate the faulty workflow with the host's supported n8n UI or CLI.
+2. Import the private pre-deployment export captured by the deployment runbook.
+3. Compare credential bindings and topology without copying their values into shared logs.
+4. Keep the restored import inactive until the owner reviews it, then publish/activate it using the same supported host procedure.
+5. Repeat the negative allow-list probe and confirm the SIP node receives zero items before declaring rollback complete.
+
+Do not delete immutable releases, current exports, subscriber state, preference state, or root-owned configuration during incident response. Evidence should include only revision/checksum, timestamps, boolean routing results, skip reasons, counts, and service status.

--- a/ops/office-automation/config/apache-site-watchdog.env.example
+++ b/ops/office-automation/config/apache-site-watchdog.env.example
@@ -1,0 +1,30 @@
+# Copy to a root-owned file outside the repository and fill values there.
+# Never commit webhook paths, tokens, or private routing values.
+OFFICE_NAME=
+WEBHOOK_URL=
+SITE_URLS=
+NOTIFY_CHANNELS=ntfy,telegram
+
+STATE_FILE=/var/lib/office-automation/apache-site-watchdog-state.json
+EVENT_LOG_FILE=/var/lib/office-automation/apache-site-watchdog-events.jsonl
+APACHE_STATUS_URL=http://127.0.0.1/server-status?auto
+PHP_FPM_STATUS_URL=http://127.0.0.1/fpm-status?json&full
+WP_PATH=/var/www/html
+PHP_FPM_SERVICE=php8.5-fpm.service
+PHP_FPM_LOG=/var/log/php8.5-fpm.log
+PHP_FPM_SLOW_LOG=/var/log/php8.5-fpm-www-slow.log
+QUERY_MONITOR_LOG=/var/log/wordpress/query-monitor-slow.jsonl
+APACHE_ERROR_LOG=/var/log/apache2/error.log
+
+CHECK_INTERVAL_SECONDS=20
+ALERT_REPEAT_SECONDS=900
+HTTP_TIMEOUT_MS=12000
+SITE_METHOD=HEAD
+SITE_FAILURES_BEFORE_DOWN=2
+WEBHOOK_TIMEOUT_MS=60000
+LOG_ALERTS_ENABLED=true
+LOG_ALERT_MAX_LINES=20
+PHP_FPM_SLOWLOG_NOTIFY_COOLDOWN_SECONDS=3600
+PHP_FPM_SLOWLOG_SUMMARY_MAX_LINES=8
+DIAGNOSTICS_ENABLED=true
+AUTO_RESTART_APACHE=false

--- a/ops/office-automation/config/office-automation-sip-notifier.env.example
+++ b/ops/office-automation/config/office-automation-sip-notifier.env.example
@@ -1,0 +1,35 @@
+# Copy to a root-owned file outside the repository and fill values there.
+# Never commit the populated file.
+OFFICE_NAME=
+HTTP_HOST=127.0.0.1
+HTTP_PORT=
+API_TOKEN=
+
+# Destinations and sender identities are intentionally blank.
+DEFAULT_EXTENSIONS=
+MESSAGE_FROM=
+
+SUBSCRIBERS_FILE=/var/lib/office-automation/sip-notifier-subscribers.json
+PREFERENCES_FILE=/var/lib/office-automation/n8n-sip-preferences.json
+COMMAND_LOG_FILE=/var/log/office-automation-sip-commands.log
+
+AMI_HOST=127.0.0.1
+AMI_PORT=
+AMI_USER=
+AMI_SECRET=
+AMI_TIMEOUT_MS=5000
+MAX_BODY_LENGTH=900
+
+# Optional inter-office routing remains disabled until every value is supplied
+# in the root-owned production file.
+INTEROFFICE_MESSAGE_ENDPOINT=
+INTEROFFICE_MESSAGE_FROM=
+INTEROFFICE_FORWARD_TARGET=
+INTEROFFICE_ALIAS_REGEX=
+INTEROFFICE_TARGET_PREFIX=
+INTEROFFICE_SENDER_ALIAS_REGEX=
+INTEROFFICE_SENDER_ALIAS_PREFIX=
+
+DEFAULT_SIP_CATEGORIES=important,error,security,sip_trunk,oauth,wordpress,host,wifi
+DEFAULT_TELEGRAM_CATEGORIES=all
+DEFAULT_NTFY_CATEGORIES=important,error,security,sip_trunk,oauth,wordpress,host,wifi,camera

--- a/ops/office-automation/lib/apache-site-watchdog-to-n8n.cjs
+++ b/ops/office-automation/lib/apache-site-watchdog-to-n8n.cjs
@@ -1,0 +1,701 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const http = require("node:http");
+const https = require("node:https");
+const os = require("node:os");
+const path = require("node:path");
+const { execFile } = require("node:child_process");
+
+function loadEnv(file) {
+  const env = {};
+  try {
+    for (const raw of fs.readFileSync(file, "utf8").split(/\r?\n/)) {
+      const line = raw.trim();
+      if (!line || line.startsWith("#")) continue;
+      const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+      if (!match) continue;
+      let value = match[2].trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) value = value.slice(1, -1);
+      env[match[1]] = value;
+    }
+  } catch {
+    // The service can still run with process environment defaults.
+  }
+  return env;
+}
+
+function csv(value) {
+  return String(value || "").split(",").map(item => item.trim()).filter(Boolean);
+}
+
+function num(env, key, fallback) {
+  const parsed = Number(env[key]);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+const env = { ...process.env, ...loadEnv(process.env.APACHE_SITE_WATCHDOG_ENV || "/etc/apache-site-watchdog.env") };
+const config = {
+  office: env.OFFICE_NAME || "office",
+  webhookUrl: env.WEBHOOK_URL || "",
+  statusUrl: env.APACHE_STATUS_URL || "http://127.0.0.1/server-status?auto",
+  siteUrls: csv(env.SITE_URLS || env.PUBLIC_URL || ""),
+  stateFile: env.STATE_FILE || "/var/lib/office-automation/apache-site-watchdog-state.json",
+  eventLogFile: env.EVENT_LOG_FILE || "/var/lib/office-automation/apache-site-watchdog-events.jsonl",
+  notifyChannels: csv(env.NOTIFY_CHANNELS || "ntfy,telegram"),
+  intervalSeconds: num(env, "CHECK_INTERVAL_SECONDS", 20),
+  repeatSeconds: num(env, "ALERT_REPEAT_SECONDS", 900),
+  httpTimeoutMs: num(env, "HTTP_TIMEOUT_MS", 12000),
+  siteMethod: String(env.SITE_METHOD || "HEAD").toUpperCase(),
+  siteFailuresBeforeDown: num(env, "SITE_FAILURES_BEFORE_DOWN", 2),
+  webhookTimeoutMs: num(env, "WEBHOOK_TIMEOUT_MS", 60000),
+  maxRequestWorkers: num(env, "MAX_REQUEST_WORKERS", 150),
+  idleWorkersCritical: num(env, "IDLE_WORKERS_CRITICAL", 0),
+  idleWorkersWarning: num(env, "IDLE_WORKERS_WARNING", 3),
+  busyWorkersCriticalPercent: num(env, "BUSY_WORKERS_CRITICAL_PERCENT", 90),
+  busyWorkersWarningPercent: num(env, "BUSY_WORKERS_WARNING_PERCENT", 75),
+  closeWaitCritical: num(env, "CLOSE_WAIT_CRITICAL", 250),
+  closeWaitWarning: num(env, "CLOSE_WAIT_WARNING", 100),
+  slowSiteMs: num(env, "SLOW_SITE_MS", 8000),
+  diagnosticsEnabled: String(env.DIAGNOSTICS_ENABLED || "true").toLowerCase() !== "false",
+  diagnosticsTimeoutMs: num(env, "DIAGNOSTICS_TIMEOUT_MS", 8000),
+  diagnosticsMaxLines: num(env, "DIAGNOSTICS_MAX_LINES", 40),
+  wpPath: env.WP_PATH || "/var/www/html",
+  phpFpmService: env.PHP_FPM_SERVICE || "php8.5-fpm.service",
+  phpFpmLog: env.PHP_FPM_LOG || "/var/log/php8.5-fpm.log",
+  phpFpmSlowLog: env.PHP_FPM_SLOW_LOG || "/var/log/php8.5-fpm-www-slow.log",
+  phpFpmStatusUrl: env.PHP_FPM_STATUS_URL || "http://127.0.0.1/fpm-status?json&full",
+  queryMonitorLog: env.QUERY_MONITOR_LOG || "/var/log/wordpress/query-monitor-slow.jsonl",
+  logAlertsEnabled: String(env.LOG_ALERTS_ENABLED || "true").toLowerCase() !== "false",
+  logAlertMaxLines: num(env, "LOG_ALERT_MAX_LINES", 20),
+  phpFpmSlowLogNotifyCooldownSeconds: num(env, "PHP_FPM_SLOWLOG_NOTIFY_COOLDOWN_SECONDS", 3600),
+  phpFpmSlowLogSummaryMaxLines: num(env, "PHP_FPM_SLOWLOG_SUMMARY_MAX_LINES", 8),
+  apacheErrorLog: env.APACHE_ERROR_LOG || "/var/log/apache2/error.log",
+  autoRestartApache: String(env.AUTO_RESTART_APACHE || "false").toLowerCase() === "true",
+  autoRestartCooldownSeconds: num(env, "AUTO_RESTART_COOLDOWN_SECONDS", 900),
+};
+
+function validateConfig() {
+  const missing = [];
+  if (!config.webhookUrl) missing.push("WEBHOOK_URL");
+  if (!config.siteUrls.length) missing.push("SITE_URLS");
+  if (!config.notifyChannels.length) missing.push("NOTIFY_CHANNELS");
+  if (config.webhookUrl) {
+    try {
+      const url = new URL(config.webhookUrl);
+      if (!/^https?:$/.test(url.protocol)) missing.push("WEBHOOK_URL(http-or-https)");
+    } catch {
+      missing.push("WEBHOOK_URL(valid-url)");
+    }
+  }
+  if (missing.length) throw new Error(`Missing or invalid configuration: ${[...new Set(missing)].join(", ")}`);
+  return true;
+}
+
+function mkdirFor(file) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+}
+
+function loadState() {
+  let state;
+  try {
+    state = { states: {}, fileOffsets: {}, lastRestartAt: 0, ...JSON.parse(fs.readFileSync(config.stateFile, "utf8")) };
+  } catch {
+    state = { states: {}, fileOffsets: {}, lastRestartAt: 0 };
+  }
+
+  const slowLogState = state.logAlerts && typeof state.logAlerts === "object"
+    ? state.logAlerts["php-fpm-slow-log"]
+    : null;
+  if (slowLogState && typeof slowLogState === "object") {
+    // Version 1 counted capped stack-trace lines, which cannot be converted to requests.
+    // Discard that legacy counter instead of reporting it as a request count.
+    delete slowLogState.suppressedLineCount;
+    slowLogState.counterVersion = 2;
+  }
+  return state;
+}
+
+function saveState(state) {
+  mkdirFor(config.stateFile);
+  fs.writeFileSync(config.stateFile, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o640 });
+}
+
+function appendJsonl(file, payload) {
+  mkdirFor(file);
+  fs.appendFileSync(file, `${JSON.stringify(payload)}\n`, { mode: 0o640 });
+}
+
+function run(command, args, timeout = 5000) {
+  return new Promise(resolve => {
+    execFile(command, args, { timeout, maxBuffer: 1024 * 1024 }, (error, stdout, stderr) => {
+      resolve({ ok: !error, code: error?.code ?? 0, stdout, stderr: stderr || error?.message || "" });
+    });
+  });
+}
+
+function redactText(value) {
+  return String(value || "")
+    .replace(/("(?:secret|token|password|authorization|api[_-]?key)"\s*:\s*")[^"]*(")/gi, "$1***$2")
+    .replace(/((?:secret|token|password|authorization|api[_-]?key)=)[^\s&]+/gi, "$1***");
+}
+
+function tailText(text, maxLines = config.diagnosticsMaxLines, maxChars = 1200) {
+  const lines = String(text || "").split(/\r?\n/).filter(Boolean).slice(-maxLines);
+  return lines.map(line => {
+    const redacted = redactText(line);
+    return redacted.length > maxChars ? `${redacted.slice(0, maxChars)}...` : redacted;
+  });
+}
+
+function requestUrl(urlString, timeoutMs) {
+  return new Promise(resolve => {
+    const started = Date.now();
+    const timings = {};
+    let settled = false;
+    const mark = key => {
+      if (timings[key] == null) timings[key] = Date.now() - started;
+    };
+    const finish = result => {
+      if (settled) return;
+      settled = true;
+      resolve({
+        ...result,
+        ms: Date.now() - started,
+        timing_ms: timings,
+      });
+    };
+    const url = new URL(urlString);
+    const client = url.protocol === "https:" ? https : http;
+    const req = client.request(url, {
+      method: config.siteMethod === "GET" ? "GET" : "HEAD",
+      timeout: timeoutMs,
+      rejectUnauthorized: false,
+      headers: { "User-Agent": `office-apache-site-watchdog/${config.office}` },
+    }, res => {
+      mark("ttfb");
+      res.resume();
+      res.on("end", () => finish({
+        ok: res.statusCode >= 200 && res.statusCode < 400,
+        statusCode: res.statusCode,
+      }));
+    });
+    req.on("socket", socket => {
+      socket.once("lookup", () => mark("dns"));
+      socket.once("connect", () => mark("connect"));
+      socket.once("secureConnect", () => mark("tls"));
+    });
+    req.on("timeout", () => req.destroy(new Error("timeout")));
+    req.on("error", error => finish({ ok: false, error: error.message }));
+    req.end();
+  });
+}
+
+function getText(urlString, timeoutMs) {
+  return new Promise(resolve => {
+    const url = new URL(urlString);
+    const client = url.protocol === "https:" ? https : http;
+    const req = client.request(url, { method: "GET", timeout: timeoutMs, rejectUnauthorized: false }, res => {
+      const chunks = [];
+      res.on("data", chunk => chunks.push(chunk));
+      res.on("end", () => resolve(res.statusCode >= 200 && res.statusCode < 400 ? Buffer.concat(chunks).toString("utf8") : ""));
+    });
+    req.on("timeout", () => req.destroy(new Error("timeout")));
+    req.on("error", () => resolve(""));
+    req.end();
+  });
+}
+
+function postJson(payload) {
+  return new Promise(resolve => {
+    const url = new URL(config.webhookUrl);
+    const client = url.protocol === "https:" ? https : http;
+    const body = Buffer.from(JSON.stringify(payload), "utf8");
+    const req = client.request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Content-Length": body.length },
+      timeout: config.webhookTimeoutMs,
+    }, res => {
+      res.resume();
+      res.on("end", () => resolve({ ok: res.statusCode >= 200 && res.statusCode < 300, statusCode: res.statusCode }));
+    });
+    req.on("timeout", () => req.destroy(new Error("timeout")));
+    req.on("error", error => resolve({ ok: false, error: error.message }));
+    req.end(body);
+  });
+}
+
+function parseStatusAuto(text) {
+  const out = {};
+  for (const line of String(text || "").split(/\r?\n/)) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    out[key] = /^\d+(\.\d+)?$/.test(value) ? Number(value) : value;
+  }
+  return out;
+}
+
+function parseJsonMaybe(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function readNewLines(state, key, file, maxBytes = 256 * 1024) {
+  state.fileOffsets = state.fileOffsets && typeof state.fileOffsets === "object" ? state.fileOffsets : {};
+  let stat;
+  try {
+    stat = fs.statSync(file);
+  } catch {
+    return [];
+  }
+
+  const previous = state.fileOffsets[key];
+  const fileId = `${stat.dev}:${stat.ino}`;
+  if (!previous || previous.fileId !== fileId) {
+    state.fileOffsets[key] = { fileId, offset: stat.size };
+    return [];
+  }
+
+  let offset = Number(previous.offset || 0);
+  if (stat.size < offset) offset = 0;
+  if (stat.size === offset) return [];
+
+  const bytesToRead = Math.min(maxBytes, stat.size - offset);
+  const start = stat.size - offset > maxBytes ? stat.size - maxBytes : offset;
+  const fd = fs.openSync(file, "r");
+  try {
+    const buffer = Buffer.alloc(bytesToRead);
+    fs.readSync(fd, buffer, 0, bytesToRead, start);
+    state.fileOffsets[key] = { fileId, offset: stat.size };
+    return tailText(buffer.toString("utf8"), config.logAlertMaxLines, 2000);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function isPhpFpmSlowLogHeader(line) {
+  return /^\[\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2}\]\s+\[pool [^\]]+\]\s+pid \d+\s*$/.test(String(line || ""));
+}
+
+function readNewPhpFpmSlowLog(state, key, file, chunkBytes = 64 * 1024) {
+  state.fileOffsets = state.fileOffsets && typeof state.fileOffsets === "object" ? state.fileOffsets : {};
+  let stat;
+  try {
+    stat = fs.statSync(file);
+  } catch {
+    return { requestCount: 0, observedLineCount: 0, bytesRead: 0, sampleLines: [] };
+  }
+
+  const previous = state.fileOffsets[key];
+  const fileId = `${stat.dev}:${stat.ino}`;
+  if (!previous || previous.fileId !== fileId) {
+    state.fileOffsets[key] = { fileId, offset: stat.size, partialLine: "" };
+    return { requestCount: 0, observedLineCount: 0, bytesRead: 0, sampleLines: [] };
+  }
+
+  let offset = Number(previous.offset || 0);
+  let partialLine = String(previous.partialLine || "");
+  if (stat.size < offset) {
+    offset = 0;
+    partialLine = "";
+  }
+  if (stat.size === offset) {
+    return { requestCount: 0, observedLineCount: 0, bytesRead: 0, sampleLines: [] };
+  }
+
+  const sampleLimit = Math.max(1, config.logAlertMaxLines, config.phpFpmSlowLogSummaryMaxLines);
+  const sampleLines = [];
+  let requestCount = 0;
+  let observedLineCount = 0;
+  let position = offset;
+  const fd = fs.openSync(file, "r");
+  try {
+    while (position < stat.size) {
+      const length = Math.min(Math.max(1024, chunkBytes), stat.size - position);
+      const buffer = Buffer.alloc(length);
+      const read = fs.readSync(fd, buffer, 0, length, position);
+      if (!read) break;
+      position += read;
+
+      const lines = `${partialLine}${buffer.subarray(0, read).toString("utf8")}`.split(/\r?\n/);
+      partialLine = lines.pop() || "";
+      for (const line of lines) {
+        if (isPhpFpmSlowLogHeader(line)) requestCount += 1;
+        if (!line.trim()) continue;
+        observedLineCount += 1;
+        sampleLines.push(line);
+        if (sampleLines.length > sampleLimit) sampleLines.shift();
+      }
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  state.fileOffsets[key] = {
+    fileId,
+    offset: stat.size,
+    partialLine: partialLine.slice(-8192),
+  };
+  return {
+    requestCount,
+    observedLineCount,
+    bytesRead: stat.size - offset,
+    sampleLines: tailText(sampleLines.join("\n"), config.logAlertMaxLines, 2000),
+  };
+}
+
+function logAlertState(state, key) {
+  state.logAlerts = state.logAlerts && typeof state.logAlerts === "object" ? state.logAlerts : {};
+  const item = state.logAlerts[key] && typeof state.logAlerts[key] === "object" ? state.logAlerts[key] : {};
+  state.logAlerts[key] = item;
+  return item;
+}
+
+function suppressSlowLogAlert(state, key, batch) {
+  const item = logAlertState(state, key);
+  const now = Date.now();
+  delete item.suppressedLineCount;
+  item.counterVersion = 2;
+  item.suppressedRequestCount = Number(item.suppressedRequestCount || 0) + batch.requestCount;
+  item.firstSuppressedAt = Number(item.firstSuppressedAt || now);
+  item.lastSuppressedAt = now;
+  item.suppressedSamples = [
+    ...(Array.isArray(item.suppressedSamples) ? item.suppressedSamples : []),
+    ...batch.sampleLines,
+  ].slice(-Math.max(0, config.phpFpmSlowLogSummaryMaxLines));
+}
+
+async function emitPhpFpmSlowLogAlert(state, batch) {
+  const key = "php-fpm-slow-log";
+  const item = logAlertState(state, key);
+  const now = Date.now();
+  const cooldownMs = Math.max(0, config.phpFpmSlowLogNotifyCooldownSeconds) * 1000;
+  const lastNotifiedAt = Number(item.lastNotifiedAt || 0);
+  if (lastNotifiedAt && cooldownMs && now - lastNotifiedAt < cooldownMs) {
+    suppressSlowLogAlert(state, key, batch);
+    console.log(`${new Date().toISOString()} suppressed PHP-FPM slowlog alert for ${batch.requestCount} new request(s); cooldown ${config.phpFpmSlowLogNotifyCooldownSeconds}s`);
+    return;
+  }
+
+  const suppressedRequestCount = Number(item.suppressedRequestCount || 0);
+  const suppressedSamples = Array.isArray(item.suppressedSamples) ? item.suppressedSamples : [];
+  const suppressedFirstAt = item.firstSuppressedAt ? new Date(Number(item.firstSuppressedAt)).toISOString() : null;
+  const suppressedLastAt = item.lastSuppressedAt ? new Date(Number(item.lastSuppressedAt)).toISOString() : null;
+  item.lastNotifiedAt = now;
+  delete item.suppressedLineCount;
+  item.counterVersion = 2;
+  item.suppressedRequestCount = 0;
+  item.firstSuppressedAt = 0;
+  item.lastSuppressedAt = 0;
+  item.suppressedSamples = [];
+
+  await emit({
+    event_type: "php_fpm_slowlog_watchdog",
+    status: "warning",
+    severity: "warning",
+    title: "PHP-FPM slow request logged",
+    message: suppressedRequestCount
+      ? `PHP-FPM logged ${batch.requestCount} new slow request(s) in ${config.office}; ${suppressedRequestCount} request(s) occurred during the cooldown.`
+      : `PHP-FPM logged ${batch.requestCount} new slow request(s) in ${config.office}.`,
+    log_file: config.phpFpmSlowLog,
+    slow_request_count: batch.requestCount,
+    slowlog_lines: batch.sampleLines,
+    slowlog_observed_line_count: batch.observedLineCount,
+    slowlog_bytes_read: batch.bytesRead,
+    suppressed_request_count: suppressedRequestCount,
+    suppressed_first_at: suppressedFirstAt,
+    suppressed_last_at: suppressedLastAt,
+    suppressed_samples: suppressedSamples,
+    cooldown_seconds: config.phpFpmSlowLogNotifyCooldownSeconds,
+  });
+}
+
+async function checkLogAlerts(state) {
+  if (!config.logAlertsEnabled) return;
+  const fpmLines = readNewLines(state, "php-fpm-log", config.phpFpmLog);
+  for (const line of fpmLines.filter(item => /server reached pm\.max_children setting/i.test(item))) {
+    await emit({
+      event_type: "php_fpm_capacity_watchdog",
+      status: "warning",
+      severity: "warning",
+      title: "PHP-FPM max_children reached",
+      message: `PHP-FPM reached pm.max_children in ${config.office}: ${line}`,
+      log_file: config.phpFpmLog,
+      log_line: line,
+    });
+  }
+
+  const slowLogBatch = readNewPhpFpmSlowLog(state, "php-fpm-slow-log", config.phpFpmSlowLog);
+  if (slowLogBatch.requestCount > 0) {
+    await emitPhpFpmSlowLogAlert(state, slowLogBatch);
+  }
+
+  const qmLines = readNewLines(state, "query-monitor-log", config.queryMonitorLog);
+  if (qmLines.length) {
+    const entries = qmLines.map(raw => parseJsonMaybe(raw) || raw);
+    const parsedEntries = entries.filter(item => item && typeof item === "object");
+    const slowDbCount = parsedEntries.reduce((sum, item) => sum + (item.db?.slow_queries?.length || 0), 0);
+    const slowHttpCount = parsedEntries.reduce((sum, item) => sum + (item.http?.slow_calls?.length || 0), 0);
+    const topRequests = parsedEntries
+      .map(item => item.request || {})
+      .sort((a, b) => Number(b.seconds || 0) - Number(a.seconds || 0))
+      .slice(0, Math.min(config.logAlertMaxLines, 10));
+    await emit({
+      event_type: "wordpress_query_monitor_slow_requests",
+      status: "warning",
+      severity: "warning",
+      title: "WordPress slow requests",
+      message: `WordPress logged ${qmLines.length} slow request(s) in ${config.office}: ${slowDbCount} slow DB queries, ${slowHttpCount} slow HTTP calls.`,
+      log_file: config.queryMonitorLog,
+      query_monitor_entries: entries.slice(0, config.logAlertMaxLines),
+      top_requests: topRequests,
+      slow_db_query_count: slowDbCount,
+      slow_http_call_count: slowHttpCount,
+    });
+  }
+}
+
+function stateChangedOrRepeat(state, key, status) {
+  const now = Date.now();
+  const previous = state.states[key] || { status: "unknown", notifiedAt: 0 };
+  if (previous.status !== status || (status !== "up" && now - Number(previous.notifiedAt || 0) >= config.repeatSeconds * 1000)) {
+    state.states[key] = { status, notifiedAt: now };
+    return previous.status !== "unknown" || status !== "up";
+  }
+  return false;
+}
+
+function buildEventPayload(event, overrides = {}) {
+  const requestedChannels = Array.isArray(overrides.notifyChannels) ? overrides.notifyChannels : config.notifyChannels;
+  return {
+    ...event,
+    event_type: event.event_type || "apache_site_watchdog",
+    category: "web_health",
+    source: "apache-site-watchdog",
+    office: overrides.office || config.office,
+    host: overrides.host || os.hostname(),
+    channels: [...requestedChannels],
+    notify_channels: [...requestedChannels],
+    created_at: overrides.createdAt || event.created_at || new Date().toISOString(),
+  };
+}
+
+async function emit(event) {
+  const payload = buildEventPayload(event);
+  appendJsonl(config.eventLogFile, payload);
+  await run("logger", ["-p", payload.status === "down" || payload.severity === "critical" ? "daemon.crit" : "daemon.warning", "-t", "apache-site-watchdog", payload.message], 3000);
+  const result = await postJson(payload);
+  if (!result.ok) console.error(`failed posting Apache site watchdog event to n8n: ${result.error || result.statusCode}`);
+  else console.log(`${new Date().toISOString()} sent ${payload.status || payload.severity} event for ${payload.site_url || "apache"}`);
+}
+
+async function apacheActive() {
+  const result = await run("systemctl", ["is-active", "apache2.service"], 5000);
+  return result.stdout.trim() === "active";
+}
+
+async function countCloseWait() {
+  const result = await run("ss", ["-tan", "state", "close-wait"], 5000);
+  if (!result.ok) return 0;
+  return result.stdout.split(/\r?\n/).filter(line => line.trim() && !line.startsWith("Recv-Q")).length;
+}
+
+async function tailFile(file) {
+  const result = await run("tail", ["-n", String(config.diagnosticsMaxLines), file], config.diagnosticsTimeoutMs);
+  return result.ok ? tailText(result.stdout) : [];
+}
+
+async function collectSiteDiagnostics() {
+  if (!config.diagnosticsEnabled) return null;
+  const [active, statusText, closeWait, phpFpmActive, phpFpmStatusText, phpFpmLog, phpFpmSlowLog, queryMonitorLog, apacheErrors, dbProcesslist, topProcesses] = await Promise.all([
+    apacheActive(),
+    getText(config.statusUrl, Math.min(config.httpTimeoutMs, config.diagnosticsTimeoutMs)),
+    countCloseWait(),
+    run("systemctl", ["is-active", config.phpFpmService], config.diagnosticsTimeoutMs),
+    getText(config.phpFpmStatusUrl, config.diagnosticsTimeoutMs),
+    tailFile(config.phpFpmLog),
+    tailFile(config.phpFpmSlowLog),
+    tailFile(config.queryMonitorLog),
+    tailFile(config.apacheErrorLog),
+    run("wp", ["--allow-root", `--path=${config.wpPath}`, "db", "query", "SHOW FULL PROCESSLIST"], config.diagnosticsTimeoutMs),
+    run("ps", ["-eo", "pid,ppid,stat,pcpu,pmem,etime,comm", "--sort=-pcpu"], config.diagnosticsTimeoutMs),
+  ]);
+  const serverStatus = statusText ? parseStatusAuto(statusText) : null;
+  const phpFpmStatus = phpFpmStatusText ? parseJsonMaybe(phpFpmStatusText) || parseStatusAuto(phpFpmStatusText) : null;
+  return {
+    apache_active: active,
+    apache_status: serverStatus,
+    close_wait_sockets: closeWait,
+    php_fpm: {
+      service: config.phpFpmService,
+      active: phpFpmActive.stdout.trim(),
+      status: phpFpmStatus,
+      recent_log: phpFpmLog,
+      recent_slowlog: phpFpmSlowLog,
+    },
+    wordpress: {
+      path: config.wpPath,
+      db_processlist: dbProcesslist.ok ? tailText(dbProcesslist.stdout, config.diagnosticsMaxLines, 600) : [],
+      db_processlist_error: dbProcesslist.ok ? null : tailText(dbProcesslist.stderr, 5, 600),
+      query_monitor_slow_requests: queryMonitorLog,
+    },
+    apache_recent_errors: apacheErrors,
+    top_processes: topProcesses.ok ? tailText(topProcesses.stdout, Math.min(config.diagnosticsMaxLines, 20), 1000) : [],
+  };
+}
+
+async function maybeRestartApache(state, status) {
+  if (status !== "critical" || !config.autoRestartApache) return false;
+  const now = Date.now();
+  if (now - Number(state.lastRestartAt || 0) < config.autoRestartCooldownSeconds * 1000) return false;
+  state.lastRestartAt = now;
+  const result = await run("systemctl", ["restart", "apache2.service"], 30000);
+  return result.ok;
+}
+
+function apacheSeverity(active, status, closeWait) {
+  if (!status) return active ? "warning" : "critical";
+  const busy = Number(status.BusyWorkers || 0);
+  const idle = Number(status.IdleWorkers || 0);
+  const busyPercent = config.maxRequestWorkers > 0 ? (busy / config.maxRequestWorkers) * 100 : 0;
+  if (busy < 5 && closeWait < config.closeWaitWarning) return "ok";
+  if (busyPercent >= config.busyWorkersCriticalPercent || closeWait >= config.closeWaitCritical) return "critical";
+  if (idle <= config.idleWorkersCritical && busyPercent >= config.busyWorkersWarningPercent) return "critical";
+  if (busyPercent >= config.busyWorkersWarningPercent || closeWait >= config.closeWaitWarning) return "warning";
+  if (idle <= config.idleWorkersWarning && busyPercent >= 25) return "warning";
+  return "ok";
+}
+
+async function checkApacheCapacity(state) {
+  const active = await apacheActive();
+  const statusText = await getText(config.statusUrl, config.httpTimeoutMs);
+  const status = statusText ? parseStatusAuto(statusText) : null;
+  const closeWait = await countCloseWait();
+  const severity = apacheSeverity(active, status, closeWait);
+  const restarted = await maybeRestartApache(state, severity);
+  if (!stateChangedOrRepeat(state, "apache-capacity", severity === "ok" ? "up" : severity)) return;
+
+  const busy = Number(status?.BusyWorkers || 0);
+  const idle = Number(status?.IdleWorkers || 0);
+  const busyPercent = config.maxRequestWorkers > 0 ? (busy / config.maxRequestWorkers) * 100 : 0;
+  await emit({
+    event_type: "apache_capacity_watchdog",
+    status: severity === "ok" ? "recovered" : severity,
+    severity,
+    title: severity === "ok" ? "Apache capacity recovered" : "Apache capacity problem",
+    message: severity === "ok"
+      ? `Apache capacity recovered in ${config.office}: ${busy} busy workers, ${idle} idle workers, ${closeWait} CLOSE-WAIT sockets.`
+      : `Apache capacity ${severity} in ${config.office}: ${busy} busy workers, ${idle} idle workers (${busyPercent.toFixed(1)}% of MaxRequestWorkers ${config.maxRequestWorkers}), ${closeWait} CLOSE-WAIT sockets.${restarted ? " Apache was restarted by the watchdog." : ""}`,
+    apache_active: active,
+    busy_workers: busy,
+    idle_workers: idle,
+    busy_percent: Number(busyPercent.toFixed(1)),
+    close_wait_sockets: closeWait,
+    auto_restarted: restarted,
+    server_status: status,
+  });
+}
+
+async function checkSite(state, siteUrl) {
+  const result = await requestUrl(siteUrl, config.httpTimeoutMs);
+  const rawStatus = result.ok ? (result.ms < config.slowSiteMs ? "up" : "slow") : "down";
+  const key = `site:${siteUrl}`;
+  const previous = state.states[key] || { status: "unknown", notifiedAt: 0, failures: 0 };
+  const failures = rawStatus === "down" ? Number(previous.failures || 0) + 1 : 0;
+  const status = rawStatus === "down" && failures < config.siteFailuresBeforeDown ? previous.status === "down" ? "down" : "up" : rawStatus;
+  const now = Date.now();
+  const shouldNotify = previous.status !== status || (status !== "up" && now - Number(previous.notifiedAt || 0) >= config.repeatSeconds * 1000);
+  state.states[key] = {
+    ...previous,
+    status,
+    failures,
+    notifiedAt: shouldNotify ? now : previous.notifiedAt,
+    lastRawStatus: rawStatus,
+    lastCheckedAt: now,
+    lastResponseMs: result.ms,
+  };
+  if (rawStatus === "down" && failures < config.siteFailuresBeforeDown) return;
+  if (!shouldNotify || (previous.status === "unknown" && status === "up")) return;
+  const diagnostics = status === "up" ? null : await collectSiteDiagnostics();
+  const reason = result.statusCode ? `HTTP ${result.statusCode}` : result.error;
+  const timingText = result.timing_ms?.ttfb != null ? `, TTFB ${result.timing_ms.ttfb}ms` : "";
+  await emit({
+    status: status === "up" ? "recovered" : status,
+    severity: status === "up" ? "info" : status === "slow" ? "warning" : "critical",
+    title: status === "up" ? "Website recovered" : status === "slow" ? "Website slow" : "Website down",
+    message: status === "up"
+      ? `${siteUrl} recovered in ${config.office}: HTTP ${result.statusCode} in ${result.ms}ms${timingText}.`
+      : status === "slow"
+        ? `${siteUrl} is slow in ${config.office}: HTTP ${result.statusCode} in ${result.ms}ms${timingText}.`
+        : `${siteUrl} is down in ${config.office}: ${reason} in ${result.ms}ms after ${failures} consecutive failed checks.`,
+    site_url: siteUrl,
+    http_status: result.statusCode || null,
+    response_ms: result.ms,
+    timing_ms: result.timing_ms || null,
+    consecutive_failures: failures,
+    error: result.error || null,
+    diagnostics,
+  });
+}
+
+async function checkOnce(state) {
+  await checkApacheCapacity(state);
+  await checkLogAlerts(state);
+  for (const siteUrl of config.siteUrls) await checkSite(state, siteUrl);
+  saveState(state);
+}
+
+async function main() {
+  const mode = process.argv[2] || "serve";
+  if (mode === "check-config") {
+    validateConfig();
+    console.log(JSON.stringify({ ok: true }));
+    return;
+  }
+  validateConfig();
+  const state = loadState();
+  if (mode === "check-once") {
+    await checkOnce(state);
+    return;
+  }
+  if (mode !== "serve") throw new Error("Usage: apache-site-watchdog-to-n8n.cjs [check-config|serve|check-once]");
+  console.log(`${new Date().toISOString()} Apache site watchdog started for ${config.siteUrls.join(", ")}`);
+  let running = false;
+  const guardedCheck = async () => {
+    if (running) return;
+    running = true;
+    try {
+      await checkOnce(state);
+    } catch (error) {
+      console.error(`watchdog check failed: ${error.stack || error.message}`);
+      saveState(state);
+    } finally {
+      running = false;
+    }
+  };
+  await guardedCheck();
+  setInterval(() => {
+    guardedCheck();
+  }, Math.max(5, config.intervalSeconds) * 1000);
+}
+
+module.exports = {
+  buildEventPayload,
+  isPhpFpmSlowLogHeader,
+  readNewPhpFpmSlowLog,
+  redactText,
+  validateConfig,
+};
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exit(1);
+  });
+}

--- a/ops/office-automation/lib/office-automation-sip-notifier.cjs
+++ b/ops/office-automation/lib/office-automation-sip-notifier.cjs
@@ -1,0 +1,865 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const http = require("node:http");
+const net = require("node:net");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+function loadEnv(file) {
+  const out = {};
+  try {
+    for (const raw of fs.readFileSync(file, "utf8").split(/\r?\n/)) {
+      const line = raw.trim();
+      if (!line || line.startsWith("#")) continue;
+      const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+      if (!match) continue;
+      let value = match[2].trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) value = value.slice(1, -1);
+      out[match[1]] = value;
+    }
+  } catch (_) {
+    // The service can still run with process environment only.
+  }
+  return out;
+}
+
+const envFile = process.env.OFFICE_AUTOMATION_SIP_ENV || "/etc/office-automation-sip-notifier.env";
+const env = { ...process.env, ...loadEnv(envFile) };
+const config = {
+  office: env.OFFICE_NAME || "office",
+  httpHost: env.HTTP_HOST || "127.0.0.1",
+  httpPort: Number(env.HTTP_PORT || 0),
+  apiToken: env.API_TOKEN || "",
+  defaultExtensions: parseCsv(env.DEFAULT_EXTENSIONS || ""),
+  subscribersFile: env.SUBSCRIBERS_FILE || "/var/lib/office-automation/sip-notifier-subscribers.json",
+  preferencesFile: env.PREFERENCES_FILE || "/var/lib/office-automation/n8n-sip-preferences.json",
+  messageFrom: env.MESSAGE_FROM || "",
+  amiHost: env.AMI_HOST || "127.0.0.1",
+  amiPort: Number(env.AMI_PORT || 0),
+  amiUser: env.AMI_USER || "",
+  amiSecret: env.AMI_SECRET || "",
+  amiTimeoutMs: Number(env.AMI_TIMEOUT_MS || "5000"),
+  maxBodyLength: Number(env.MAX_BODY_LENGTH || "900"),
+  interofficeMessageEndpoint: env.INTEROFFICE_MESSAGE_ENDPOINT || "",
+  interofficeMessageFrom: env.INTEROFFICE_MESSAGE_FROM || "",
+  interofficeForwardTarget: env.INTEROFFICE_FORWARD_TARGET || "",
+  interofficeAliasRegex: new RegExp(env.INTEROFFICE_ALIAS_REGEX || "$^"),
+  interofficeTargetPrefix: env.INTEROFFICE_TARGET_PREFIX || "",
+  interofficeSenderAliasRegex: new RegExp(env.INTEROFFICE_SENDER_ALIAS_REGEX || "$^"),
+  interofficeSenderAliasPrefix: env.INTEROFFICE_SENDER_ALIAS_PREFIX || "",
+  commandLogFile: env.COMMAND_LOG_FILE || "/var/log/office-automation-sip-commands.log",
+};
+
+let actionCounter = 0;
+
+function parseCsv(value) {
+  return String(value || "").split(",").map(item => item.trim()).filter(Boolean);
+}
+
+function validateConfig() {
+  const missing = [];
+  if (!Number.isInteger(config.httpPort) || config.httpPort < 1 || config.httpPort > 65535) missing.push("HTTP_PORT");
+  if (!config.apiToken) missing.push("API_TOKEN");
+  if (!config.messageFrom) missing.push("MESSAGE_FROM");
+  if (!Number.isInteger(config.amiPort) || config.amiPort < 1 || config.amiPort > 65535) missing.push("AMI_PORT");
+  if (!config.amiUser) missing.push("AMI_USER");
+  if (!config.amiSecret) missing.push("AMI_SECRET");
+  if (config.interofficeMessageEndpoint && !config.interofficeForwardTarget) missing.push("INTEROFFICE_FORWARD_TARGET");
+  if (missing.length) throw new Error(`Missing required configuration: ${missing.join(", ")}`);
+  return true;
+}
+
+function unique(values) {
+  return [...new Set(values.map(item => String(item || "").trim()).filter(Boolean))].sort();
+}
+
+const categoryAliases = {
+  nvr: "camera",
+  cameras: "camera",
+  camera: "camera",
+  motion: "camera",
+  dahua: "camera",
+  led: "camera",
+  host: "host",
+  pc: "host",
+  netwatch: "host",
+  wifi: "wifi",
+  wireless: "wifi",
+  routeros: "routeros",
+  dhcp: "wifi",
+  sip: "sip_trunk",
+  trunk: "sip_trunk",
+  sip_trunk: "sip_trunk",
+  oauth: "oauth",
+  wordpress: "wordpress",
+  wp: "wordpress",
+  security: "security",
+  login: "security",
+  error: "error",
+  errors: "error",
+  failure: "error",
+  important: "important",
+  critical: "important",
+  system: "system",
+  all: "all",
+};
+
+const knownCategories = ["important", "error", "security", "sip_trunk", "oauth", "wordpress", "host", "wifi", "routeros", "camera", "system", "all"];
+
+function normalizeCategory(value) {
+  const key = String(value || "").trim().toLowerCase().replace(/[^a-z0-9_]+/g, "_").replace(/^_+|_+$/g, "");
+  return categoryAliases[key] || key;
+}
+
+function normalizeCategories(values) {
+  const items = Array.isArray(values) ? values : parseCsv(values);
+  return unique(items.map(normalizeCategory).filter(Boolean));
+}
+
+function normalizeChannel(value) {
+  const channel = String(value || "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  if (["pbx", "phone", "call", "voice"].includes(channel)) return "sip";
+  if (["telegram_bot", "telegrambot"].includes(channel)) return "telegram";
+  if (["ntfy_sh", "ntfysh"].includes(channel)) return "ntfy";
+  return channel;
+}
+
+function channelFlagEnabled(value) {
+  if (value === true || value === 1) return true;
+  if (typeof value !== "string") return false;
+  return ["true", "1", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+function explicitRequestedChannels(payload) {
+  const source = payload && typeof payload === "object" ? payload : {};
+  const hasNotifyChannels = Object.prototype.hasOwnProperty.call(source, "notify_channels");
+  const hasChannels = Object.prototype.hasOwnProperty.call(source, "channels");
+  if (!hasNotifyChannels && !hasChannels) return null;
+
+  const allowLists = [];
+  for (const raw of [hasNotifyChannels ? source.notify_channels : undefined, hasChannels ? source.channels : undefined]) {
+    if (raw === undefined) continue;
+    const requested = [];
+    if (Array.isArray(raw)) {
+      requested.push(...raw);
+    } else if (raw && typeof raw === "object") {
+      requested.push(...Object.entries(raw).filter(([, enabled]) => channelFlagEnabled(enabled)).map(([channel]) => channel));
+    } else if (raw !== null) {
+      requested.push(...parseCsv(raw));
+    }
+    allowLists.push(new Set(requested.map(normalizeChannel).filter(Boolean)));
+  }
+  if (!allowLists.length) return new Set();
+  const candidates = new Set(allowLists.flatMap(allowed => [...allowed].filter(channel => channel !== "all")));
+  if (!candidates.size && allowLists.every(allowed => allowed.has("all"))) return new Set(["all"]);
+  return new Set([...candidates].filter(channel => allowLists.every(allowed => allowed.has(channel) || allowed.has("all"))));
+}
+
+function payloadRequestsChannel(payload, channel) {
+  const requested = explicitRequestedChannels(payload);
+  if (requested === null) return true;
+  return requested.has("all") || requested.has(normalizeChannel(channel));
+}
+
+function decodeArg(value) {
+  return Buffer.from(String(value || ""), "base64").toString("utf8");
+}
+
+function commandLogRecord(record, at = new Date().toISOString()) {
+  const knownError = record.error === "could_not_detect_sender_extension" ? record.error : "command_failed";
+  return {
+    at,
+    office: config.office,
+    direction: String(record.direction || "unknown"),
+    ...(Object.prototype.hasOwnProperty.call(record, "ok") ? { ok: Boolean(record.ok) } : {}),
+    ...(record.error ? { error: knownError } : {}),
+    ...(record.command ? { command: String(record.command) } : {}),
+    ...(record.categories ? { categories: normalizeCategories(record.categories) } : {}),
+    endpoint_present: Boolean(record.endpoint),
+    sender_present: Boolean(record.from),
+    body_bytes: Buffer.byteLength(String(record.body || ""), "utf8"),
+  };
+}
+
+function appendCommandLog(record) {
+  try {
+    const safeRecord = commandLogRecord(record);
+    fs.appendFileSync(config.commandLogFile, `${JSON.stringify(safeRecord)}\n`);
+  } catch {
+    // Logging must never prevent command handling.
+  }
+}
+
+function endpointFromIdentity(identity) {
+  const text = String(identity || "");
+  const sipUser = text.match(/sip:([^@;>]+)/i);
+  if (sipUser) return sipUser[1].replace(/^"|"$/g, "");
+  const bare = text.match(/\b([0-9]{2,5})\b/);
+  return bare ? bare[1] : "";
+}
+
+function loadSubscribers() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(config.subscribersFile, "utf8"));
+    return new Set(Array.isArray(parsed.subscribers) ? parsed.subscribers.map(String) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveSubscribers(subscribers) {
+  fs.mkdirSync(path.dirname(config.subscribersFile), { recursive: true });
+  const payload = JSON.stringify({ subscribers: [...subscribers].sort() }, null, 2);
+  fs.writeFileSync(config.subscribersFile, `${payload}\n`, { mode: 0o640 });
+}
+
+function loadPreferences() {
+  try {
+    return normalizePreferences({ cameraNotifications: false, cameraSubscribers: [], ...JSON.parse(fs.readFileSync(config.preferencesFile, "utf8")) });
+  } catch {
+    return normalizePreferences({ cameraNotifications: false, cameraSubscribers: [] });
+  }
+}
+
+function savePreferences(preferences) {
+  fs.mkdirSync(path.dirname(config.preferencesFile), { recursive: true });
+  fs.writeFileSync(config.preferencesFile, `${JSON.stringify(normalizePreferences(preferences), null, 2)}\n`, { mode: 0o640 });
+}
+
+function defaultChannelCategories(channel) {
+  if (channel === "sip") return normalizeCategories(env.DEFAULT_SIP_CATEGORIES || "important,error,security,sip_trunk,oauth,wordpress,host,wifi");
+  if (channel === "telegram") return normalizeCategories(env.DEFAULT_TELEGRAM_CATEGORIES || "all");
+  if (channel === "ntfy") return normalizeCategories(env.DEFAULT_NTFY_CATEGORIES || "important,error,security,sip_trunk,oauth,wordpress,host,wifi,camera");
+  return ["all"];
+}
+
+function normalizePreferences(preferences) {
+  const prefs = preferences && typeof preferences === "object" ? preferences : {};
+  prefs.channels = prefs.channels && typeof prefs.channels === "object" ? prefs.channels : {};
+  for (const channel of ["sip", "telegram", "ntfy"]) {
+    const current = prefs.channels[channel] && typeof prefs.channels[channel] === "object" ? prefs.channels[channel] : {};
+    current.categories = normalizeCategories(current.categories && current.categories.length ? current.categories : defaultChannelCategories(channel));
+    current.mutedCategories = normalizeCategories(current.mutedCategories || []);
+    current.endpoints = current.endpoints && typeof current.endpoints === "object" ? current.endpoints : {};
+    prefs.channels[channel] = current;
+  }
+
+  const cameraSubscribers = Array.isArray(prefs.cameraSubscribers) ? prefs.cameraSubscribers.map(String) : [];
+  for (const endpoint of cameraSubscribers) {
+    const item = prefs.channels.sip.endpoints[endpoint] || {};
+    item.categories = normalizeCategories([...(item.categories || []), "camera"]);
+    item.mutedCategories = normalizeCategories(item.mutedCategories || []);
+    prefs.channels.sip.endpoints[endpoint] = item;
+  }
+  return prefs;
+}
+
+function eventCategories(payload) {
+  const explicit = normalizeCategories(payload.categories || payload.category || "");
+  const text = [
+    payload.event_type,
+    payload.type,
+    payload.source,
+    payload.title,
+    payload.message,
+    payload.status,
+    payload.severity,
+  ].map(value => String(value || "").toLowerCase()).join(" ");
+  const categories = new Set(explicit);
+  const severity = String(payload.severity || "").toLowerCase();
+
+  if (/(error|failure|failed|critical|unauthorized|forbidden|busy)/.test(text) || ["error", "critical", "warning", "warn"].includes(severity)) {
+    categories.add("error");
+    categories.add("important");
+  }
+  if (/(camera|dahua|nvr|motion|videomotion|smartmotion|\bled\b)/.test(text)) categories.add("camera");
+  if (/(netwatch|host|pc|online|offline|arrived|left)/.test(text)) categories.add("host");
+  if (/(wifi|wireless|registration|dhcp|lease)/.test(text)) categories.add("wifi");
+  if (/(routeros|mikrotik)/.test(text)) categories.add("routeros");
+  if (/(sip_trunk|sip trunk|trunk|pjsip|busy_cleared)/.test(text)) {
+    categories.add("sip_trunk");
+    categories.add("important");
+  }
+  if (/oauth/.test(text)) {
+    categories.add("oauth");
+    categories.add("important");
+  }
+  if (/(wordpress|wp_login|wp login)/.test(text)) categories.add("wordpress");
+  if (/(security|login|fail2ban|ban|pam|unknown|unauthorized)/.test(text)) {
+    categories.add("security");
+    categories.add("important");
+  }
+  if (!categories.size) categories.add("system");
+  return [...categories].sort();
+}
+
+function categoryMatches(allowed, categories) {
+  const allow = normalizeCategories(allowed);
+  const cats = normalizeCategories(categories);
+  if (allow.includes("all")) return true;
+  return cats.some(category => allow.includes(category));
+}
+
+function channelAllowed(preferences, channel, payload) {
+  if (!payloadRequestsChannel(payload, channel)) return false;
+  if (channel === "telegram" && isFailedLoginEvent(payload)) return false;
+  const categories = eventCategories(payload);
+  const channelPrefs = normalizePreferences(preferences).channels[channel] || {};
+  if (categoryMatches(channelPrefs.mutedCategories || [], categories)) return false;
+  return categoryMatches(channelPrefs.categories || [], categories);
+}
+
+function isFailedLoginEvent(payload) {
+  const text = [
+    payload.event_type,
+    payload.type,
+    payload.source,
+    payload.title,
+    payload.message,
+    payload.text,
+    payload.status,
+    payload.severity,
+    payload.reason,
+  ].map(value => String(value || "").toLowerCase()).join(" ");
+  return /(failed|failure|denied|invalid|incorrect|unauthorized|forbidden)/.test(text)
+    && /(login|log in|signin|sign in|wordpress|wp_login|wp login|authentication|password)/.test(text);
+}
+
+function endpointAllowed(preferences, endpoint, payload, subscribers, defaultExtensions = config.defaultExtensions) {
+  if (!payloadRequestsChannel(payload, "sip")) return false;
+  const prefs = normalizePreferences(preferences);
+  const sipPrefs = prefs.channels.sip;
+  const endpointKey = String(endpoint);
+  const hasEndpointPreferences = Object.prototype.hasOwnProperty.call(sipPrefs.endpoints, endpointKey);
+  const isSubscriber = subscribers && subscribers.has(endpointKey);
+  const isDefault = defaultExtensions.map(String).includes(endpointKey);
+  if (!hasEndpointPreferences && !isSubscriber && !isDefault) return false;
+  const endpointPrefs = sipPrefs.endpoints[endpointKey] || {};
+  const categories = eventCategories(payload);
+  const endpointCategories = normalizeCategories(endpointPrefs.categories || []);
+  const muted = normalizeCategories(endpointPrefs.mutedCategories || []);
+  if (categoryMatches(muted, categories)) return false;
+  if (endpointCategories.length) return categoryMatches(endpointCategories, categories);
+  return categoryMatches(sipPrefs.categories || [], categories);
+}
+
+function routeDecision(payload, dependencies = {}) {
+  const preferences = dependencies.preferences || loadPreferences();
+  return {
+    ok: true,
+    categories: eventCategories(payload),
+    channels: {
+      sip: channelAllowed(preferences, "sip", payload),
+      telegram: channelAllowed(preferences, "telegram", payload),
+      ntfy: channelAllowed(preferences, "ntfy", payload),
+    },
+  };
+}
+
+function applyPreferenceUpdate(body) {
+  const prefs = loadPreferences();
+  const channel = String(body.channel || "sip").trim().toLowerCase();
+  if (!["sip", "telegram", "ntfy"].includes(channel)) throw new Error("channel must be one of sip, telegram, ntfy");
+  const action = String(body.action || "").trim().toLowerCase();
+  const categories = normalizeCategories(body.categories || body.category || "all");
+  const endpoint = body.endpoint ? String(body.endpoint).trim() : "";
+
+  if (channel === "sip" && endpoint) {
+    const next = updateEndpointSubscription(prefs, normalizeCommandEndpoint(endpoint), action, categories);
+    savePreferences(next);
+    return { ok: true, channel, endpoint: normalizeCommandEndpoint(endpoint), action, categories, preferences: next };
+  }
+
+  const channelPrefs = prefs.channels[channel];
+  const current = new Set(normalizeCategories(channelPrefs.categories || []));
+  const muted = new Set(normalizeCategories(channelPrefs.mutedCategories || []));
+  if (action === "sub" || action === "subscribe" || action === "allow") {
+    if (categories.includes("all")) muted.clear();
+    for (const category of categories) {
+      current.add(category);
+      muted.delete(category);
+    }
+  } else if (action === "unsub" || action === "unsubscribe" || action === "mute" || action === "block") {
+    if (categories.includes("all")) {
+      current.clear();
+      muted.clear();
+      muted.add("all");
+    } else {
+      for (const category of categories) {
+        current.delete(category);
+        muted.add(category);
+      }
+    }
+  } else if (action === "set") {
+    channelPrefs.categories = categories;
+    channelPrefs.mutedCategories = [];
+    savePreferences(prefs);
+    return { ok: true, channel, action, categories, preferences: prefs };
+  } else {
+    throw new Error("action must be sub, unsub, set, allow, mute, or block");
+  }
+  channelPrefs.categories = [...current].sort();
+  channelPrefs.mutedCategories = [...muted].sort();
+  savePreferences(prefs);
+  return { ok: true, channel, action, categories, preferences: prefs };
+}
+
+function amiHeaderValue(value) {
+  return String(value ?? "").replace(/[\r\n]/g, " ").trim();
+}
+
+function writeAmiAction(socket, fields) {
+  const lines = Object.entries(fields)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${key}: ${amiHeaderValue(value)}`);
+  socket.write(`${lines.join("\r\n")}\r\n\r\n`);
+}
+
+function parseAmiFrame(frame) {
+  const parsed = {};
+  for (const line of frame.split(/\r\n/)) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    parsed[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim();
+  }
+  return parsed;
+}
+
+function amiAction(fields) {
+  return new Promise((resolve, reject) => {
+    if (!config.amiSecret) {
+      reject(new Error("AMI_SECRET is required"));
+      return;
+    }
+    const socket = net.createConnection({ host: config.amiHost, port: config.amiPort });
+    const actionId = `n8n-sip-${Date.now()}-${++actionCounter}`;
+    let buffer = "";
+    let loggedIn = false;
+    let settled = false;
+    const finish = (error, result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.end();
+      if (error) reject(error);
+      else resolve(result);
+    };
+    const timer = setTimeout(() => finish(new Error(`AMI action timed out after ${config.amiTimeoutMs}ms`)), config.amiTimeoutMs);
+    socket.on("connect", () => {
+      writeAmiAction(socket, { Action: "Login", Username: config.amiUser, Secret: config.amiSecret, ActionID: `${actionId}-login` });
+    });
+    socket.on("data", chunk => {
+      buffer += chunk.toString("utf8");
+      const frames = buffer.split(/\r\n\r\n/);
+      buffer = frames.pop() || "";
+      for (const frame of frames) {
+        const parsed = parseAmiFrame(frame);
+        if (!loggedIn && parsed.response) {
+          if (parsed.response === "Error") return finish(new Error(parsed.message || "AMI login failed"));
+          loggedIn = true;
+          writeAmiAction(socket, { ...fields, ActionID: actionId });
+          continue;
+        }
+        if (loggedIn && parsed.actionid === actionId) {
+          if (parsed.response === "Error") finish(new Error(parsed.message || "AMI action failed"));
+          else finish(null, parsed);
+        }
+      }
+    });
+    socket.on("error", finish);
+    socket.on("close", () => {
+      if (!settled) finish(new Error("AMI connection closed before action completed"));
+    });
+  });
+}
+
+async function sendSipMessage(endpoint, body, from = config.messageFrom) {
+  const route = resolvePjsipMessageDestination(String(endpoint));
+  const messageFrom = route.route === "interoffice" && config.interofficeMessageFrom ? config.interofficeMessageFrom : from;
+  await sendRawSipMessage(route.destination, body, messageFrom);
+  return route;
+}
+
+async function sendRawSipMessage(destination, body, from) {
+  await amiAction({
+    Action: "MessageSend",
+    Destination: destination,
+    From: from,
+    Base64Body: Buffer.from(String(body), "utf8").toString("base64"),
+  });
+}
+
+function forwardedSenderFromIdentity(identity) {
+  const endpoint = endpointFromIdentity(identity);
+  const aliasRegex = new RegExp(config.interofficeSenderAliasRegex);
+  if (endpoint && config.interofficeSenderAliasPrefix && aliasRegex.test(endpoint)) {
+    return `sip:${config.interofficeSenderAliasPrefix}${endpoint.slice(1)}@127.0.0.1`;
+  }
+  return String(identity || config.messageFrom).replace(/[\r\n]/g, " ");
+}
+
+async function forwardMessageToRemoteN8n(remoteEndpoint, from, body) {
+  const endpoint = String(remoteEndpoint || "").trim();
+  if (!endpoint) throw new Error("remote endpoint is required");
+  if (!config.interofficeForwardTarget) throw new Error("INTEROFFICE_FORWARD_TARGET is required");
+  if (!pjsipEndpointExists(endpoint)) throw new Error("configured interoffice PJSIP endpoint is unavailable");
+  const forwardedFrom = forwardedSenderFromIdentity(from);
+  const destination = `pjsip:PJSIP/${config.interofficeForwardTarget}@${endpoint}`;
+  await sendRawSipMessage(destination, body, forwardedFrom);
+  return { ok: true, route: "interoffice" };
+}
+
+function pjsipEndpointExists(endpoint) {
+  const result = spawnSync("asterisk", ["-rx", `pjsip show endpoint ${endpoint}`], { encoding: "utf8" });
+  const output = `${result.stdout || ""}\n${result.stderr || ""}`;
+  if (/Unable to find object/i.test(output)) return false;
+  if (result.status !== 0 && !/Endpoint:/i.test(output)) {
+    throw new Error("could not verify the requested PJSIP endpoint");
+  }
+  return /Endpoint:/i.test(output);
+}
+
+function resolvePjsipMessageDestination(endpoint) {
+  const target = String(endpoint || "").trim();
+  const aliasRegex = new RegExp(config.interofficeAliasRegex);
+  if (config.interofficeMessageEndpoint && aliasRegex.test(target)) {
+    if (!pjsipEndpointExists(config.interofficeMessageEndpoint)) {
+      throw new Error("configured interoffice PJSIP endpoint is unavailable");
+    }
+    const rewrittenTarget = `${config.interofficeTargetPrefix}${target.slice(1)}`;
+    return {
+      route: "interoffice",
+      rewritten_target: rewrittenTarget,
+      interoffice_endpoint: config.interofficeMessageEndpoint,
+      destination: `pjsip:PJSIP/${rewrittenTarget}@${config.interofficeMessageEndpoint}`,
+    };
+  }
+
+  if (!pjsipEndpointExists(target)) {
+    throw new Error("requested PJSIP endpoint is unavailable");
+  }
+  return { route: "local", rewritten_target: target, destination: `pjsip:${target}` };
+}
+
+function normalizeCommandEndpoint(endpoint) {
+  const target = String(endpoint || "").trim();
+  if (!target) return "";
+  const aliasRegex = new RegExp(config.interofficeSenderAliasRegex);
+  if (config.interofficeMessageEndpoint && aliasRegex.test(target) && !pjsipEndpointExists(target)) {
+    return `${config.interofficeSenderAliasPrefix}${target.slice(1)}`;
+  }
+  return target;
+}
+
+function formatNotification(payload) {
+  const title = payload.title || payload.event_type || "n8n notification";
+  const status = payload.status ? `Status: ${payload.status}` : "";
+  const severity = payload.severity ? `Severity: ${payload.severity}` : "";
+  const reason = payload.reason ? `Reason: ${payload.reason}` : "";
+  const message = payload.message || payload.text || "";
+  const lines = [`[n8n ${config.office}] ${title}`, status, severity, message, reason].filter(Boolean);
+  const text = lines.join("\n");
+  return text.length > config.maxBodyLength ? `${text.slice(0, config.maxBodyLength - 3)}...` : text;
+}
+
+function isCameraNotification(payload) {
+  return eventCategories(payload).includes("camera");
+}
+
+async function notify(payload, dependencies = {}) {
+  const categories = eventCategories(payload);
+  if (!payloadRequestsChannel(payload, "sip")) {
+    return { ok: true, skipped: true, reason: "sip_channel_not_requested", endpoints: [], categories, results: [] };
+  }
+  const preferences = dependencies.preferences || loadPreferences();
+  const subscribers = dependencies.subscribers instanceof Set ? dependencies.subscribers : loadSubscribers();
+  const defaultExtensions = Array.isArray(dependencies.defaultExtensions) ? dependencies.defaultExtensions.map(String) : config.defaultExtensions;
+  const send = typeof dependencies.sendSipMessage === "function" ? dependencies.sendSipMessage : sendSipMessage;
+  const requested = Array.isArray(payload.extensions) ? payload.extensions.map(String) : parseCsv(payload.extensions || "");
+  const cameraSubscribers = Array.isArray(preferences.cameraSubscribers) ? preferences.cameraSubscribers.map(String) : [];
+  const cameraEndpoints = cameraSubscribers.length
+    ? cameraSubscribers
+    : preferences.cameraNotifications === true
+      ? defaultExtensions
+      : [];
+  let endpoints = isCameraNotification(payload)
+    ? [...new Set(cameraEndpoints)].filter(Boolean)
+    : [...new Set(requested.length ? requested : [...defaultExtensions, ...subscribers])].filter(Boolean);
+  endpoints = endpoints.filter(endpoint => endpointAllowed(preferences, endpoint, payload, subscribers, defaultExtensions));
+  if (isCameraNotification(payload) && (preferences.cameraNotifications === false || endpoints.length === 0)) {
+    return { ok: true, skipped: true, reason: "camera_notifications_unsubscribed", endpoints: [] };
+  }
+  const body = formatNotification(payload);
+  const results = [];
+  for (const endpoint of endpoints) {
+    try {
+      const route = await send(endpoint, body);
+      results.push({ ok: true, route: route.route });
+    } catch {
+      results.push({ ok: false, error: "sip_send_failed" });
+    }
+  }
+  return {
+    ok: results.every(item => item.ok),
+    endpoint_count: endpoints.length,
+    sent_count: results.filter(item => item.ok).length,
+    failed_count: results.filter(item => !item.ok).length,
+    categories,
+    results,
+  };
+}
+
+function commandHelp() {
+  return [
+    "n8n automation alerts:",
+    "SUB IMPORTANT - receive important alerts",
+    "UNSUB IMPORTANT - stop important alerts",
+    "NVR SUB / NVR UNSUB - camera and motion alerts",
+    "SUB ALL / UNSUB ALL - all SIP alerts on or off",
+    "STATUS - show this extension's subscriptions",
+    "Use the office routing aliases configured by the administrator.",
+    `Categories: ${knownCategories.join(", ")}`,
+    "HELP - show this help",
+  ].join("\n");
+}
+
+function commandStatus(endpoint, preferences) {
+  const prefs = normalizePreferences(preferences);
+  const sipPrefs = prefs.channels.sip;
+  const endpointPrefs = sipPrefs.endpoints[String(endpoint)] || {};
+  const categories = normalizeCategories(endpointPrefs.categories || []);
+  const muted = normalizeCategories(endpointPrefs.mutedCategories || []);
+  return [
+    `n8n SIP subscriptions for ${config.office} ext ${endpoint}:`,
+    `Subscribed: ${categories.length ? categories.join(", ") : "(office defaults)"}`,
+    `Muted: ${muted.length ? muted.join(", ") : "(none)"}`,
+    `Office SIP default: ${(sipPrefs.categories || []).join(", ")}`,
+    `Telegram channel: ${(prefs.channels.telegram.categories || []).join(", ")}`,
+    `ntfy channel: ${(prefs.channels.ntfy.categories || []).join(", ")}`,
+  ].join("\n");
+}
+
+function parseSubscriptionCommand(command) {
+  const text = String(command || "").trim().toUpperCase();
+  if (["STATUS", "STATE", "GET", "LIST", "EVENTS"].includes(text)) return { action: "status", categories: [] };
+  const parts = text.split(/\s+/).filter(Boolean);
+  if (!parts.length) return { action: "help", categories: [] };
+  if (parts.length === 2 && ["STATUS", "STATE", "GET", "LIST", "EVENTS"].includes(parts[1])) return { action: "status", categories: normalizeCategories(parts[0]) };
+  if (parts.length === 1 && ["SUB", "SUBSCRIBE", "START"].includes(parts[0])) return { action: "sub", categories: ["all"] };
+  if (parts.length === 1 && ["UNSUB", "UNSUBSCRIBE", "STOP"].includes(parts[0])) return { action: "unsub", categories: ["all"] };
+  let action = "";
+  let categoryText = "";
+  if (["SUB", "SUBSCRIBE", "START"].includes(parts[0])) {
+    action = "sub";
+    categoryText = parts.slice(1).join(",");
+  } else if (["UNSUB", "UNSUBSCRIBE", "STOP"].includes(parts[0])) {
+    action = "unsub";
+    categoryText = parts.slice(1).join(",");
+  } else if (["SUB", "SUBSCRIBE", "START"].includes(parts[parts.length - 1])) {
+    action = "sub";
+    categoryText = parts.slice(0, -1).join(",");
+  } else if (["UNSUB", "UNSUBSCRIBE", "STOP"].includes(parts[parts.length - 1])) {
+    action = "unsub";
+    categoryText = parts.slice(0, -1).join(",");
+  }
+  if (!action) return { action: "help", categories: [] };
+  const categories = normalizeCategories(categoryText || "all");
+  return { action, categories: categories.length ? categories : ["all"] };
+}
+
+function updateEndpointSubscription(preferences, endpoint, action, categories) {
+  const prefs = normalizePreferences(preferences);
+  const sipPrefs = prefs.channels.sip;
+  const item = sipPrefs.endpoints[String(endpoint)] || {};
+  const current = new Set(normalizeCategories(item.categories || []));
+  const muted = new Set(normalizeCategories(item.mutedCategories || []));
+  const requested = normalizeCategories(categories);
+  if (action === "sub") {
+    if (requested.includes("all")) muted.clear();
+    for (const category of requested) {
+      current.add(category);
+      muted.delete(category);
+    }
+  } else if (action === "unsub") {
+    if (requested.includes("all")) {
+      current.clear();
+      muted.clear();
+      muted.add("all");
+    } else {
+      for (const category of requested) {
+        current.delete(category);
+        muted.add(category);
+      }
+    }
+  }
+  item.categories = [...current].sort();
+  item.mutedCategories = [...muted].sort();
+  sipPrefs.endpoints[String(endpoint)] = item;
+
+  const cameraSubscribers = new Set(Array.isArray(prefs.cameraSubscribers) ? prefs.cameraSubscribers.map(String) : []);
+  if (item.categories.includes("all") || item.categories.includes("camera")) cameraSubscribers.add(String(endpoint));
+  else cameraSubscribers.delete(String(endpoint));
+  prefs.cameraSubscribers = [...cameraSubscribers].sort();
+  prefs.cameraNotifications = prefs.cameraSubscribers.length > 0;
+  prefs.cameraNotificationsUpdatedAt = new Date().toISOString();
+  prefs.cameraNotificationsUpdatedBy = endpoint;
+  return prefs;
+}
+
+async function handleMessageEvent(from, body) {
+  const endpoint = normalizeCommandEndpoint(endpointFromIdentity(from));
+  appendCommandLog({ direction: "inbound", from, endpoint, body: String(body || "") });
+  if (!endpoint) {
+    appendCommandLog({ direction: "result", ok: false, error: "could_not_detect_sender_extension", from, body: String(body || "") });
+    return { ok: false, error: "could_not_detect_sender_extension" };
+  }
+  const command = String(body || "").trim().toUpperCase();
+  const subscribers = loadSubscribers();
+  const preferences = loadPreferences();
+  const parsed = parseSubscriptionCommand(command);
+  if (parsed.action === "status") {
+    await sendSipMessage(endpoint, commandStatus(endpoint, preferences));
+    appendCommandLog({ direction: "result", ok: true, endpoint, command: "STATUS" });
+    return { ok: true, command: "STATUS" };
+  }
+  if (parsed.action === "sub" || parsed.action === "unsub") {
+    const nextPreferences = updateEndpointSubscription(preferences, endpoint, parsed.action, parsed.categories);
+    savePreferences(nextPreferences);
+    const text = commandStatus(endpoint, nextPreferences);
+    await sendSipMessage(endpoint, `${parsed.action === "sub" ? "Subscribed" : "Unsubscribed"} ${parsed.categories.join(", ")}.\n${text}`);
+    appendCommandLog({ direction: "result", ok: true, endpoint, command: parsed.action.toUpperCase(), categories: parsed.categories });
+    return { ok: true, command: parsed.action.toUpperCase(), categories: parsed.categories };
+  }
+  if (["SUB", "SUBSCRIBE", "START"].includes(command)) {
+    subscribers.add(endpoint);
+    saveSubscribers(subscribers);
+    await sendSipMessage(endpoint, `Subscribed to n8n automation alerts for ${config.office}.`);
+    appendCommandLog({ direction: "result", ok: true, endpoint, command: "SUB" });
+    return { ok: true, command: "SUB" };
+  }
+  if (["UNSUB", "UNSUBSCRIBE", "STOP"].includes(command)) {
+    subscribers.delete(endpoint);
+    saveSubscribers(subscribers);
+    await sendSipMessage(endpoint, `Unsubscribed from n8n automation alerts for ${config.office}.`);
+    appendCommandLog({ direction: "result", ok: true, endpoint, command: "UNSUB" });
+    return { ok: true, command: "UNSUB" };
+  }
+  await sendSipMessage(endpoint, commandHelp());
+  appendCommandLog({ direction: "result", ok: true, endpoint, command: "HELP" });
+  return { ok: true, command: "HELP" };
+}
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", chunk => chunks.push(chunk));
+    req.on("end", () => {
+      try {
+        const text = Buffer.concat(chunks).toString("utf8");
+        resolve(text ? JSON.parse(text) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = Buffer.from(JSON.stringify(payload));
+  res.writeHead(statusCode, { "content-type": "application/json", "content-length": body.length });
+  res.end(body);
+}
+
+function authorized(req) {
+  if (!config.apiToken) return true;
+  return req.headers.authorization === `Bearer ${config.apiToken}` || req.headers["x-api-token"] === config.apiToken;
+}
+
+async function serve() {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url, `http://${config.httpHost}:${config.httpPort}`);
+      if (req.method === "GET" && url.pathname === "/health") {
+        sendJson(res, 200, { ok: true, office: config.office, defaultEndpointCount: config.defaultExtensions.length, subscriberCount: loadSubscribers().size });
+        return;
+      }
+      if (!authorized(req)) {
+        sendJson(res, 401, { ok: false, error: "unauthorized" });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/v1/notify") {
+        sendJson(res, 200, await notify(await readJson(req)));
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/v1/preferences") {
+        sendJson(res, 200, { ok: true, office: config.office, preferences: loadPreferences(), subscribers: [...loadSubscribers()].sort(), categories: knownCategories });
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/v1/preferences") {
+        sendJson(res, 200, applyPreferenceUpdate(await readJson(req)));
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/v1/route") {
+        sendJson(res, 200, routeDecision(await readJson(req)));
+        return;
+      }
+      sendJson(res, 404, { ok: false, error: "not_found" });
+    } catch (error) {
+      sendJson(res, 400, { ok: false, error: error.message });
+    }
+  });
+  server.listen(config.httpPort, config.httpHost, () => {
+    console.log(`${new Date().toISOString()} office automation SIP notifier listening on ${config.httpHost}:${config.httpPort}`);
+  });
+}
+
+async function main() {
+  const mode = process.argv[2] || "serve";
+  if (mode === "check-config") {
+    validateConfig();
+    console.log(JSON.stringify({ ok: true }));
+    return;
+  }
+  validateConfig();
+  if (mode === "serve") return serve();
+  if (mode === "message-event") {
+    const result = await handleMessageEvent(decodeArg(process.argv[3]), decodeArg(process.argv[5]));
+    console.log(JSON.stringify(result));
+    return;
+  }
+  if (mode === "forward-message") {
+    const result = await forwardMessageToRemoteN8n(process.argv[3], decodeArg(process.argv[4]), decodeArg(process.argv[6]));
+    console.log(JSON.stringify(result));
+    return;
+  }
+  if (mode === "send") {
+    const payload = JSON.parse(process.argv[3] || "{}");
+    console.log(JSON.stringify(await notify(payload)));
+    return;
+  }
+  throw new Error("Usage: office-automation-sip-notifier.cjs [check-config|serve|message-event <from64> <to64> <body64>|forward-message <remote-endpoint> <from64> <to64> <body64>|send <json>]");
+}
+
+module.exports = {
+  categoryMatches,
+  channelFlagEnabled,
+  commandLogRecord,
+  endpointAllowed,
+  eventCategories,
+  explicitRequestedChannels,
+  normalizeChannel,
+  notify,
+  payloadRequestsChannel,
+  routeDecision,
+  validateConfig,
+};
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exit(1);
+  });
+}

--- a/ops/office-automation/n8n/normalize-office-event.code.js
+++ b/ops/office-automation/n8n/normalize-office-event.code.js
@@ -1,0 +1,287 @@
+const inputJson = $input.first().json;
+const body = inputJson.body || {};
+const query = inputJson.query || {};
+const headers = inputJson.headers || {};
+const hostMap = {};
+
+function first(...values) {
+  for (const value of values) {
+    if (value !== undefined && value !== null && String(value).trim() !== '') return String(value).trim();
+  }
+  return '';
+}
+
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function displayValue(value) {
+  if (value === undefined || value === null || value === '') return '';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (Array.isArray(value)) return `[${value.length} item${value.length === 1 ? '' : 's'}]`;
+  if (typeof value === 'object') return JSON.stringify(value).slice(0, 120);
+  return String(value).replace(/\s+/g, ' ').trim().slice(0, 160);
+}
+
+function redactText(value) {
+  return String(value || '')
+    .replace(/(bearer\s+)[A-Za-z0-9._~+/-]+/gi, '$1***')
+    .replace(/((?:secret|token|password|authorization|api[_-]?key)=)[^\s&]+/gi, '$1***');
+}
+
+function sanitizeForAudit(value, depth = 0) {
+  if (depth > 6) return '[truncated]';
+  if (Array.isArray(value)) return value.slice(0, 100).map(item => sanitizeForAudit(item, depth + 1));
+  if (!isPlainObject(value)) return typeof value === 'string' ? redactText(value) : value;
+  const out = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (/(?:authorization|token|secret|password|api[_-]?key|credential|chat[_-]?id|phone|mobile|destination|extension)/i.test(key)) {
+      out[key] = '[redacted]';
+    } else {
+      out[key] = sanitizeForAudit(item, depth + 1);
+    }
+  }
+  return out;
+}
+
+function pickFields(source, keys) {
+  const out = {};
+  if (!isPlainObject(source)) return out;
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      const value = displayValue(source[key]);
+      if (value !== '') out[key] = value;
+    }
+  }
+  return out;
+}
+
+function formatFieldList(fields, separator = ', ') {
+  return Object.entries(fields).map(([key, value]) => `${key}=${value}`).join(separator);
+}
+
+function objectSnapshotKey(eventType, data) {
+  const type = first(data.type, eventType.split('.')[0], 'object');
+  const id = first(data.id, data.product_id, data.order_id, data.user_id, data.sku, data.code, data.name, data.title);
+  return id ? `${type}:${id}` : '';
+}
+
+function objectLabel(eventType, data) {
+  const kind = first(data.type, eventType.split('.')[0], 'Object').replaceAll('_', ' ');
+  const name = first(data.name, data.title, data.woo_name, data.display_name, data.login);
+  const sku = first(data.sku, data.patris_product_code, data.product_code, data.code);
+  const id = first(data.id, data.product_id, data.order_id, data.user_id);
+  const parts = [];
+  if (name) parts.push(name);
+  if (sku) parts.push(`SKU ${sku}`);
+  if (id) parts.push(`ID ${id}`);
+  return `${kind.charAt(0).toUpperCase()}${kind.slice(1)}${parts.length ? `: ${parts.join(' / ')}` : ''}`;
+}
+
+function summarizeObjectEvent(eventType, data) {
+  if (!isPlainObject(data)) return null;
+
+  const trackedKeys = [
+    'id', 'product_id', 'type', 'name', 'title', 'sku', 'status',
+    'regular_price', 'sale_price', 'price', 'min_price', 'max_price',
+    'stock_quantity', 'stock_status', 'manage_stock', 'weight',
+    'patris_product_code', 'patris_name', 'patris_foreign_currency',
+    'patris_foreign_price', 'patris_total_stock', 'patris_minimum_stock',
+    'patris_final_price', 'patris_updated_at', 'import_freight_method_id',
+    'price_per_kg_cny', 'enabled', 'old_status', 'new_status',
+    'number', 'total', 'currency', 'payment_method',
+    'login', 'email', 'display_name',
+  ];
+  const snapshot = pickFields(data, trackedKeys);
+  const label = objectLabel(eventType, data);
+  const actionText = eventType.split('.').slice(1).join(' ') || first(data.status, 'updated');
+  const lines = [label];
+  const changes = Array.isArray(data.changed_fields)
+    ? data.changed_fields
+        .filter(item => isPlainObject(item) && first(item.field))
+        .map(item => ({
+          field: first(item.field),
+          old: displayValue(item.old),
+          new: displayValue(item.new),
+        }))
+    : [];
+  const key = objectSnapshotKey(eventType, data);
+
+  try {
+    const store = typeof $getWorkflowStaticData === 'function' ? $getWorkflowStaticData('global') : {};
+    store.objectSnapshots = isPlainObject(store.objectSnapshots) ? store.objectSnapshots : {};
+    const previous = key && isPlainObject(store.objectSnapshots[key]) ? store.objectSnapshots[key] : null;
+    if (previous && !changes.length) {
+      for (const [field, value] of Object.entries(snapshot)) {
+        if (previous[field] !== undefined && previous[field] !== value) {
+          changes.push({ field, old: previous[field], new: value });
+        }
+      }
+    }
+    if (key && !eventType.endsWith('.deleted')) {
+      store.objectSnapshots[key] = snapshot;
+      const keys = Object.keys(store.objectSnapshots).sort();
+      while (keys.length > 500) delete store.objectSnapshots[keys.shift()];
+    } else if (key && eventType.endsWith('.deleted')) {
+      delete store.objectSnapshots[key];
+    }
+  } catch (error) {
+    // Static data is best-effort; the notification still carries current values.
+  }
+
+  if (changes.length) {
+    lines.push(`Changed: ${changes.slice(0, 8).map(item => `${item.field}: ${item.old} -> ${item.new}`).join('; ')}`);
+    if (changes.length > 8) lines.push(`Changed fields truncated: ${changes.length - 8} more.`);
+  } else if (Object.keys(snapshot).length) {
+    lines.push(`Current: ${formatFieldList(snapshot)}`);
+  }
+
+  return {
+    title: `${label} ${actionText}`.slice(0, 180),
+    summary: lines.join('\n'),
+    detailLines: lines,
+    object: { label, key },
+    changes,
+    current_values: snapshot,
+  };
+}
+
+const eventType = first(body.event_type, body.event, body.type, query.event_type, query.event, 'automation_event');
+const status = first(body.status, body.state, body.value, query.status, query.state).toLowerCase();
+const data = isPlainObject(body.data) ? body.data : {};
+const ip = first(body.ip, body.host, body.address, query.ip, query.host);
+const mac = first(body.mac, body['mac-address'], body.mac_address, query.mac);
+const hostname = first(body.hostname, body.host_name, body.name, query.hostname, query.name, hostMap[ip]?.name);
+const person = first(body.person, hostMap[ip]?.person);
+const source = first(body.source, body.origin, body.event ? 'wordpress' : 'routeros');
+const router = first(body.router, body.router_name, headers['x-routeros-identity']);
+const ssid = first(body.ssid, body.interface, body.radio, query.ssid);
+const signal = first(body.signal, body.signal_strength, body['signal-strength']);
+const camera = first(body.camera, body.channel, body.device, query.camera);
+const brightness = first(body.brightness, body.led_brightness, body.intensity);
+const mode = first(body.mode, body.led_mode);
+const nowIso = new Date().toISOString();
+const localTime = new Date().toLocaleString('fa-IR', { timeZone: 'Asia/Tehran' });
+
+function parseRelayTime(value) {
+  const match = String(value || '').match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/);
+  if (!match) return null;
+  const [, year, month, day, hour, minute, second] = match;
+  return new Date(Date.UTC(year, Number(month) - 1, day, hour, minute, second));
+}
+
+const relayId = first(body.relay_id, headers['x-office-automation-relay-id']);
+const relayTime = parseRelayTime(relayId);
+const ingressAgeSeconds = relayTime ? Math.floor((Date.now() - relayTime.getTime()) / 1000) : null;
+const maxRelayAgeSeconds = 15 * 60;
+if (ingressAgeSeconds !== null && ingressAgeSeconds > maxRelayAgeSeconds) return [];
+
+
+let title = 'Office automation event';
+let action = status || eventType;
+let summary = '';
+let tags = 'bell,computer';
+let objectSummary = null;
+
+if (eventType.includes('netwatch') || eventType.includes('host')) {
+  const isUp = ['up', 'available', 'online', '1', 'true'].includes(status);
+  const isDown = ['down', 'unavailable', 'offline', '0', 'false'].includes(status);
+  action = isUp ? 'arrived/online' : isDown ? 'left/offline' : action;
+  title = `${hostname || ip || 'Host'} ${isUp ? 'online' : isDown ? 'offline' : action}`;
+  tags = isUp ? 'green_circle,computer' : 'red_circle,computer';
+  summary = `${hostname || 'Host'} ${ip ? `(${ip})` : ''} is ${isUp ? 'online' : isDown ? 'offline' : status || 'updated'}.`;
+} else if (eventType.includes('wifi') || eventType.includes('registration')) {
+  const joined = ['up', 'connected', 'registered', 'join', 'joined'].includes(status);
+  const left = ['down', 'disconnected', 'deregistered', 'leave', 'left'].includes(status);
+  action = joined ? 'phone/device joined Wi-Fi' : left ? 'phone/device left Wi-Fi' : action;
+  title = `${hostname || mac || 'Wireless device'} ${joined ? 'joined Wi-Fi' : left ? 'left Wi-Fi' : 'Wi-Fi update'}`;
+  tags = joined ? 'green_circle,wifi' : left ? 'red_circle,wifi' : 'wifi';
+  summary = `${hostname || 'Wireless device'} ${mac ? `(${mac})` : ''} ${joined ? 'joined' : left ? 'left' : 'updated on'} Wi-Fi${ssid ? ` via ${ssid}` : ''}.`;
+} else if (eventType.includes('dahua') || eventType.includes('camera') || eventType.includes('motion') || eventType.includes('led')) {
+  title = `${camera || 'Camera'} ${eventType.replaceAll('_', ' ')}`;
+  tags = eventType.includes('motion') ? 'warning,camera' : 'bulb,camera';
+  summary = `${camera || 'Camera'} event: ${eventType}${mode ? `, mode ${mode}` : ''}${brightness ? `, brightness ${brightness}` : ''}.`;
+} else if (isPlainObject(data) && Object.keys(data).length) {
+  objectSummary = summarizeObjectEvent(eventType, data);
+  title = first(body.title, objectSummary?.title, eventType.replaceAll('.', ' '));
+  summary = first(body.message, body.text, objectSummary?.summary, `${eventType} ${status}`.trim());
+  tags = eventType.includes('product') ? 'shopping_cart,package' : eventType.includes('order') ? 'receipt' : 'bell';
+} else {
+  title = first(body.title, 'Office automation event');
+  summary = first(body.message, body.text, `${eventType} ${status}`.trim());
+}
+
+title = redactText(title);
+summary = redactText(summary);
+
+const actor = person ? `\nPerson: ${person}` : '';
+const objectDetailLines = objectSummary?.detailLines?.length ? objectSummary.detailLines : [];
+const details = [
+  `<b>${title}</b>`,
+  '',
+  `<b>Office:</b> Digitalogic`,
+  `<b>Time:</b> ${localTime}`,
+  `<b>Event:</b> <code>${eventType}</code>`,
+  ip ? `<b>IP:</b> <code>${ip}</code>` : '',
+  mac ? `<b>MAC:</b> <code>${mac}</code>` : '',
+  hostname ? `<b>Device:</b> ${hostname}` : '',
+  person ? `<b>Person:</b> ${person}` : '',
+  router ? `<b>Router:</b> ${router}` : '',
+  ssid ? `<b>Wi-Fi:</b> ${ssid}` : '',
+  signal ? `<b>Signal:</b> ${signal}` : '',
+  camera ? `<b>Camera:</b> ${camera}` : '',
+  ...objectDetailLines.map(line => `<b>Object:</b> ${line}`),
+  '',
+  `<blockquote>${summary}</blockquote>`,
+].filter(Boolean).join('\n');
+
+const eventRecord = {
+  timestamp: nowIso,
+  local_time: localTime,
+  office: 'Digitalogic',
+  event_type: eventType,
+  status,
+  action,
+  ip,
+  mac,
+  hostname,
+  person,
+  source,
+  router,
+  ssid,
+  signal,
+  camera,
+  brightness,
+  mode,
+  relay_id: relayId,
+  ingress_age_seconds: ingressAgeSeconds,
+  raw: sanitizeForAudit(body),
+};
+
+return [{
+  json: {
+    ...sanitizeForAudit(inputJson),
+    eventRecord,
+    telegramText: details,
+    ntfyTitle: title,
+    ntfyTags: tags,
+    ntfyText: `${title}\nDigitalogic\n${localTime}\n${summary}${actor}`,
+    eventJsonLine: JSON.stringify(eventRecord) + '\n',
+    redisMessage: JSON.stringify(eventRecord),
+    sipPayload: JSON.stringify({
+      title,
+      status: status || eventType.split('.').slice(1).join('.'),
+      message: summary,
+      reason: redactText(first(body.reason, body.cause, body.hint, body.error_description, body.error_message, body.error)),
+      severity: first(body.severity, body.level, eventType.includes('failure') || eventType.includes('error') ? 'error' : 'info'),
+      event_type: eventType,
+      channels: body.channels,
+      notify_channels: body.notify_channels,
+      object: objectSummary?.object,
+      details: objectDetailLines,
+      changes: objectSummary?.changes || [],
+      current_values: objectSummary?.current_values || {},
+    }),
+  },
+  pairedItem: { item: 0 },
+}];

--- a/ops/office-automation/n8n/office-automation-events.template.json
+++ b/ops/office-automation/n8n/office-automation-events.template.json
@@ -1,0 +1,443 @@
+{
+  "id": "__N8N_WORKFLOW_ID__",
+  "name": "Office - Automation Events",
+  "description": "Secret-free source template. Render credentials, webhook paths, destinations, and endpoint URLs outside the repository before an owner-approved import.",
+  "active": false,
+  "isArchived": false,
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "__OFFICE_AUTOMATION_WEBHOOK_PATH__",
+        "responseMode": "onReceived",
+        "options": {
+          "responseCode": 202
+        },
+        "responseData": "firstEntryJson"
+      },
+      "id": "office-automation-events-webhook",
+      "name": "Office Automation Events Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        0,
+        0
+      ],
+      "webhookId": "__OFFICE_AUTOMATION_WEBHOOK_ID__"
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "__NORMALIZE_OFFICE_EVENT_CODE__"
+      },
+      "id": "normalize-office-automation-event",
+      "name": "Normalize Office Automation Event",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        260,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "toText",
+        "sourceProperty": "eventJsonLine",
+        "binaryPropertyName": "eventLogFile",
+        "options": {}
+      },
+      "id": "convert-event-log-to-file",
+      "name": "Convert Event Log to File",
+      "type": "n8n-nodes-base.convertToFile",
+      "typeVersion": 1.1,
+      "position": [
+        520,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "write",
+        "fileName": "__LOCAL_EVENT_LOG_FILE__",
+        "dataPropertyName": "=eventLogFile",
+        "options": {
+          "append": true
+        }
+      },
+      "id": "append-local-event-log",
+      "name": "Append Local Event Log",
+      "type": "n8n-nodes-base.readWriteFile",
+      "typeVersion": 1.1,
+      "position": [
+        780,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "publish",
+        "channel": "__REDIS_CHANNEL__",
+        "messageData": "={{ $json.redisMessage }}"
+      },
+      "id": "publish-event-to-redis",
+      "name": "Publish Event to Redis",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [
+        520,
+        120
+      ],
+      "credentials": {
+        "redis": {
+          "id": "__REDIS_CREDENTIAL_ID__",
+          "name": "__REDIS_CREDENTIAL_NAME__"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "chatId": "__TELEGRAM_CHAT_ID__",
+        "text": "={{ $('Normalize Office Automation Event').item.json.telegramText }}",
+        "additionalFields": {
+          "parse_mode": "HTML",
+          "appendAttribution": false,
+          "disable_web_page_preview": true
+        }
+      },
+      "id": "notify-telegram-automation-group",
+      "name": "Notify Telegram Automation Group",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        1560,
+        -260
+      ],
+      "credentials": {
+        "telegramApi": {
+          "id": "__TELEGRAM_CREDENTIAL_ID__",
+          "name": "__TELEGRAM_CREDENTIAL_NAME__"
+        }
+      },
+      "onError": "continueRegularOutput",
+      "continueOnFail": true,
+      "retryOnFail": false,
+      "maxTries": 1,
+      "waitBetweenTries": 0
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "__NTFY_URL__",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Title",
+              "value": "={{ $('Normalize Office Automation Event').item.json.ntfyTitle }}"
+            },
+            {
+              "name": "Tags",
+              "value": "={{ $('Normalize Office Automation Event').item.json.ntfyTags }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "contentType": "raw",
+        "rawContentType": "text/plain",
+        "body": "={{ $('Normalize Office Automation Event').item.json.ntfyText }}",
+        "options": {
+          "timeout": 3000
+        }
+      },
+      "id": "notify-ntfy-office-topic",
+      "name": "Notify ntfy Office Topic",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1560,
+        80
+      ],
+      "onError": "continueRegularOutput",
+      "continueOnFail": true,
+      "retryOnFail": false,
+      "maxTries": 1,
+      "waitBetweenTries": 0
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "__SIP_NOTIFY_URL__",
+        "sendHeaders": true,
+        "sendBody": true,
+        "contentType": "raw",
+        "rawContentType": "application/json",
+        "body": "={{ $('Normalize Office Automation Event').item.json.sipPayload }}",
+        "options": {
+          "timeout": 3000
+        },
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth"
+      },
+      "id": "notify-sip-extensions",
+      "name": "Notify SIP Extensions",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1560,
+        -90
+      ],
+      "onError": "continueRegularOutput",
+      "continueOnFail": true,
+      "retryOnFail": false,
+      "maxTries": 1,
+      "waitBetweenTries": 0,
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "__SIP_ROUTING_CREDENTIAL_ID__",
+          "name": "__SIP_ROUTING_CREDENTIAL_NAME__"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "__SHEETS_WEBHOOK_URL__",
+        "sendBody": true,
+        "contentType": "raw",
+        "rawContentType": "application/json",
+        "body": "={{ JSON.stringify({ eventRecord: $('Normalize Office Automation Event').item.json.eventRecord }) }}",
+        "options": {
+          "timeout": 3000
+        }
+      },
+      "id": "append-event-to-central-google-sheet",
+      "name": "Append Event to Central Google Sheet",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        520,
+        300
+      ],
+      "onError": "continueRegularOutput",
+      "continueOnFail": true,
+      "retryOnFail": false,
+      "maxTries": 1,
+      "waitBetweenTries": 0
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "__SIP_ROUTE_URL__",
+        "sendHeaders": true,
+        "sendBody": true,
+        "contentType": "raw",
+        "rawContentType": "application/json",
+        "body": "={{ $('Normalize Office Automation Event').item.json.sipPayload }}",
+        "options": {
+          "timeout": 2000
+        },
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth"
+      },
+      "id": "get-notification-routing-policy",
+      "name": "Get Notification Routing Policy",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1040,
+        -120
+      ],
+      "onError": "continueRegularOutput",
+      "continueOnFail": true,
+      "retryOnFail": false,
+      "maxTries": 1,
+      "waitBetweenTries": 0,
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "__SIP_ROUTING_CREDENTIAL_ID__",
+          "name": "__SIP_ROUTING_CREDENTIAL_NAME__"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const route = $('Get Notification Routing Policy').item.json;\nreturn route.channels?.telegram ? $input.all() : [];"
+      },
+      "id": "gate-telegram-notification",
+      "name": "Gate Telegram Notification",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1300,
+        -260
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const route = $('Get Notification Routing Policy').item.json;\nreturn route.channels?.ntfy ? $input.all() : [];"
+      },
+      "id": "gate-ntfy-notification",
+      "name": "Gate ntfy Notification",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1300,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const route = $('Get Notification Routing Policy').item.json;\nreturn route.channels?.sip ? $input.all() : [];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1300,
+        -90
+      ],
+      "id": "00000000-0000-4000-8000-000000000088",
+      "name": "Gate SIP Notification"
+    }
+  ],
+  "connections": {
+    "Office Automation Events Webhook": {
+      "main": [
+        [
+          {
+            "node": "Normalize Office Automation Event",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Office Automation Event": {
+      "main": [
+        [
+          {
+            "node": "Convert Event Log to File",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Publish Event to Redis",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Append Event to Central Google Sheet",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Convert Event Log to File": {
+      "main": [
+        [
+          {
+            "node": "Append Local Event Log",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Append Local Event Log": {
+      "main": [
+        [
+          {
+            "node": "Get Notification Routing Policy",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Notify Telegram Automation Group": {
+      "main": [
+        []
+      ]
+    },
+    "Notify ntfy Office Topic": {
+      "main": [
+        []
+      ]
+    },
+    "Notify SIP Extensions": {
+      "main": [
+        []
+      ]
+    },
+    "Append Event to Central Google Sheet": {
+      "main": [
+        []
+      ]
+    },
+    "Get Notification Routing Policy": {
+      "main": [
+        [
+          {
+            "node": "Gate Telegram Notification",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Gate ntfy Notification",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Gate SIP Notification",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Gate Telegram Notification": {
+      "main": [
+        [
+          {
+            "node": "Notify Telegram Automation Group",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Gate ntfy Notification": {
+      "main": [
+        [
+          {
+            "node": "Notify ntfy Office Topic",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Gate SIP Notification": {
+      "main": [
+        [
+          {
+            "node": "Notify SIP Extensions",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true,
+    "saveDataSuccessExecution": "none",
+    "saveDataErrorExecution": "all",
+    "errorWorkflow": "__ERROR_WORKFLOW_ID__",
+    "executionTimeout": 60
+  },
+  "staticData": null,
+  "pinData": {},
+  "tags": []
+}

--- a/ops/office-automation/package.json
+++ b/ops/office-automation/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "digitalogic-office-automation-operations",
+	"version": "1.0.0",
+	"private": true,
+	"description": "Secret-free watchdog, notification-routing, n8n workflow, and deployment assets.",
+	"scripts": {
+		"check": "node --check lib/apache-site-watchdog-to-n8n.cjs && node --check lib/office-automation-sip-notifier.cjs && node --check scripts/render-n8n-workflow.cjs",
+		"test": "node --test test/*.test.cjs"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	}
+}

--- a/ops/office-automation/scripts/deploy.sh
+++ b/ops/office-automation/scripts/deploy.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source_root="$(cd -- "$script_dir/.." && pwd)"
+install_root="${OFFICE_AUTOMATION_ROOT:-/opt/office-automation}"
+sip_env="${OFFICE_AUTOMATION_SIP_ENV_FILE:-/etc/office-automation-sip-notifier.env}"
+watchdog_env="${APACHE_SITE_WATCHDOG_ENV_FILE:-/etc/apache-site-watchdog.env}"
+sip_service="${OFFICE_AUTOMATION_SIP_SERVICE:-office-automation-sip-notifier.service}"
+watchdog_service="${APACHE_SITE_WATCHDOG_SERVICE:-apache-site-watchdog.service}"
+
+usage() {
+	printf 'Usage: %s [--plan|--apply] <release-id>\n' "$0" >&2
+}
+
+mode="${1:---plan}"
+release_id="${2:-}"
+if [[ "$mode" != "--plan" && "$mode" != "--apply" ]]; then
+	usage
+	exit 2
+fi
+if [[ -z "$release_id" || ! "$release_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
+	usage
+	exit 2
+fi
+if [[ "$install_root" != /* || "$install_root" == / ]]; then
+	printf 'OFFICE_AUTOMATION_ROOT must be an absolute non-root path.\n' >&2
+	exit 2
+fi
+
+for file in \
+	lib/office-automation-sip-notifier.cjs \
+	lib/apache-site-watchdog-to-n8n.cjs; do
+	[[ -f "$source_root/$file" ]] || { printf 'Missing release source: %s\n' "$file" >&2; exit 1; }
+	node --check "$source_root/$file"
+done
+
+release_dir="$install_root/releases/$release_id"
+printf 'Release plan: install reviewed scripts as %s and atomically switch %s/current.\n' "$release_id" "$install_root"
+printf 'The n8n workflow is not imported or activated by this script.\n'
+if [[ "$mode" == "--plan" ]]; then
+	exit 0
+fi
+
+if [[ -e "$release_dir" ]]; then
+	printf 'Release already exists; refusing to overwrite: %s\n' "$release_dir" >&2
+	exit 1
+fi
+
+install -d -o root -g root -m 0755 "$install_root/releases" "$release_dir/lib" "$install_root/backups"
+install -o root -g root -m 0755 "$source_root/lib/office-automation-sip-notifier.cjs" "$release_dir/lib/office-automation-sip-notifier.cjs"
+install -o root -g root -m 0755 "$source_root/lib/apache-site-watchdog-to-n8n.cjs" "$release_dir/lib/apache-site-watchdog-to-n8n.cjs"
+(
+	cd -- "$release_dir"
+	sha256sum lib/office-automation-sip-notifier.cjs lib/apache-site-watchdog-to-n8n.cjs > manifest.sha256
+)
+chmod 0644 "$release_dir/manifest.sha256"
+
+OFFICE_AUTOMATION_SIP_ENV="$sip_env" node "$release_dir/lib/office-automation-sip-notifier.cjs" check-config >/dev/null
+APACHE_SITE_WATCHDOG_ENV="$watchdog_env" node "$release_dir/lib/apache-site-watchdog-to-n8n.cjs" check-config >/dev/null
+
+backup_dir="$install_root/backups/$release_id"
+install -d -o root -g root -m 0700 "$backup_dir"
+for name in office-automation-sip-notifier.cjs apache-site-watchdog-to-n8n.cjs; do
+	legacy="$install_root/$name"
+	if [[ -e "$legacy" && ! -L "$legacy" ]]; then
+		mv -- "$legacy" "$backup_dir/$name"
+		chmod 0700 "$backup_dir/$name"
+	fi
+done
+
+previous_target="$(readlink "$install_root/current" 2>/dev/null || true)"
+temporary_link="$install_root/.current-$release_id-$$"
+
+restore_previous() {
+	set +e
+	rm -f -- "$temporary_link"
+	if [[ -n "$previous_target" ]]; then
+		ln -s "$previous_target" "$temporary_link"
+		mv -Tf -- "$temporary_link" "$install_root/current"
+	else
+		rm -f -- "$install_root/current"
+	fi
+	for name in office-automation-sip-notifier.cjs apache-site-watchdog-to-n8n.cjs; do
+		stable="$install_root/$name"
+		if [[ -f "$backup_dir/$name" ]]; then
+			rm -f -- "$stable"
+			mv -- "$backup_dir/$name" "$stable"
+		elif [[ -n "$previous_target" ]]; then
+			ln -sfn "current/lib/$name" "$stable"
+		else
+			rm -f -- "$stable"
+		fi
+	done
+	systemctl restart "$sip_service" "$watchdog_service" || true
+}
+
+rollback_armed=true
+on_deploy_error() {
+	status=$?
+	trap - ERR
+	if [[ "$rollback_armed" == true ]]; then
+		printf 'Deployment failed before verification; restoring the previous script release.\n' >&2
+		restore_previous
+	fi
+	exit "$status"
+}
+trap on_deploy_error ERR
+
+ln -s "releases/$release_id" "$temporary_link"
+mv -Tf -- "$temporary_link" "$install_root/current"
+ln -sfn current/lib/office-automation-sip-notifier.cjs "$install_root/office-automation-sip-notifier.cjs"
+ln -sfn current/lib/apache-site-watchdog-to-n8n.cjs "$install_root/apache-site-watchdog-to-n8n.cjs"
+
+if ! systemctl restart "$sip_service" "$watchdog_service" \
+	|| ! systemctl is-active --quiet "$sip_service" \
+	|| ! systemctl is-active --quiet "$watchdog_service"; then
+	printf 'Service verification failed; restoring the previous script release.\n' >&2
+	rollback_armed=false
+	trap - ERR
+	restore_previous
+	exit 1
+fi
+
+rollback_armed=false
+trap - ERR
+printf 'Installed office-automation release %s. Validate the dry-run routing probes before any separate n8n activation.\n' "$release_id"

--- a/ops/office-automation/scripts/render-n8n-workflow.cjs
+++ b/ops/office-automation/scripts/render-n8n-workflow.cjs
@@ -1,0 +1,145 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const templatePath = path.join(root, 'n8n', 'office-automation-events.template.json');
+const normalizerPath = path.join(root, 'n8n', 'normalize-office-event.code.js');
+
+const environmentByPlaceholder = Object.freeze({
+	__ERROR_WORKFLOW_ID__: 'OFFICE_N8N_ERROR_WORKFLOW_ID',
+	__LOCAL_EVENT_LOG_FILE__: 'OFFICE_N8N_LOCAL_EVENT_LOG_FILE',
+	__N8N_WORKFLOW_ID__: 'OFFICE_N8N_WORKFLOW_ID',
+	__NTFY_URL__: 'OFFICE_N8N_NTFY_URL',
+	__OFFICE_AUTOMATION_WEBHOOK_ID__: 'OFFICE_N8N_WEBHOOK_ID',
+	__OFFICE_AUTOMATION_WEBHOOK_PATH__: 'OFFICE_N8N_WEBHOOK_PATH',
+	__REDIS_CHANNEL__: 'OFFICE_N8N_REDIS_CHANNEL',
+	__REDIS_CREDENTIAL_ID__: 'OFFICE_N8N_REDIS_CREDENTIAL_ID',
+	__REDIS_CREDENTIAL_NAME__: 'OFFICE_N8N_REDIS_CREDENTIAL_NAME',
+	__SHEETS_WEBHOOK_URL__: 'OFFICE_N8N_SHEETS_WEBHOOK_URL',
+	__SIP_NOTIFY_URL__: 'OFFICE_N8N_SIP_NOTIFY_URL',
+	__SIP_ROUTE_URL__: 'OFFICE_N8N_SIP_ROUTE_URL',
+	__SIP_ROUTING_CREDENTIAL_ID__: 'OFFICE_N8N_SIP_ROUTING_CREDENTIAL_ID',
+	__SIP_ROUTING_CREDENTIAL_NAME__: 'OFFICE_N8N_SIP_ROUTING_CREDENTIAL_NAME',
+	__TELEGRAM_CHAT_ID__: 'OFFICE_N8N_TELEGRAM_CHAT_ID',
+	__TELEGRAM_CREDENTIAL_ID__: 'OFFICE_N8N_TELEGRAM_CREDENTIAL_ID',
+	__TELEGRAM_CREDENTIAL_NAME__: 'OFFICE_N8N_TELEGRAM_CREDENTIAL_NAME',
+});
+
+function requiredValues(environment = process.env) {
+	const missing = [];
+	const values = {};
+	for (const [placeholder, variable] of Object.entries(environmentByPlaceholder)) {
+		const value = String(environment[variable] || '').trim();
+		if (!value) missing.push(variable);
+		values[placeholder] = value;
+	}
+	if (missing.length) throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+	return values;
+}
+
+function replacePlaceholders(value, replacements) {
+	if (Array.isArray(value)) return value.map(item => replacePlaceholders(item, replacements));
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, replacePlaceholders(item, replacements)]));
+	}
+	if (typeof value !== 'string') return value;
+	let rendered = value;
+	for (const [placeholder, replacement] of Object.entries(replacements)) {
+		rendered = rendered.split(placeholder).join(replacement);
+	}
+	return rendered;
+}
+
+function assertUrl(value, label) {
+	let url;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error(`${label} must be a valid URL`);
+	}
+	if (!['http:', 'https:'].includes(url.protocol)) throw new Error(`${label} must use http or https`);
+}
+
+function validateRendered(workflow, serialized) {
+	if (workflow.active !== false) throw new Error('Rendered workflow must remain inactive');
+	const unresolved = [...new Set(serialized.match(/__[A-Z0-9_]+__/g) || [])];
+	if (unresolved.length) throw new Error(`Unresolved workflow placeholders: ${unresolved.join(', ')}`);
+	for (const [field, label] of [
+		[workflow.nodes.find(node => node.name === 'Notify ntfy Office Topic')?.parameters?.url, 'ntfy URL'],
+		[workflow.nodes.find(node => node.name === 'Notify SIP Extensions')?.parameters?.url, 'SIP notify URL'],
+		[workflow.nodes.find(node => node.name === 'Get Notification Routing Policy')?.parameters?.url, 'SIP route URL'],
+		[workflow.nodes.find(node => node.name === 'Append Event to Central Google Sheet')?.parameters?.url, 'Sheets webhook URL'],
+	]) assertUrl(field, label);
+
+	const routeOutputs = workflow.connections?.['Get Notification Routing Policy']?.main?.[0] || [];
+	if (routeOutputs.some(edge => edge.node === 'Notify SIP Extensions')) throw new Error('SIP notify node bypasses its route gate');
+	if (!routeOutputs.some(edge => edge.node === 'Gate SIP Notification')) throw new Error('SIP route gate is not connected');
+	const gateOutputs = workflow.connections?.['Gate SIP Notification']?.main?.[0] || [];
+	if (!gateOutputs.some(edge => edge.node === 'Notify SIP Extensions')) throw new Error('SIP route gate does not reach the notify node');
+	const normalizerCode = workflow.nodes.find(node => node.name === 'Normalize Office Automation Event')?.parameters?.jsCode || '';
+	if (!normalizerCode.includes('channels: body.channels') || !normalizerCode.includes('notify_channels: body.notify_channels')) {
+		throw new Error('Normalized SIP payload does not preserve explicit channel fields');
+	}
+}
+
+function renderWorkflow(environment = process.env) {
+	const template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
+	const replacements = {
+		...requiredValues(environment),
+		__NORMALIZE_OFFICE_EVENT_CODE__: fs.readFileSync(normalizerPath, 'utf8'),
+	};
+	const workflow = replacePlaceholders(template, replacements);
+	const serialized = `${JSON.stringify(workflow, null, 2)}\n`;
+	validateRendered(workflow, serialized);
+	return { workflow, serialized };
+}
+
+function parseArguments(argv) {
+	const args = new Set(argv);
+	const outputIndex = argv.indexOf('--output');
+	return {
+		check: args.has('--check'),
+		force: args.has('--force'),
+		output: outputIndex >= 0 ? argv[outputIndex + 1] : '',
+	};
+}
+
+function outputIsInsideRepository(output) {
+	const relative = path.relative(root, output);
+	return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function main() {
+	const options = parseArguments(process.argv.slice(2));
+	const { serialized } = renderWorkflow();
+	if (options.check) {
+		process.stdout.write('{"ok":true}\n');
+		return;
+	}
+	if (!options.output || !path.isAbsolute(options.output)) throw new Error('--output must be an absolute path outside the repository');
+	if (outputIsInsideRepository(options.output)) throw new Error('Refusing to write rendered workflow inside the repository');
+	fs.mkdirSync(path.dirname(options.output), { recursive: true, mode: 0o700 });
+	fs.writeFileSync(options.output, serialized, { encoding: 'utf8', flag: options.force ? 'w' : 'wx', mode: 0o600 });
+	fs.chmodSync(options.output, 0o600);
+	process.stdout.write('{"ok":true,"written":true}\n');
+}
+
+module.exports = {
+	environmentByPlaceholder,
+	outputIsInsideRepository,
+	renderWorkflow,
+	replacePlaceholders,
+	requiredValues,
+	validateRendered,
+};
+
+if (require.main === module) {
+	try {
+		main();
+	} catch (error) {
+		process.stderr.write(`${error.message}\n`);
+		process.exit(1);
+	}
+}

--- a/ops/office-automation/scripts/rollback.sh
+++ b/ops/office-automation/scripts/rollback.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install_root="${OFFICE_AUTOMATION_ROOT:-/opt/office-automation}"
+sip_env="${OFFICE_AUTOMATION_SIP_ENV_FILE:-/etc/office-automation-sip-notifier.env}"
+watchdog_env="${APACHE_SITE_WATCHDOG_ENV_FILE:-/etc/apache-site-watchdog.env}"
+sip_service="${OFFICE_AUTOMATION_SIP_SERVICE:-office-automation-sip-notifier.service}"
+watchdog_service="${APACHE_SITE_WATCHDOG_SERVICE:-apache-site-watchdog.service}"
+
+usage() {
+	printf 'Usage: %s [--plan|--apply] <existing-release-id>\n' "$0" >&2
+}
+
+mode="${1:---plan}"
+release_id="${2:-}"
+if [[ "$mode" != "--plan" && "$mode" != "--apply" ]]; then
+	usage
+	exit 2
+fi
+if [[ -z "$release_id" || ! "$release_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
+	usage
+	exit 2
+fi
+if [[ "$install_root" != /* || "$install_root" == / ]]; then
+	printf 'OFFICE_AUTOMATION_ROOT must be an absolute non-root path.\n' >&2
+	exit 2
+fi
+
+release_dir="$install_root/releases/$release_id"
+[[ -d "$release_dir" ]] || { printf 'Release does not exist: %s\n' "$release_dir" >&2; exit 1; }
+(
+	cd -- "$release_dir"
+	sha256sum -c manifest.sha256
+)
+OFFICE_AUTOMATION_SIP_ENV="$sip_env" node "$release_dir/lib/office-automation-sip-notifier.cjs" check-config >/dev/null
+APACHE_SITE_WATCHDOG_ENV="$watchdog_env" node "$release_dir/lib/apache-site-watchdog-to-n8n.cjs" check-config >/dev/null
+
+printf 'Rollback plan: atomically switch %s/current to release %s and restart both services.\n' "$install_root" "$release_id"
+printf 'The n8n workflow is not changed by this script; restore its separately exported backup as documented.\n'
+if [[ "$mode" == "--plan" ]]; then
+	exit 0
+fi
+
+previous_target="$(readlink "$install_root/current" 2>/dev/null || true)"
+temporary_link="$install_root/.current-$release_id-$$"
+
+restore_previous() {
+	set +e
+	rm -f -- "$temporary_link"
+	if [[ -n "$previous_target" ]]; then
+		ln -s "$previous_target" "$temporary_link"
+		mv -Tf -- "$temporary_link" "$install_root/current"
+		ln -sfn current/lib/office-automation-sip-notifier.cjs "$install_root/office-automation-sip-notifier.cjs"
+		ln -sfn current/lib/apache-site-watchdog-to-n8n.cjs "$install_root/apache-site-watchdog-to-n8n.cjs"
+	else
+		rm -f -- \
+			"$install_root/current" \
+			"$install_root/office-automation-sip-notifier.cjs" \
+			"$install_root/apache-site-watchdog-to-n8n.cjs"
+	fi
+	systemctl restart "$sip_service" "$watchdog_service" || true
+}
+
+rollback_armed=true
+on_rollback_error() {
+	status=$?
+	trap - ERR
+	if [[ "$rollback_armed" == true ]]; then
+		printf 'Rollback failed before verification; restoring the prior current link.\n' >&2
+		restore_previous
+	fi
+	exit "$status"
+}
+trap on_rollback_error ERR
+
+ln -s "releases/$release_id" "$temporary_link"
+mv -Tf -- "$temporary_link" "$install_root/current"
+ln -sfn current/lib/office-automation-sip-notifier.cjs "$install_root/office-automation-sip-notifier.cjs"
+ln -sfn current/lib/apache-site-watchdog-to-n8n.cjs "$install_root/apache-site-watchdog-to-n8n.cjs"
+
+if ! systemctl restart "$sip_service" "$watchdog_service" \
+	|| ! systemctl is-active --quiet "$sip_service" \
+	|| ! systemctl is-active --quiet "$watchdog_service"; then
+	printf 'Rollback target failed service checks; restoring the prior current link.\n' >&2
+	rollback_armed=false
+	trap - ERR
+	restore_previous
+	exit 1
+fi
+
+rollback_armed=false
+trap - ERR
+printf 'Rolled back office-automation scripts to release %s.\n' "$release_id"

--- a/ops/office-automation/test/assets.test.cjs
+++ b/ops/office-automation/test/assets.test.cjs
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+
+function filesUnder(directory) {
+	return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+		const item = path.join(directory, entry.name);
+		return entry.isDirectory() ? filesUnder(item) : [item];
+	});
+}
+
+test('versioned assets contain placeholders instead of private routing values', () => {
+	const files = filesUnder(root).filter(file => !file.includes(`${path.sep}test${path.sep}`));
+	const content = files.map(file => fs.readFileSync(file, 'utf8')).join('\n');
+
+	assert.doesNotMatch(content, /sip:\d{2,}@/i);
+	assert.doesNotMatch(content, /PJSIP\/\d{2,}@/i);
+	assert.doesNotMatch(content, /\b(?:10\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b/);
+	assert.doesNotMatch(content, /(?<!\d)(?:\+98|0098|98|0)?9\d{9}(?!\d)/);
+	assert.doesNotMatch(content, /[A-Z0-9._%+-]+@(?:gmail|outlook|yahoo)\.[A-Z]{2,}/i);
+	assert.doesNotMatch(content, /https?:\/\/[^\s"']+\/webhook\/[A-Za-z0-9_-]+/i);
+	assert.doesNotMatch(content, /(?:apiToken|amiSecret|chatId)\s*[:=]\s*["'][^_$"'][^"']*["']/i);
+	assert.doesNotMatch(content, /\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{20,}\b/);
+	assert.doesNotMatch(content, /\bAKIA[A-Z0-9]{16}\b/);
+	assert.doesNotMatch(content, /\b\d{6,12}:[A-Za-z0-9_-]{30,}\b/);
+	assert.doesNotMatch(content, /-----BEGIN [A-Z ]*PRIVATE KEY-----/);
+	assert.doesNotMatch(content, /\bBearer\s+[A-Za-z0-9._~+/-]{24,}\b/i);
+});
+
+test('sensitive example environment keys stay blank', () => {
+	const example = fs.readFileSync(path.join(root, 'config', 'office-automation-sip-notifier.env.example'), 'utf8');
+	for (const key of [
+		'API_TOKEN',
+		'DEFAULT_EXTENSIONS',
+		'MESSAGE_FROM',
+		'AMI_PORT',
+		'AMI_USER',
+		'AMI_SECRET',
+		'INTEROFFICE_MESSAGE_ENDPOINT',
+		'INTEROFFICE_MESSAGE_FROM',
+		'INTEROFFICE_FORWARD_TARGET',
+		'INTEROFFICE_ALIAS_REGEX',
+		'INTEROFFICE_TARGET_PREFIX',
+		'INTEROFFICE_SENDER_ALIAS_REGEX',
+		'INTEROFFICE_SENDER_ALIAS_PREFIX',
+	]) {
+		assert.match(example, new RegExp(`^${key}=$`, 'm'));
+	}
+});
+
+test('new operational scripts use shell or CommonJS only', () => {
+	const scriptFiles = filesUnder(path.join(root, 'scripts'));
+	assert.equal(scriptFiles.every(file => /\.(?:cjs|sh)$/.test(file)), true);
+	for (const file of scriptFiles) assert.doesNotMatch(fs.readFileSync(file, 'utf8'), /\bpython(?:3)?\b/i);
+});

--- a/ops/office-automation/test/routing.test.cjs
+++ b/ops/office-automation/test/routing.test.cjs
@@ -1,0 +1,170 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+	commandLogRecord,
+	channelFlagEnabled,
+	endpointAllowed,
+	explicitRequestedChannels,
+	notify,
+	payloadRequestsChannel,
+	routeDecision,
+} = require('../lib/office-automation-sip-notifier.cjs');
+
+function preferences(overrides = {}) {
+	return {
+		channels: {
+			sip: {
+				categories: ['error', 'important'],
+				mutedCategories: [],
+				endpoints: {},
+				...(overrides.sip || {}),
+			},
+			telegram: { categories: ['all'], mutedCategories: [], endpoints: {} },
+			ntfy: { categories: ['all'], mutedCategories: [], endpoints: {} },
+		},
+	};
+}
+
+test('explicit ntfy and Telegram request is a hard SIP deny with zero sends', async () => {
+	let sends = 0;
+	const result = await notify({
+		event_type: 'php_fpm_slowlog',
+		category: 'web_health',
+		severity: 'warning',
+		notify_channels: ['ntfy', 'telegram'],
+		extensions: ['synthetic-subscriber'],
+	}, {
+		preferences: preferences(),
+		subscribers: new Set(['synthetic-subscriber']),
+		defaultExtensions: ['synthetic-default'],
+		sendSipMessage: async () => {
+			sends += 1;
+			return { route: 'local' };
+		},
+	});
+
+	assert.deepEqual(result, {
+		ok: true,
+		skipped: true,
+		reason: 'sip_channel_not_requested',
+		endpoints: [],
+		categories: ['error', 'important', 'web_health'],
+		results: [],
+	});
+	assert.equal(sends, 0);
+});
+
+test('route policy denies SIP before the n8n SIP gate for an explicit non-SIP allow-list', () => {
+	const result = routeDecision({
+		category: 'web_health',
+		severity: 'warning',
+		channels: ['ntfy', 'telegram'],
+		notify_channels: ['ntfy', 'telegram'],
+	}, { preferences: preferences() });
+
+	assert.deepEqual(result.channels, { sip: false, telegram: true, ntfy: true });
+});
+
+test('explicit SIP request sends only to eligible subscriber and default endpoints', async () => {
+	const sent = [];
+	const result = await notify({
+		event_type: 'service_warning',
+		category: 'error',
+		severity: 'warning',
+		channels: ['sip'],
+		extensions: ['synthetic-subscriber', 'synthetic-unsubscribed', 'synthetic-default'],
+	}, {
+		preferences: preferences(),
+		subscribers: new Set(['synthetic-subscriber']),
+		defaultExtensions: ['synthetic-default'],
+		sendSipMessage: async endpoint => {
+			sent.push(endpoint);
+			return { route: 'local', rewritten_target: endpoint };
+		},
+	});
+
+	assert.deepEqual(sent, ['synthetic-subscriber', 'synthetic-default']);
+	assert.equal(result.ok, true);
+	assert.equal(result.endpoint_count, 2);
+	assert.equal(result.sent_count, 2);
+	assert.equal(result.failed_count, 0);
+	assert.equal(result.results.length, 2);
+	assert.equal(result.results.some(item => Object.prototype.hasOwnProperty.call(item, 'endpoint')), false);
+	assert.doesNotMatch(JSON.stringify(result), /synthetic-(?:subscriber|default|unsubscribed)/);
+});
+
+test('SIP send failures return a stable code without destination or transport details', async () => {
+	const result = await notify({
+		category: 'error',
+		severity: 'warning',
+		channels: ['sip'],
+		extensions: ['synthetic-private-endpoint'],
+	}, {
+		preferences: preferences(),
+		subscribers: new Set(['synthetic-private-endpoint']),
+		defaultExtensions: [],
+		sendSipMessage: async endpoint => {
+			throw new Error(`transport failed for ${endpoint}`);
+		},
+	});
+
+	assert.equal(result.ok, false);
+	assert.equal(result.endpoint_count, 1);
+	assert.equal(result.failed_count, 1);
+	assert.deepEqual(result.results, [{ ok: false, error: 'sip_send_failed' }]);
+	assert.doesNotMatch(JSON.stringify(result), /synthetic-private-endpoint|transport failed/);
+});
+
+test('endpoint category and mute preferences still apply after the channel gate', () => {
+	const prefs = preferences({
+		sip: {
+			categories: ['all'],
+			endpoints: {
+				'synthetic-muted': { categories: ['error'], mutedCategories: ['error'] },
+				'synthetic-allowed': { categories: ['error'], mutedCategories: [] },
+			},
+		},
+	});
+	const payload = { category: 'error', severity: 'warning', channels: ['sip'] };
+
+	assert.equal(endpointAllowed(prefs, 'synthetic-muted', payload, new Set(), []), false);
+	assert.equal(endpointAllowed(prefs, 'synthetic-allowed', payload, new Set(), []), true);
+	assert.equal(endpointAllowed(prefs, 'synthetic-unknown', payload, new Set(), []), false);
+});
+
+test('legacy payloads retain the historical channel behavior', () => {
+	assert.equal(explicitRequestedChannels({ event_type: 'legacy' }), null);
+	assert.equal(payloadRequestsChannel({ event_type: 'legacy' }, 'sip'), true);
+	assert.equal(payloadRequestsChannel({ channels: { sip: false, ntfy: true } }, 'sip'), false);
+	assert.equal(payloadRequestsChannel({ channels: { sip: 'false', ntfy: 'true' } }, 'sip'), false);
+	assert.equal(payloadRequestsChannel({ channels: { sip: true } }, 'sip'), true);
+	assert.equal(payloadRequestsChannel({ channels: ['sip'], notify_channels: ['ntfy'] }, 'sip'), false);
+	assert.equal(payloadRequestsChannel({ channels: ['all'], notify_channels: ['sip'] }, 'sip'), true);
+});
+
+test('object channel flags use explicit boolean semantics', () => {
+	assert.equal(channelFlagEnabled(true), true);
+	assert.equal(channelFlagEnabled('yes'), true);
+	assert.equal(channelFlagEnabled('false'), false);
+	assert.equal(channelFlagEnabled('synthetic-value'), false);
+});
+
+test('command audit records contain metadata rather than identities or message bodies', () => {
+	const record = commandLogRecord({
+		direction: 'inbound',
+		from: 'synthetic-sender-identity',
+		endpoint: 'synthetic-private-endpoint',
+		body: 'synthetic-private-message',
+		error: 'failure mentioning synthetic-private-endpoint',
+	}, '2026-07-21T00:00:00.000Z');
+	const serialized = JSON.stringify(record);
+
+	assert.equal(record.endpoint_present, true);
+	assert.equal(record.sender_present, true);
+	assert.equal(record.body_bytes, Buffer.byteLength('synthetic-private-message'));
+	assert.equal(record.error, 'command_failed');
+	assert.doesNotMatch(serialized, /synthetic-(?:sender|private)/);
+});

--- a/ops/office-automation/test/slowlog.test.cjs
+++ b/ops/office-automation/test/slowlog.test.cjs
@@ -1,0 +1,80 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	buildEventPayload,
+	isPhpFpmSlowLogHeader,
+	readNewPhpFpmSlowLog,
+	redactText,
+} = require('../lib/apache-site-watchdog-to-n8n.cjs');
+
+function fixture(t) {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'digitalogic-slowlog-'));
+	t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+	const file = path.join(directory, 'slow.log');
+	fs.writeFileSync(file, 'existing content is intentionally anchored\n');
+	return file;
+}
+
+test('slowlog ingestion counts request headers rather than stack-trace lines', t => {
+	const file = fixture(t);
+	const state = {};
+	assert.equal(readNewPhpFpmSlowLog(state, 'slowlog', file).requestCount, 0);
+
+	fs.appendFileSync(file, [
+		'[21-Jul-2026 10:00:00] [pool www] pid 101',
+		'script_filename = /var/www/html/index.php',
+		'[0x0001] function() /var/www/html/index.php:1',
+		'[21-Jul-2026 10:00:01] [pool www] pid 102',
+		'[0x0002] other() /var/www/html/index.php:2',
+		'',
+	].join('\n'));
+	const batch = readNewPhpFpmSlowLog(state, 'slowlog', file, 16);
+
+	assert.equal(batch.requestCount, 2);
+	assert.equal(batch.observedLineCount, 5);
+	assert.ok(batch.observedLineCount > batch.requestCount);
+});
+
+test('a partial slowlog header is counted only after its newline arrives', t => {
+	const file = fixture(t);
+	const state = {};
+	readNewPhpFpmSlowLog(state, 'slowlog', file);
+	const header = '[21-Jul-2026 10:01:00] [pool www] pid 103';
+
+	fs.appendFileSync(file, header);
+	assert.equal(readNewPhpFpmSlowLog(state, 'slowlog', file).requestCount, 0);
+	fs.appendFileSync(file, '\n');
+	assert.equal(readNewPhpFpmSlowLog(state, 'slowlog', file).requestCount, 1);
+	assert.equal(isPhpFpmSlowLogHeader(header), true);
+});
+
+test('watchdog payload preserves the explicit allow-list in both channel fields', () => {
+	const payload = buildEventPayload({
+		event_type: 'php_fpm_slowlog',
+		severity: 'warning',
+		message: 'Synthetic slow request fixture',
+		channels: ['sip'],
+		notify_channels: ['sip'],
+	}, {
+		office: 'synthetic-office',
+		host: 'synthetic-host',
+		createdAt: '2026-07-21T00:00:00.000Z',
+		notifyChannels: ['ntfy', 'telegram'],
+	});
+
+	assert.deepEqual(payload.channels, ['ntfy', 'telegram']);
+	assert.deepEqual(payload.notify_channels, ['ntfy', 'telegram']);
+	assert.equal(payload.category, 'web_health');
+	assert.equal(payload.channels.includes('sip'), false);
+});
+
+test('diagnostic redaction removes secret-like values', () => {
+	const redacted = redactText('token=synthetic-value password=another {"authorization":"third"}');
+	assert.equal(redacted, 'token=*** password=*** {"authorization":"***"}');
+});

--- a/ops/office-automation/test/workflow.test.cjs
+++ b/ops/office-automation/test/workflow.test.cjs
@@ -1,0 +1,86 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	environmentByPlaceholder,
+	outputIsInsideRepository,
+	renderWorkflow,
+} = require('../scripts/render-n8n-workflow.cjs');
+
+const root = path.resolve(__dirname, '..');
+const template = JSON.parse(fs.readFileSync(path.join(root, 'n8n', 'office-automation-events.template.json'), 'utf8'));
+
+function syntheticEnvironment() {
+	const environment = {};
+	for (const variable of Object.values(environmentByPlaceholder)) environment[variable] = `synthetic-${variable.toLowerCase()}`;
+	Object.assign(environment, {
+		OFFICE_N8N_LOCAL_EVENT_LOG_FILE: '/var/lib/office-automation/synthetic-events.jsonl',
+		OFFICE_N8N_NTFY_URL: 'https://example.invalid/synthetic-topic',
+		OFFICE_N8N_SHEETS_WEBHOOK_URL: 'https://example.invalid/synthetic-sheets',
+		OFFICE_N8N_SIP_NOTIFY_URL: 'http://127.0.0.1:9999/v1/notify',
+		OFFICE_N8N_SIP_ROUTE_URL: 'http://127.0.0.1:9999/v1/route',
+		OFFICE_N8N_WEBHOOK_PATH: 'synthetic-office-events',
+	});
+	return environment;
+}
+
+test('versioned workflow is inactive and SIP has no route-gate bypass', () => {
+	assert.equal(template.active, false);
+	const routeEdges = template.connections['Get Notification Routing Policy'].main[0];
+	assert.equal(routeEdges.some(edge => edge.node === 'Notify SIP Extensions'), false);
+	assert.equal(routeEdges.some(edge => edge.node === 'Gate SIP Notification'), true);
+	const gate = template.nodes.find(node => node.name === 'Gate SIP Notification');
+	assert.match(gate.parameters.jsCode, /route\.channels\?\.sip/);
+	assert.equal(template.connections['Gate SIP Notification'].main[0][0].node, 'Notify SIP Extensions');
+});
+
+test('workflow rendering resolves placeholders and keeps the artifact inactive', () => {
+	const { workflow, serialized } = renderWorkflow(syntheticEnvironment());
+	assert.equal(workflow.active, false);
+	assert.doesNotMatch(serialized, /__[A-Z0-9_]+__/);
+	assert.match(serialized, /synthetic-office-events/);
+	const code = workflow.nodes.find(node => node.name === 'Normalize Office Automation Event').parameters.jsCode;
+	assert.match(code, /channels: body\.channels/);
+	assert.match(code, /notify_channels: body\.notify_channels/);
+	assert.doesNotMatch(code, /\b(?:10\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b/);
+	assert.match(code, /const hostMap = \{\};/);
+});
+
+test('normalization redacts credentials and private phone-routing fields before audit outputs', () => {
+	const { workflow } = renderWorkflow(syntheticEnvironment());
+	const code = workflow.nodes.find(node => node.name === 'Normalize Office Automation Event').parameters.jsCode;
+	const execute = new Function('$input', '$getWorkflowStaticData', code);
+	const [item] = execute({
+		first: () => ({
+			json: {
+				body: {
+					event_type: 'synthetic.warning',
+					severity: 'warning',
+					message: 'Bearer synthetic-private-credential',
+					api_token: 'synthetic-private-token',
+					billing_phone: 'synthetic-private-phone',
+					destination: 'synthetic-private-destination',
+					notify_channels: ['ntfy', 'telegram'],
+				},
+			},
+		}),
+	}, () => ({}));
+	const serialized = JSON.stringify(item.json);
+	const sipPayload = JSON.parse(item.json.sipPayload);
+
+	assert.equal(item.json.eventRecord.raw.api_token, '[redacted]');
+	assert.equal(item.json.eventRecord.raw.billing_phone, '[redacted]');
+	assert.equal(item.json.eventRecord.raw.destination, '[redacted]');
+	assert.deepEqual(sipPayload.notify_channels, ['ntfy', 'telegram']);
+	assert.doesNotMatch(serialized, /synthetic-private-(?:credential|token|phone|destination)/);
+});
+
+test('renderer rejects repository output paths', () => {
+	assert.equal(outputIsInsideRepository(path.join(root, 'rendered.json')), true);
+	assert.equal(outputIsInsideRepository(path.join(os.tmpdir(), 'digitalogic-rendered.json')), false);
+});


### PR DESCRIPTION
## Summary

- add version-controlled production sources for the Apache/PHP-FPM watchdog and SIP notifier
- preserve explicit `channels` / `notify_channels` allow-lists through n8n and independently enforce them in `/v1/notify`
- gate the SIP node on `/v1/route`, retain category/mute and subscriber/default-endpoint policy, and fail closed on conflicting channel lists
- count canonical PHP-FPM slow-request headers rather than stack frames
- add an inactive, credential-placeholder n8n template, protected renderer, secret-safe audit output, immutable deploy/rollback scripts, and owner-run runbooks

## Safety

- runtime credentials, webhook paths, destinations, aliases, and endpoint identities remain outside Git in protected configuration
- notification responses and command/audit records expose counts and stable error codes rather than destination or transport details
- the workflow renderer refuses active artifacts, repository output paths, unresolved placeholders, invalid URLs, or an SIP gate bypass
- no production deployment, route, service, credential, or n8n activation was performed

## Validation

- `composer test`: 318 tests, 1,985 assertions; 1 existing warning and 5 existing skips
- PHPCS baseline: 39,828 errors and 3,008 warnings, both below repository limits
- all versioned PHP syntax checks
- complete repository JavaScript, Google Sheets, PBX, and shell checks
- office automation suite: 19/19 passing, including zero-send negative and eligible-endpoint positive fixtures
- `composer audit --locked`: no advisories
- diff and privacy/secret-pattern checks

Refs #88

Review: pending owner approval