### PR TITLE
Strip local 021 prefix from PBX callbacks

### DIFF
--- a/ops/pbx/DEPLOYMENT.md
+++ b/ops/pbx/DEPLOYMENT.md
@@ -78,9 +78,11 @@ Remove the former `digitalogic-call-verification-menu`, public digit 2, pending
 lookup, and conditional shortcut from those public priorities completely.
 
 Inside the existing `[prefix-tci-callerid]` subroutine, normalize `00989…` first
-and `0989…` second, replacing either prefix with `09`. Only after normalization
-may the existing internal callback access prefix `9` be added. This ordering maps
-both variants to the same callable mobile number without changing any other ANI.
+and `0989…` second, replacing either prefix with `09`. Then strip `021` from a
+same-city Tehran landline. Only after those transformations may the existing
+internal callback access prefix `9` be added. For example, `02166754123` becomes
+`966754123`; the outbound `_9X.` route removes the access digit and sends
+`66754123`. Non-Tehran landline prefixes remain intact.
 
 Do not add a public fallback digit. The private `verify` context is intentionally
 unrouted until a separate Digitalogic IVR is designed and approved.
@@ -107,6 +109,8 @@ Use real PSTN ANI and redacted evidence:
   audio, early `Answer()`, prompt, or DTMF collection.
 - `0989123456789` and `00989123456789` both normalize to `09123456789` before
   the internal callback access prefix is added; an existing `09…` ANI is unchanged.
+- `02166754123` becomes extension caller ID `966754123`; one-touch redial sends
+  the same-city subscriber number `66754123` without the `021` prefix.
 - Both s and _X inbound paths behave identically.
 - The dormant helper contexts remain loaded but unreachable from public and
   internal dialplan paths.

--- a/ops/pbx/README.md
+++ b/ops/pbx/README.md
@@ -6,7 +6,9 @@ the current production DID bypasses every verification helper and rings extensio
 101 directly. The helper and its BGM-mixed prompts remain installed but dormant
 for the next, separately approved IVR pass. No public verification digit exists.
 Before the existing internal callback prefix is added, inbound caller IDs beginning
-with `0989` or `00989` are canonicalized to the Iranian local `09` form.
+with `0989` or `00989` are canonicalized to the Iranian local `09` form. Tehran
+landlines also lose the same-city `021` prefix, so extension redial uses a number
+the TCI trunk accepts.
 
 The dormant wrapper forwards one reviewed mode to the helper:
 

--- a/ops/pbx/asterisk/digitalogic-pending-shortcut.conf
+++ b/ops/pbx/asterisk/digitalogic-pending-shortcut.conf
@@ -15,11 +15,13 @@
 ;
 ;   same => n,ExecIf($["${CALLERID(num):0:5}"="00989"]?Set(CALLERID(num)=09${CALLERID(num):5}))
 ;   same => n,ExecIf($["${CALLERID(num):0:4}"="0989"]?Set(CALLERID(num)=09${CALLERID(num):4}))
+;   same => n,ExecIf($["${CALLERID(num):0:3}"="021"]?Set(CALLERID(num)=${CALLERID(num):3}))
 ;   same => n,ExecIf($["${CALLERID(num)}"!=""]?Set(CALLERID(num)=9${CALLERID(num)}))
 ;
 ; This maps 0989XXXXXXXXX and 00989XXXXXXXXX to the same canonical
-; 09XXXXXXXXX number. All other caller IDs pass through unchanged before the
-; existing callback access prefix is added.
+; 09XXXXXXXXX number. A same-city Tehran landline loses its 021 trunk prefix
+; before the existing callback access prefix is added; other caller IDs pass
+; through unchanged.
 
 [pbx-call-verification-pending-digitalogic]
 exten => preflight,1,AGI(/usr/local/libexec/pbx-verification-digitalogic,preflight)

--- a/ops/pbx/test/pbx-assets.test.js
+++ b/ops/pbx/test/pbx-assets.test.js
@@ -23,32 +23,39 @@ test('Digitalogic keeps verification dormant while the public DID routes directl
 	assert.doesNotMatch(dialplan, /^\s*same => n\([^)]+\)/m);
 });
 
-test('TCI international-style mobile caller IDs normalize before callback prefixing', () => {
+test('TCI caller IDs normalize and strip local 021 before callback prefixing', () => {
 	const dialplan = read('asterisk/digitalogic-pending-shortcut.conf');
 	const from00989 = '${CALLERID(num):0:5}"="00989';
 	const from0989 = '${CALLERID(num):0:4}"="0989';
+	const local021 = '${CALLERID(num):0:3}"="021';
 	const callbackPrefix = 'Set(CALLERID(num)=9${CALLERID(num)})';
 	assert.notEqual(dialplan.indexOf(from00989), -1);
 	assert.notEqual(dialplan.indexOf(from0989), -1);
+	assert.notEqual(dialplan.indexOf(local021), -1);
 	assert.notEqual(dialplan.indexOf(callbackPrefix), -1);
 	assert.ok(dialplan.indexOf(from00989) < dialplan.indexOf(from0989));
-	assert.ok(dialplan.indexOf(from0989) < dialplan.indexOf(callbackPrefix));
+	assert.ok(dialplan.indexOf(from0989) < dialplan.indexOf(local021));
+	assert.ok(dialplan.indexOf(local021) < dialplan.indexOf(callbackPrefix));
 	assert.match(dialplan, /00989[^\n]+CALLERID\(num\)=09\$\{CALLERID\(num\):5\}/);
 	assert.match(dialplan, /0989[^\n]+CALLERID\(num\)=09\$\{CALLERID\(num\):4\}/);
 
-	const normalize = (number) => {
+	const callbackNumber = (number) => {
 		if (number.startsWith('00989')) {
-			return `09${number.slice(5)}`;
+			number = `09${number.slice(5)}`;
 		}
 		if (number.startsWith('0989')) {
-			return `09${number.slice(4)}`;
+			number = `09${number.slice(4)}`;
 		}
-		return number;
+		if (number.startsWith('021')) {
+			number = number.slice(3);
+		}
+		return `9${number}`;
 	};
-	assert.equal(normalize('0989123456789'), '09123456789');
-	assert.equal(normalize('00989123456789'), '09123456789');
-	assert.equal(normalize('09123456789'), '09123456789');
-	assert.equal(normalize('02166754123'), '02166754123');
+	assert.equal(callbackNumber('0989123456789'), '909123456789');
+	assert.equal(callbackNumber('00989123456789'), '909123456789');
+	assert.equal(callbackNumber('09123456789'), '909123456789');
+	assert.equal(callbackNumber('02166754123'), '966754123');
+	assert.equal(callbackNumber('02612345678'), '902612345678');
 });
 
 test('private code collection stays inside AGI and wrapper forwards its mode', () => {


### PR DESCRIPTION
## What changed

- Strip the same-city Tehran `021` prefix after mobile normalization and before callback access prefixing.
- Document the exact extension and trunk dial forms.
- Add regression coverage for Tehran, mobile, and non-Tehran caller IDs.

## Why

The local TCI trunk may reject same-city calls when `021` is retained. Extension one-touch callback must therefore display the PBX access digit followed by the local subscriber number.

Digitalogic remains direct-to-extension-101; this does not enable a public IVR or verification route.

## Validation

- `npm run check`
- `npm test` — 25/25 passed
- `bash -n bin/pbx-verification-digitalogic scripts/*.sh`
- `git diff --check`
- Production dialplan reload succeeded and extension 101 is available

Closes #142
