### PR TITLE
Add private product supplier links

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,8 +81,10 @@ jobs:
         node --check assets/js/branding/admin-branding.js
         node --check assets/js/call-verification.js
         node --check assets/js/sidebar-login.js
+        node --check assets/js/product-supplier-links-admin.js
         node --test tests/call-verification-ui.test.js
         node --test tests/sidebar-login-style.test.js
+        node --test tests/product-supplier-links-admin.test.js
         node --test tests/product-query.test.js
         node --test tests/admin-branding-auth-nav.test.js
         node --test tests/product-identity.test.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added administrator-only WooCommerce product supplier links with a Persian
+  classic-editor panel, redacted product-list summaries, protected metadata,
+  exact product targeting, and stdin-only WP-CLI write commands.
 - Added an explicit Patris storefront pricing policy and non-mutating `wp digitalogic pricing audit` command that report canonical Patris, WooCommerce regular, promotion, and effective prices separately.
 - Added version-controlled, secret-free production sources and tests for the Apache/PHP-FPM watchdog, SIP notifier, gated n8n event workflow, and plan-first deploy/rollback procedures.
 - Added a persisted, optional sticky first product column that follows the first visible/reordered column in RTL and LTR while keeping the selection control frozen beside it.

--- a/assets/css/product-supplier-links-admin.css
+++ b/assets/css/product-supplier-links-admin.css
@@ -1,0 +1,53 @@
+.digitalogic-supplier-links {
+    direction: rtl;
+    text-align: right;
+}
+
+.digitalogic-supplier-links__empty.is-hidden {
+    display: none;
+}
+
+.digitalogic-supplier-link {
+    margin: 16px 0;
+    padding: 16px;
+    border: 1px solid #dcdcde;
+    border-radius: 6px;
+    background: #fff;
+}
+
+.digitalogic-supplier-link legend {
+    padding: 0 8px;
+    font-weight: 600;
+}
+
+.digitalogic-supplier-link__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px 18px;
+}
+
+.digitalogic-supplier-link__grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.digitalogic-supplier-link__grid input,
+.digitalogic-supplier-link__grid select,
+.digitalogic-supplier-link__grid textarea {
+    width: 100%;
+}
+
+.digitalogic-supplier-link__wide {
+    grid-column: 1 / -1;
+}
+
+@media (max-width: 782px) {
+    .digitalogic-supplier-link__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .digitalogic-supplier-link__wide {
+        grid-column: auto;
+    }
+}

--- a/assets/js/product-supplier-links-admin.js
+++ b/assets/js/product-supplier-links-admin.js
@@ -1,0 +1,69 @@
+(function () {
+    'use strict';
+
+    function refreshEmptyState(root) {
+        var emptyState = root.querySelector('.digitalogic-supplier-links__empty');
+        var hasRows = root.querySelector('.digitalogic-supplier-link') !== null;
+
+        if (emptyState) {
+            emptyState.classList.toggle('is-hidden', hasRows);
+        }
+    }
+
+    function addRow(root) {
+        var template = document.getElementById('tmpl-digitalogic-supplier-link-row');
+        var rows = root.querySelector('.digitalogic-supplier-links__rows');
+        var index = Number.parseInt(root.dataset.nextIndex || '0', 10);
+
+        if (!template || !rows || !Number.isFinite(index)) {
+            return;
+        }
+
+        rows.insertAdjacentHTML('beforeend', template.innerHTML.replaceAll('__INDEX__', String(index)));
+        root.dataset.nextIndex = String(index + 1);
+        refreshEmptyState(root);
+
+        var newRows = rows.querySelectorAll('.digitalogic-supplier-link');
+        var lastRow = newRows[newRows.length - 1];
+        var urlInput = lastRow ? lastRow.querySelector('input[type="url"]') : null;
+        if (urlInput) {
+            urlInput.focus();
+        }
+    }
+
+    function initialize() {
+        var root = document.getElementById('digitalogic-private-supplier-links');
+        if (!root) {
+            return;
+        }
+
+        root.addEventListener('click', function (event) {
+            var addButton = event.target.closest('.digitalogic-supplier-links__add');
+            if (addButton) {
+                event.preventDefault();
+                addRow(root);
+                return;
+            }
+
+            var removeButton = event.target.closest('.digitalogic-supplier-link__remove');
+            if (!removeButton) {
+                return;
+            }
+
+            event.preventDefault();
+            var row = removeButton.closest('.digitalogic-supplier-link');
+            if (row) {
+                row.remove();
+                refreshEmptyState(root);
+            }
+        });
+
+        refreshEmptyState(root);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initialize);
+    } else {
+        initialize();
+    }
+}());

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -124,6 +124,7 @@ final class Digitalogic {
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-import-export.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-unit-converter.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-identifier-resolver.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-supplier-links.php';
 		require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-metadata-inspector.php';
 		require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-write-lock.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-pricing-input-credential.php'; // phpcs:ignore
@@ -165,6 +166,7 @@ final class Digitalogic {
         if (is_admin()) {
             require_once DIGITALOGIC_PLUGIN_DIR . 'includes/admin/class-admin.php';
 			require_once DIGITALOGIC_PLUGIN_DIR . 'includes/admin/class-digitalogic-product-table.php';
+            require_once DIGITALOGIC_PLUGIN_DIR . 'includes/admin/class-digitalogic-product-supplier-links-admin.php';
         }
 
         // API includes
@@ -174,6 +176,7 @@ final class Digitalogic {
         // WP-CLI
         if (defined('WP_CLI') && WP_CLI) {
             require_once DIGITALOGIC_PLUGIN_DIR . 'includes/cli/class-cli-commands.php';
+            require_once DIGITALOGIC_PLUGIN_DIR . 'includes/cli/class-digitalogic-product-supplier-links-cli.php';
         }
     }
 
@@ -212,6 +215,7 @@ final class Digitalogic {
         Digitalogic_Logger::instance();
 		Digitalogic_Product_Write_Lock::instance();
         Digitalogic_Product_Manager::instance();
+        Digitalogic_Product_Supplier_Links::instance();
         Digitalogic_Pricing::instance();
         Digitalogic_Import_Export::instance();
         Digitalogic_Patris_Feed::instance();
@@ -232,6 +236,7 @@ final class Digitalogic {
 
         if (is_admin()) {
             Digitalogic_Admin::instance();
+            Digitalogic_Product_Supplier_Links_Admin::instance();
         }
 
         Digitalogic_REST_API::instance();

--- a/docs/PRIVATE-SUPPLIER-LINKS.md
+++ b/docs/PRIVATE-SUPPLIER-LINKS.md
@@ -1,0 +1,76 @@
+# لینک‌های خصوصی تأمین‌کنندگان
+
+این قابلیت برای نگهداری لینک خرید محصولات دیجیتالاجیک طراحی شده است. لینک‌های
+تائوبائو، ۱۶۸۸، تی‌مال، علی‌بابا، علی‌اکسپرس، فروشگاه‌های ایرانی و منابع دیگر
+به محصول اصلی ووکامرس متصل می‌شوند.
+
+## مرز دسترسی
+
+- فقط کاربری که هم‌زمان مجوزهای `manage_options` و ویرایش همان محصول را دارد
+  می‌تواند لینک‌ها را ببیند یا تغییر دهد.
+- اطلاعات در متای محافظت‌شده
+  `_digitalogic_private_supplier_links_v1` ذخیره می‌شود.
+- متا در REST API وردپرس ثبت نمی‌شود و از پاسخ‌های REST و webhook ووکامرس نیز
+  حذف می‌شود.
+- هیچ فیلد، اسکریپت یا نشانه‌ای در صفحه عمومی محصول یا داده‌های ساختاریافته
+  اضافه نمی‌شود.
+- نسخه نخست فقط محصول اصلی را می‌پذیرد؛ لینک تنوع‌ها باید فعلاً با توضیح یا
+  کد فروشنده روی محصول اصلی ثبت شود.
+
+## پنل مدیریت
+
+در ویرایش کلاسیک محصول، جعبه «منابع خرید خصوصی» برای مدیران نمایش داده می‌شود.
+ستون «منابع خرید» در فهرست محصولات فقط تعداد و نام پلتفرم‌ها را نشان می‌دهد و
+نشانی اینترنتی را نمایش نمی‌دهد.
+
+## WP-CLI
+
+تمام دستورها باید با `--user=<administrator>` اجرا شوند. شناسه محصول با یکی از
+`--id` یا `--sku` به‌صورت دقیق انتخاب می‌شود.
+
+```bash
+wp digitalogic supplier-links list --id=123 --user=administrator
+```
+
+برای جلوگیری از ثبت نشانی خصوصی در آرگومان‌های پردازش، دستورهای نوشتن JSON را
+فقط از stdin می‌خوانند:
+
+```bash
+printf '%s' "$SELLER_LINK_JSON" \
+  | wp digitalogic supplier-links add --id=123 --user=administrator
+
+printf '%s' "$SELLER_LINKS_JSON" \
+  | wp digitalogic supplier-links replace --sku=MODULE-1 --user=administrator
+
+wp digitalogic supplier-links remove \
+  --id=123 \
+  --link-id=sl_0123456789abcdef0123 \
+  --user=administrator
+```
+
+خروجی دستورهای نوشتن فقط شناسه محصول، تعداد لینک‌ها و شناسه‌های داخلی لینک را
+برمی‌گرداند و شامل نشانی یا یادداشت خصوصی نیست.
+
+### نمونه شیء JSON
+
+```json
+{
+  "marketplace": "taobao",
+  "site_name": "Taobao",
+  "url": "https://item.taobao.com/item.htm?id=123",
+  "source_title": "عنوان ثبت‌شده در سابقه خرید",
+  "seller": "نام فروشنده",
+  "seller_sku": "ABC-123",
+  "source": "purchase_history",
+  "status": "matched",
+  "note": "یادداشت داخلی",
+  "last_checked": "2026-07-24"
+}
+```
+
+مقادیر پشتیبانی‌شده:
+
+- `marketplace`: `taobao`, `1688`, `tmall`, `alibaba`, `aliexpress`,
+  `iranian_market`, `other`
+- `source`: `purchase_history`, `iranian_market`, `manual`, `other`
+- `status`: `candidate`, `matched`, `purchased`, `preferred`, `inactive`

--- a/includes/admin/class-digitalogic-product-supplier-links-admin.php
+++ b/includes/admin/class-digitalogic-product-supplier-links-admin.php
@@ -1,0 +1,430 @@
+<?php
+/**
+ * Administrator-only product supplier-link editor.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Render and save private supplier links on classic WooCommerce product screens.
+ */
+final class Digitalogic_Product_Supplier_Links_Admin {
+
+	/**
+	 * Shared instance.
+	 *
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Return the shared handler.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register classic product-editor hooks.
+	 */
+	private function __construct() {
+		add_action( 'add_meta_boxes_product', array( $this, 'add_meta_box' ) );
+		add_action( 'save_post_product', array( $this, 'save_product' ), 10, 3 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'admin_notices', array( $this, 'show_saved_error' ) );
+		add_filter( 'manage_edit-product_columns', array( $this, 'add_product_column' ), 30 );
+		add_action( 'manage_product_posts_custom_column', array( $this, 'render_product_column' ), 10, 2 );
+	}
+
+	/**
+	 * Register the private Persian metabox.
+	 *
+	 * @param WP_Post $post Product post.
+	 * @return void
+	 */
+	public function add_meta_box( $post ) {
+		if ( ! is_object( $post ) || empty( $post->ID ) || ! $this->can_manage_product( $post->ID ) ) {
+			return;
+		}
+
+		add_meta_box(
+			'digitalogic-private-supplier-links-box',
+			'منابع خرید خصوصی',
+			array( $this, 'render_meta_box' ),
+			'product',
+			'normal',
+			'default'
+		);
+	}
+
+	/**
+	 * Render a private, RTL link repeater.
+	 *
+	 * @param WP_Post $post Product post.
+	 * @return void
+	 */
+	public function render_meta_box( $post ) {
+		if ( ! $this->can_manage_product( $post->ID ) ) {
+			return;
+		}
+
+		$links = Digitalogic_Product_Supplier_Links::instance()->get_links( $post->ID );
+		if ( is_wp_error( $links ) ) {
+			$links = array();
+		}
+
+		wp_nonce_field( 'digitalogic_save_supplier_links', 'digitalogic_supplier_links_nonce' );
+		?>
+		<div
+			id="digitalogic-private-supplier-links"
+			class="digitalogic-supplier-links"
+			dir="rtl"
+			data-next-index="<?php echo esc_attr( (string) count( $links ) ); ?>"
+		>
+			<p class="description">
+				این اطلاعات فقط برای مدیران سایت نگهداری می‌شود و در فروشگاه، داده‌های ساختاریافته یا API عمومی نمایش داده نمی‌شود.
+			</p>
+			<div class="digitalogic-supplier-links__rows">
+				<?php
+				foreach ( $links as $index => $link ) {
+					$this->render_link_row( (string) $index, $link );
+				}
+				?>
+			</div>
+			<p class="digitalogic-supplier-links__empty<?php echo empty( $links ) ? '' : ' is-hidden'; ?>">
+				هنوز منبع خریدی برای این محصول ثبت نشده است.
+			</p>
+			<p>
+				<button type="button" class="button digitalogic-supplier-links__add">افزودن منبع خرید</button>
+			</p>
+		</div>
+		<script type="text/html" id="tmpl-digitalogic-supplier-link-row">
+			<?php $this->render_link_row( '__INDEX__', array() ); ?>
+		</script>
+		<?php
+	}
+
+	/**
+	 * Persist only nonce-verified administrator input.
+	 *
+	 * @param int     $post_id Product ID.
+	 * @param WP_Post $post Product post.
+	 * @param bool    $update Whether an existing product is being updated.
+	 * @return void
+	 */
+	public function save_product( $post_id, $post, $update ) {
+		unset( $update );
+		if (
+			! is_object( $post )
+			|| 'product' !== $post->post_type
+			|| wp_is_post_autosave( $post_id )
+			|| wp_is_post_revision( $post_id )
+			|| ! $this->can_manage_product( $post_id )
+		) {
+			return;
+		}
+
+		$nonce = isset( $_POST['digitalogic_supplier_links_nonce'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			? sanitize_text_field( wp_unslash( $_POST['digitalogic_supplier_links_nonce'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			: '';
+		if ( '' === $nonce || ! wp_verify_nonce( $nonce, 'digitalogic_save_supplier_links' ) ) {
+			return;
+		}
+
+		$raw_links = isset( $_POST['digitalogic_supplier_links'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			? map_deep( wp_unslash( $_POST['digitalogic_supplier_links'] ), 'sanitize_text_field' ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			: array();
+		$result    = Digitalogic_Product_Supplier_Links::instance()->replace_links( $post_id, $raw_links );
+		if ( is_wp_error( $result ) ) {
+			set_transient(
+				'digitalogic_supplier_links_error_' . get_current_user_id(),
+				$result->get_error_message(),
+				MINUTE_IN_SECONDS
+			);
+		}
+	}
+
+	/**
+	 * Enqueue the repeater only on classic product editors.
+	 *
+	 * @param string $hook_suffix Current admin page.
+	 * @return void
+	 */
+	public function enqueue_assets( $hook_suffix ) {
+		if ( ! in_array( $hook_suffix, array( 'post.php', 'post-new.php' ), true ) || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+		if ( ! is_object( $screen ) || 'product' !== $screen->post_type ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'digitalogic-product-supplier-links',
+			DIGITALOGIC_PLUGIN_URL . 'assets/css/product-supplier-links-admin.css',
+			array(),
+			DIGITALOGIC_VERSION
+		);
+		wp_enqueue_script(
+			'digitalogic-product-supplier-links',
+			DIGITALOGIC_PLUGIN_URL . 'assets/js/product-supplier-links-admin.js',
+			array(),
+			DIGITALOGIC_VERSION,
+			true
+		);
+	}
+
+	/**
+	 * Display a redacted validation error after a product save redirect.
+	 *
+	 * @return void
+	 */
+	public function show_saved_error() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$key     = 'digitalogic_supplier_links_error_' . get_current_user_id();
+		$message = get_transient( $key );
+		if ( ! is_string( $message ) || '' === $message ) {
+			return;
+		}
+
+		delete_transient( $key );
+		echo '<div class="notice notice-error is-dismissible"><p>' . esc_html( $message ) . '</p></div>';
+	}
+
+	/**
+	 * Add a non-sensitive count/provider column for administrators.
+	 *
+	 * @param array $columns Existing product columns.
+	 * @return array
+	 */
+	public function add_product_column( $columns ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return $columns;
+		}
+
+		$result   = array();
+		$inserted = false;
+		foreach ( $columns as $key => $label ) {
+			if ( 'date' === $key ) {
+				$result['digitalogic_supplier_links'] = 'منابع خرید';
+				$inserted                             = true;
+			}
+			$result[ $key ] = $label;
+		}
+		if ( ! $inserted ) {
+			$result['digitalogic_supplier_links'] = 'منابع خرید';
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Render only a count and provider labels, never seller URLs.
+	 *
+	 * @param string $column Column key.
+	 * @param int    $post_id Product ID.
+	 * @return void
+	 */
+	public function render_product_column( $column, $post_id ) {
+		if ( 'digitalogic_supplier_links' !== $column || ! $this->can_manage_product( $post_id ) ) {
+			return;
+		}
+
+		$summary = Digitalogic_Product_Supplier_Links::instance()->get_summary( $post_id );
+		if ( is_wp_error( $summary ) || 0 === $summary['count'] ) {
+			echo '<span aria-label="بدون منبع خرید">—</span>';
+			return;
+		}
+
+		$providers = array_map( array( $this, 'provider_label' ), $summary['providers'] );
+		echo '<strong>' . esc_html( number_format_i18n( $summary['count'] ) . ' منبع' ) . '</strong>';
+		echo '<br><span class="description">' . esc_html( implode( '، ', $providers ) ) . '</span>';
+	}
+
+	/**
+	 * Render one server-escaped repeater card.
+	 *
+	 * @param string $index Row index or template marker.
+	 * @param array  $link Stored link.
+	 * @return void
+	 */
+	private function render_link_row( $index, $link ) {
+		$link   = wp_parse_args(
+			$link,
+			array(
+				'id'           => '',
+				'marketplace'  => 'other',
+				'site_name'    => '',
+				'url'          => '',
+				'source_title' => '',
+				'seller'       => '',
+				'seller_sku'   => '',
+				'source'       => 'manual',
+				'status'       => 'candidate',
+				'note'         => '',
+				'created_at'   => '',
+				'last_checked' => '',
+			)
+		);
+		$prefix = 'digitalogic_supplier_links[' . $index . ']';
+		?>
+		<fieldset class="digitalogic-supplier-link">
+			<legend>منبع خرید خصوصی</legend>
+			<input type="hidden" name="<?php echo esc_attr( $prefix . '[id]' ); ?>" value="<?php echo esc_attr( $link['id'] ); ?>">
+			<input type="hidden" name="<?php echo esc_attr( $prefix . '[created_at]' ); ?>" value="<?php echo esc_attr( $link['created_at'] ); ?>">
+			<div class="digitalogic-supplier-link__grid">
+				<label>
+					<span>بازار یا پلتفرم</span>
+					<select name="<?php echo esc_attr( $prefix . '[marketplace]' ); ?>">
+						<?php foreach ( $this->marketplace_options() as $value => $label ) : ?>
+							<option value="<?php echo esc_attr( $value ); ?>"<?php echo $value === $link['marketplace'] ? ' selected' : ''; ?>>
+								<?php echo esc_html( $label ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</label>
+				<label>
+					<span>نام سایت یا فروشنده</span>
+					<input type="text" maxlength="120" name="<?php echo esc_attr( $prefix . '[site_name]' ); ?>" value="<?php echo esc_attr( $link['site_name'] ); ?>">
+				</label>
+				<label class="digitalogic-supplier-link__wide">
+					<span>لینک کالا</span>
+					<input type="url" dir="ltr" maxlength="4096" required name="<?php echo esc_attr( $prefix . '[url]' ); ?>" value="<?php echo esc_attr( $link['url'] ); ?>">
+					<?php if ( '' !== $link['url'] ) : ?>
+						<a href="<?php echo esc_url( $link['url'] ); ?>" target="_blank" rel="noopener noreferrer">باز کردن لینک</a>
+					<?php endif; ?>
+				</label>
+				<label class="digitalogic-supplier-link__wide">
+					<span>عنوان کالا در منبع</span>
+					<input type="text" maxlength="240" name="<?php echo esc_attr( $prefix . '[source_title]' ); ?>" value="<?php echo esc_attr( $link['source_title'] ); ?>">
+				</label>
+				<label>
+					<span>نام فروشنده</span>
+					<input type="text" maxlength="160" name="<?php echo esc_attr( $prefix . '[seller]' ); ?>" value="<?php echo esc_attr( $link['seller'] ); ?>">
+				</label>
+				<label>
+					<span>کد کالا نزد فروشنده</span>
+					<input type="text" dir="ltr" maxlength="120" name="<?php echo esc_attr( $prefix . '[seller_sku]' ); ?>" value="<?php echo esc_attr( $link['seller_sku'] ); ?>">
+				</label>
+				<label>
+					<span>منبع تطبیق</span>
+					<select name="<?php echo esc_attr( $prefix . '[source]' ); ?>">
+						<?php foreach ( $this->source_options() as $value => $label ) : ?>
+							<option value="<?php echo esc_attr( $value ); ?>"<?php echo $value === $link['source'] ? ' selected' : ''; ?>>
+								<?php echo esc_html( $label ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</label>
+				<label>
+					<span>وضعیت</span>
+					<select name="<?php echo esc_attr( $prefix . '[status]' ); ?>">
+						<?php foreach ( $this->status_options() as $value => $label ) : ?>
+							<option value="<?php echo esc_attr( $value ); ?>"<?php echo $value === $link['status'] ? ' selected' : ''; ?>>
+								<?php echo esc_html( $label ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</label>
+				<label>
+					<span>آخرین بررسی</span>
+					<input type="date" dir="ltr" name="<?php echo esc_attr( $prefix . '[last_checked]' ); ?>" value="<?php echo esc_attr( $link['last_checked'] ); ?>">
+				</label>
+				<label class="digitalogic-supplier-link__wide">
+					<span>یادداشت داخلی</span>
+					<textarea rows="3" maxlength="1000" name="<?php echo esc_attr( $prefix . '[note]' ); ?>"><?php echo esc_textarea( $link['note'] ); ?></textarea>
+				</label>
+			</div>
+			<p>
+				<button type="button" class="button-link-delete digitalogic-supplier-link__remove">حذف این منبع</button>
+			</p>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Whether the current administrator can manage a product.
+	 *
+	 * @param int $post_id Product ID.
+	 * @return bool
+	 */
+	private function can_manage_product( $post_id ) {
+		return current_user_can( 'manage_options' ) && current_user_can( 'edit_post', (int) $post_id );
+	}
+
+	/**
+	 * Marketplace labels.
+	 *
+	 * @return array
+	 */
+	private function marketplace_options() {
+		return array(
+			'taobao'         => 'تائوبائو',
+			'1688'           => '۱۶۸۸',
+			'tmall'          => 'تی‌مال',
+			'alibaba'        => 'علی‌بابا',
+			'aliexpress'     => 'علی‌اکسپرس',
+			'iranian_market' => 'فروشگاه ایرانی',
+			'other'          => 'سایر',
+		);
+	}
+
+	/**
+	 * Match-source labels.
+	 *
+	 * @return array
+	 */
+	private function source_options() {
+		return array(
+			'purchase_history' => 'سابقه خرید',
+			'iranian_market'   => 'بررسی بازار ایران',
+			'manual'           => 'ثبت دستی',
+			'other'            => 'سایر',
+		);
+	}
+
+	/**
+	 * Review-state labels.
+	 *
+	 * @return array
+	 */
+	private function status_options() {
+		return array(
+			'candidate' => 'نیازمند بررسی',
+			'matched'   => 'تطبیق داده‌شده',
+			'purchased' => 'خریداری‌شده',
+			'preferred' => 'منبع ترجیحی',
+			'inactive'  => 'غیرفعال',
+		);
+	}
+
+	/**
+	 * Convert a stored provider token into a Persian list-table label.
+	 *
+	 * @param string $provider Provider token.
+	 * @return string
+	 */
+	private function provider_label( $provider ) {
+		if ( str_starts_with( $provider, 'iranian_market:' ) ) {
+			return 'ایران: ' . sanitize_text_field( substr( $provider, strlen( 'iranian_market:' ) ) );
+		}
+
+		$options = $this->marketplace_options();
+
+		return $options[ $provider ] ?? 'سایر';
+	}
+}

--- a/includes/class-digitalogic-product-supplier-links.php
+++ b/includes/class-digitalogic-product-supplier-links.php
@@ -1,0 +1,764 @@
+<?php
+/**
+ * Private WooCommerce product supplier-link storage.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Store reviewed seller links without exposing them to storefront transports.
+ */
+final class Digitalogic_Product_Supplier_Links {
+
+	/**
+	 * Protected product meta key.
+	 */
+	public const META_KEY = '_digitalogic_private_supplier_links_v1';
+
+	/**
+	 * Maximum links stored against one product.
+	 */
+	private const MAX_LINKS = 50;
+
+	/**
+	 * Maximum accepted stdin or request payload size.
+	 */
+	public const MAX_INPUT_BYTES = 1048576;
+
+	/**
+	 * Shared instance.
+	 *
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Return the shared service.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register storage and privacy boundaries.
+	 */
+	private function __construct() {
+		add_action( 'init', array( $this, 'register_meta' ) );
+		add_filter( 'woocommerce_rest_prepare_product_object', array( $this, 'scrub_rest_response' ), 999, 3 );
+		add_filter( 'woocommerce_rest_prepare_product_variation_object', array( $this, 'scrub_rest_response' ), 999, 3 );
+		add_filter( 'woocommerce_rest_pre_insert_product_object', array( $this, 'prevent_rest_write' ), 999, 3 );
+		add_filter( 'woocommerce_rest_pre_insert_product_variation_object', array( $this, 'prevent_rest_write' ), 999, 3 );
+		add_filter( 'woocommerce_webhook_payload', array( $this, 'scrub_webhook_payload' ), 999, 4 );
+	}
+
+	/**
+	 * Register protected metadata without a core REST schema.
+	 *
+	 * @return void
+	 */
+	public function register_meta() {
+		register_post_meta(
+			'product',
+			self::META_KEY,
+			array(
+				'type'              => 'array',
+				'single'            => true,
+				'default'           => array(),
+				'show_in_rest'      => false,
+				'sanitize_callback' => array( $this, 'sanitize_registered_meta' ),
+				'auth_callback'     => array( $this, 'authorize_meta' ),
+			)
+		);
+	}
+
+	/**
+	 * Permit direct metadata access only to administrators who can edit the product.
+	 *
+	 * @param bool   $allowed Existing authorization decision.
+	 * @param string $meta_key Meta key.
+	 * @param int    $post_id Product ID.
+	 * @return bool
+	 */
+	public function authorize_meta( $allowed, $meta_key, $post_id ) {
+		unset( $allowed, $meta_key );
+
+		return current_user_can( 'manage_options' ) && current_user_can( 'edit_post', (int) $post_id );
+	}
+
+	/**
+	 * Best-effort sanitation for callers of the generic metadata API.
+	 *
+	 * Feature writes use replace_links(), which returns validation errors instead
+	 * of silently dropping a malformed row.
+	 *
+	 * @param mixed $value Raw metadata value.
+	 * @return array
+	 */
+	public function sanitize_registered_meta( $value ) {
+		$normalized = $this->normalize_links( $value, array() );
+
+		return is_wp_error( $normalized ) ? array() : $normalized;
+	}
+
+	/**
+	 * Read private links for one parent product.
+	 *
+	 * Callers must enforce the administrator boundary before presenting this
+	 * value. The service deliberately exposes no frontend hook or public route.
+	 *
+	 * @param int $product_id Parent product ID.
+	 * @return array|WP_Error
+	 */
+	public function get_links( $product_id ) {
+		$product = $this->validate_parent_product( $product_id );
+		if ( is_wp_error( $product ) ) {
+			return $product;
+		}
+
+		$stored = get_post_meta( $product_id, self::META_KEY, true );
+		if ( ! is_array( $stored ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				$stored,
+				static function ( $row ) {
+					return is_array( $row )
+						&& isset( $row['id'], $row['url'], $row['marketplace'] )
+						&& is_string( $row['id'] )
+						&& is_string( $row['url'] )
+						&& is_string( $row['marketplace'] );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Replace all private links on one parent product.
+	 *
+	 * @param int   $product_id Parent product ID.
+	 * @param mixed $raw_links Raw link rows.
+	 * @return array|WP_Error Normalized persisted rows.
+	 */
+	public function replace_links( $product_id, $raw_links ) {
+		$product = $this->validate_parent_product( $product_id );
+		if ( is_wp_error( $product ) ) {
+			return $product;
+		}
+
+		$existing = $this->get_links( $product_id );
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
+		}
+
+		$normalized = $this->normalize_links( $raw_links, $existing );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
+		}
+
+		if ( empty( $normalized ) ) {
+			delete_post_meta( $product_id, self::META_KEY );
+			$readback = get_post_meta( $product_id, self::META_KEY, true );
+			if ( '' !== $readback && array() !== $readback ) {
+				return $this->storage_error();
+			}
+
+			return array();
+		}
+
+		update_post_meta( $product_id, self::META_KEY, $normalized );
+		$readback = get_post_meta( $product_id, self::META_KEY, true );
+		if ( $readback !== $normalized ) {
+			return $this->storage_error();
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Add one link without allowing duplicates.
+	 *
+	 * @param int   $product_id Parent product ID.
+	 * @param mixed $raw_link Raw link object.
+	 * @return array|WP_Error Full normalized link collection.
+	 */
+	public function add_link( $product_id, $raw_link ) {
+		$links = $this->get_links( $product_id );
+		if ( is_wp_error( $links ) ) {
+			return $links;
+		}
+
+		$links[] = $raw_link;
+
+		return $this->replace_links( $product_id, $links );
+	}
+
+	/**
+	 * Remove one link by its stable private identifier.
+	 *
+	 * @param int    $product_id Parent product ID.
+	 * @param string $link_id Link identifier.
+	 * @return array|WP_Error Remaining normalized links.
+	 */
+	public function remove_link( $product_id, $link_id ) {
+		$link_id = sanitize_key( $this->scalar_string( $link_id ) );
+		if ( ! preg_match( '/^sl_[a-f0-9]{20}$/', $link_id ) ) {
+			return new WP_Error(
+				'digitalogic_supplier_link_id_invalid',
+				'شناسه لینک تأمین‌کننده معتبر نیست.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$links = $this->get_links( $product_id );
+		if ( is_wp_error( $links ) ) {
+			return $links;
+		}
+
+		$remaining = array_values(
+			array_filter(
+				$links,
+				static function ( $link ) use ( $link_id ) {
+					return ! isset( $link['id'] ) || $link_id !== $link['id'];
+				}
+			)
+		);
+
+		if ( count( $remaining ) === count( $links ) ) {
+			return new WP_Error(
+				'digitalogic_supplier_link_not_found',
+				'لینک تأمین‌کننده پیدا نشد.',
+				array( 'status' => 404 )
+			);
+		}
+
+		return $this->replace_links( $product_id, $remaining );
+	}
+
+	/**
+	 * Return a non-sensitive list-table summary.
+	 *
+	 * @param int $product_id Parent product ID.
+	 * @return array|WP_Error
+	 */
+	public function get_summary( $product_id ) {
+		$links = $this->get_links( $product_id );
+		if ( is_wp_error( $links ) ) {
+			return $links;
+		}
+
+		$providers = array();
+		foreach ( $links as $link ) {
+			$provider = isset( $link['marketplace'] ) ? sanitize_key( $link['marketplace'] ) : 'other';
+			if ( 'iranian_market' === $provider && ! empty( $link['site_name'] ) ) {
+				$provider .= ':' . sanitize_text_field( $link['site_name'] );
+			}
+			$providers[] = $provider;
+		}
+
+		return array(
+			'count'     => count( $links ),
+			'providers' => array_values( array_unique( $providers ) ),
+		);
+	}
+
+	/**
+	 * Remove private metadata from WooCommerce REST responses.
+	 *
+	 * @param mixed $response REST response.
+	 * @param mixed $wc_object WooCommerce product object.
+	 * @param mixed $request REST request.
+	 * @return mixed
+	 */
+	public function scrub_rest_response( $response, $wc_object = null, $request = null ) {
+		unset( $wc_object, $request );
+		if ( ! is_object( $response ) || ! method_exists( $response, 'get_data' ) || ! method_exists( $response, 'set_data' ) ) {
+			return $response;
+		}
+
+		$response->set_data( $this->scrub_payload( $response->get_data() ) );
+
+		return $response;
+	}
+
+	/**
+	 * Refuse WooCommerce REST writes to the private metadata key.
+	 *
+	 * @param mixed $product WooCommerce product object.
+	 * @param mixed $request REST request.
+	 * @param bool  $creating Whether a new object is being created.
+	 * @return mixed
+	 */
+	public function prevent_rest_write( $product, $request, $creating = false ) {
+		unset( $creating );
+		if ( ! is_object( $product ) || ! method_exists( $product, 'delete_meta_data' ) || ! method_exists( $product, 'get_id' ) ) {
+			return $product;
+		}
+
+		$meta_data = is_object( $request ) && method_exists( $request, 'get_param' )
+			? $request->get_param( 'meta_data' )
+			: null;
+		if ( ! is_array( $meta_data ) || ! $this->contains_private_meta( $meta_data ) ) {
+			return $product;
+		}
+
+		$product_id = (int) $product->get_id();
+		$existing   = $product_id > 0 ? get_post_meta( $product_id, self::META_KEY, true ) : '';
+		foreach ( $meta_data as $row ) {
+			if ( is_array( $row ) && isset( $row['key'] ) && self::is_private_meta_key( $row['key'] ) ) {
+				$product->delete_meta_data( (string) $row['key'] );
+			}
+		}
+		$product->delete_meta_data( self::META_KEY );
+		if ( is_array( $existing ) && ! empty( $existing ) && method_exists( $product, 'update_meta_data' ) ) {
+			$product->update_meta_data( self::META_KEY, $existing );
+		}
+
+		return $product;
+	}
+
+	/**
+	 * Remove private metadata from every WooCommerce webhook payload.
+	 *
+	 * @param mixed  $payload Webhook payload.
+	 * @param string $resource_name Resource name.
+	 * @param int    $resource_id Resource ID.
+	 * @param int    $webhook_id Webhook ID.
+	 * @return mixed
+	 */
+	public function scrub_webhook_payload( $payload, $resource_name = '', $resource_id = 0, $webhook_id = 0 ) {
+		unset( $resource_name, $resource_id, $webhook_id );
+
+		return $this->scrub_payload( $payload );
+	}
+
+	/**
+	 * Normalize a bounded collection while preserving created timestamps.
+	 *
+	 * @param mixed $raw_links Raw rows.
+	 * @param array $existing Existing normalized rows.
+	 * @return array|WP_Error
+	 */
+	private function normalize_links( $raw_links, $existing ) {
+		if ( ! is_array( $raw_links ) ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_invalid',
+				'فهرست لینک‌های تأمین‌کننده معتبر نیست.',
+				array( 'status' => 400 )
+			);
+		}
+		if ( count( $raw_links ) > self::MAX_LINKS ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_limit',
+				'تعداد لینک‌های تأمین‌کننده از حد مجاز بیشتر است.',
+				array(
+					'status'  => 400,
+					'maximum' => self::MAX_LINKS,
+				)
+			);
+		}
+
+		$existing_by_id = array();
+		foreach ( $existing as $row ) {
+			if ( isset( $row['id'] ) && is_string( $row['id'] ) ) {
+				$existing_by_id[ $row['id'] ] = $row;
+			}
+		}
+
+		$normalized        = array();
+		$seen_urls         = array();
+		$seen_ids          = array();
+		$seen_supplied_ids = array();
+		foreach ( array_values( $raw_links ) as $index => $raw_link ) {
+			$supplied_id = is_array( $raw_link ) && isset( $raw_link['id'] )
+				? sanitize_key( $this->scalar_string( $raw_link['id'] ) )
+				: '';
+			if ( isset( $existing_by_id[ $supplied_id ] ) ) {
+				if ( isset( $seen_supplied_ids[ $supplied_id ] ) ) {
+					return $this->duplicate_id_error( $index );
+				}
+				$seen_supplied_ids[ $supplied_id ] = true;
+			}
+
+			$row = $this->normalize_link( $raw_link, $existing_by_id );
+			if ( is_wp_error( $row ) ) {
+				$data          = (array) $row->get_error_data();
+				$data['index'] = $index;
+
+				return new WP_Error( $row->get_error_code(), $row->get_error_message(), $data );
+			}
+			if ( isset( $seen_urls[ $row['url'] ] ) ) {
+				continue;
+			}
+			if ( isset( $seen_ids[ $row['id'] ] ) ) {
+				return $this->duplicate_id_error( $index );
+			}
+
+			$seen_urls[ $row['url'] ] = true;
+			$seen_ids[ $row['id'] ]   = true;
+			$normalized[]             = $row;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize one private supplier row.
+	 *
+	 * @param mixed $raw_link Raw row.
+	 * @param array $existing_by_id Existing rows keyed by ID.
+	 * @return array|WP_Error
+	 */
+	private function normalize_link( $raw_link, $existing_by_id ) {
+		if ( ! is_array( $raw_link ) ) {
+			return new WP_Error(
+				'digitalogic_supplier_link_invalid',
+				'یکی از لینک‌های تأمین‌کننده معتبر نیست.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$url = $this->normalize_url( $raw_link['url'] ?? '' );
+		if ( is_wp_error( $url ) ) {
+			return $url;
+		}
+
+		$marketplace = sanitize_key( $this->scalar_string( $raw_link['marketplace'] ?? '' ) );
+		if ( '' === $marketplace ) {
+			$marketplace = $this->infer_marketplace( $url );
+		}
+		if ( ! in_array( $marketplace, $this->marketplaces(), true ) ) {
+			return new WP_Error(
+				'digitalogic_supplier_marketplace_invalid',
+				'نوع بازار یا پلتفرم معتبر نیست.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$supplied_id = isset( $raw_link['id'] ) ? sanitize_key( $this->scalar_string( $raw_link['id'] ) ) : '';
+		$link_id     = preg_match( '/^sl_[a-f0-9]{20}$/', $supplied_id ) && isset( $existing_by_id[ $supplied_id ] )
+			? $supplied_id
+			: '';
+		if ( '' === $link_id ) {
+			$link_id = 'sl_' . substr( hash( 'sha256', $marketplace . "\0" . $url ), 0, 20 );
+		}
+
+		$existing   = $existing_by_id[ $link_id ] ?? array();
+		$now        = current_time( 'mysql', true );
+		$created_at = isset( $existing['created_at'] )
+			? (string) $existing['created_at']
+			: $this->normalize_datetime( $raw_link['created_at'] ?? '', $now );
+
+		$source = sanitize_key( $this->scalar_string( $raw_link['source'] ?? 'manual' ) );
+		if ( ! in_array( $source, $this->sources(), true ) ) {
+			$source = 'manual';
+		}
+
+		$status = sanitize_key( $this->scalar_string( $raw_link['status'] ?? 'candidate' ) );
+		if ( ! in_array( $status, $this->statuses(), true ) ) {
+			$status = 'candidate';
+		}
+
+		$site_name = $this->sanitize_text( $raw_link['site_name'] ?? '', 120 );
+		if ( '' === $site_name ) {
+			$site_name = (string) wp_parse_url( $url, PHP_URL_HOST );
+		}
+
+		return array(
+			'id'           => $link_id,
+			'marketplace'  => $marketplace,
+			'site_name'    => $site_name,
+			'url'          => $url,
+			'source_title' => $this->sanitize_text( $raw_link['source_title'] ?? '', 240 ),
+			'seller'       => $this->sanitize_text( $raw_link['seller'] ?? '', 160 ),
+			'seller_sku'   => $this->sanitize_text( $raw_link['seller_sku'] ?? '', 120 ),
+			'source'       => $source,
+			'status'       => $status,
+			'note'         => $this->sanitize_note( $raw_link['note'] ?? '' ),
+			'created_at'   => $created_at,
+			'updated_at'   => $now,
+			'last_checked' => $this->normalize_date( $raw_link['last_checked'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Normalize and bound an HTTP(S) URL without retaining credentials/fragments.
+	 *
+	 * @param mixed $raw_url Raw URL.
+	 * @return string|WP_Error
+	 */
+	private function normalize_url( $raw_url ) {
+		if ( ! is_scalar( $raw_url ) ) {
+			return $this->url_error();
+		}
+
+		$raw_url = trim( (string) $raw_url );
+		if ( '' === $raw_url || strlen( $raw_url ) > 4096 ) {
+			return $this->url_error();
+		}
+
+		$url   = esc_url_raw( $raw_url, array( 'http', 'https' ) );
+		$parts = wp_parse_url( $url );
+		if (
+			! is_array( $parts )
+			|| empty( $parts['scheme'] )
+			|| empty( $parts['host'] )
+			|| ! in_array( strtolower( $parts['scheme'] ), array( 'http', 'https' ), true )
+			|| isset( $parts['user'] )
+			|| isset( $parts['pass'] )
+		) {
+			return $this->url_error();
+		}
+
+		$normalized = strtolower( $parts['scheme'] ) . '://' . strtolower( $parts['host'] );
+		if ( isset( $parts['port'] ) ) {
+			$normalized .= ':' . (int) $parts['port'];
+		}
+		$normalized .= isset( $parts['path'] ) && '' !== $parts['path'] ? $parts['path'] : '/';
+		if ( isset( $parts['query'] ) && '' !== $parts['query'] ) {
+			$normalized .= '?' . $parts['query'];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Infer a known marketplace from the listing host.
+	 *
+	 * @param string $url Normalized URL.
+	 * @return string
+	 */
+	private function infer_marketplace( $url ) {
+		$host = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+		$map  = array(
+			'1688.com'       => '1688',
+			'taobao.com'     => 'taobao',
+			'tmall.com'      => 'tmall',
+			'alibaba.com'    => 'alibaba',
+			'aliexpress.com' => 'aliexpress',
+		);
+		foreach ( $map as $domain => $marketplace ) {
+			if ( $host === $domain || str_ends_with( $host, '.' . $domain ) ) {
+				return $marketplace;
+			}
+		}
+
+		return str_ends_with( $host, '.ir' ) ? 'iranian_market' : 'other';
+	}
+
+	/**
+	 * Whether a REST request explicitly addresses the private metadata key.
+	 *
+	 * @param array $meta_data REST metadata rows.
+	 * @return bool
+	 */
+	private function contains_private_meta( $meta_data ) {
+		foreach ( $meta_data as $row ) {
+			if ( is_array( $row ) && isset( $row['key'] ) && self::is_private_meta_key( $row['key'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Recursively scrub the protected key from response and webhook arrays.
+	 *
+	 * @param mixed $payload Arbitrary payload.
+	 * @return mixed
+	 */
+	private function scrub_payload( $payload ) {
+		if ( ! is_array( $payload ) ) {
+			return $payload;
+		}
+
+		foreach ( $payload as $key => $value ) {
+			if ( 'meta_data' === $key && is_array( $value ) ) {
+				$value = array_values(
+					array_filter(
+						$value,
+						static function ( $row ) {
+							return ! is_array( $row )
+								|| ! isset( $row['key'] )
+								|| ! self::is_private_meta_key( $row['key'] );
+						}
+					)
+				);
+			}
+			$payload[ $key ] = $this->scrub_payload( $value );
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Validate that storage targets a parent WooCommerce product.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return true|WP_Error
+	 */
+	private function validate_parent_product( $product_id ) {
+		$product_id = absint( $product_id );
+		if ( $product_id < 1 || 'product' !== get_post_type( $product_id ) ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_parent_product_required',
+				'لینک تأمین‌کننده باید به محصول اصلی ووکامرس متصل شود، نه تنوع محصول.',
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Known marketplace identifiers.
+	 *
+	 * @return array
+	 */
+	private function marketplaces() {
+		return array( 'taobao', '1688', 'tmall', 'alibaba', 'aliexpress', 'iranian_market', 'other' );
+	}
+
+	/**
+	 * Known provenance identifiers.
+	 *
+	 * @return array
+	 */
+	private function sources() {
+		return array( 'purchase_history', 'iranian_market', 'manual', 'other' );
+	}
+
+	/**
+	 * Known review-state identifiers.
+	 *
+	 * @return array
+	 */
+	private function statuses() {
+		return array( 'candidate', 'matched', 'purchased', 'preferred', 'inactive' );
+	}
+
+	/**
+	 * Sanitize one bounded single-line value.
+	 *
+	 * @param mixed $value Raw text.
+	 * @param int   $maximum Maximum characters.
+	 * @return string
+	 */
+	private function sanitize_text( $value, $maximum ) {
+		return mb_substr( sanitize_text_field( $this->scalar_string( $value ) ), 0, $maximum );
+	}
+
+	/**
+	 * Sanitize a bounded private note.
+	 *
+	 * @param mixed $value Raw note.
+	 * @return string
+	 */
+	private function sanitize_note( $value ) {
+		return mb_substr( sanitize_textarea_field( $this->scalar_string( $value ) ), 0, 1000 );
+	}
+
+	/**
+	 * Preserve a valid UTC-ish storage timestamp or use the supplied fallback.
+	 *
+	 * @param mixed  $value Raw timestamp.
+	 * @param string $fallback Current timestamp.
+	 * @return string
+	 */
+	private function normalize_datetime( $value, $fallback ) {
+		$value = trim( $this->scalar_string( $value ) );
+
+		return preg_match( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $value ) ? $value : $fallback;
+	}
+
+	/**
+	 * Preserve a valid source-check date.
+	 *
+	 * @param mixed $value Raw date.
+	 * @return string
+	 */
+	private function normalize_date( $value ) {
+		$value = trim( $this->scalar_string( $value ) );
+
+		return preg_match( '/^\d{4}-\d{2}-\d{2}$/', $value ) ? $value : '';
+	}
+
+	/**
+	 * Build a generic URL validation error without reflecting private input.
+	 *
+	 * @return WP_Error
+	 */
+	private function url_error() {
+		return new WP_Error(
+			'digitalogic_supplier_link_url_invalid',
+			'نشانی اینترنتی تأمین‌کننده معتبر نیست.',
+			array( 'status' => 400 )
+		);
+	}
+
+	/**
+	 * Build a stable storage error without including private payload content.
+	 *
+	 * @return WP_Error
+	 */
+	private function storage_error() {
+		return new WP_Error(
+			'digitalogic_supplier_links_storage_failed',
+			'ذخیره لینک‌های تأمین‌کننده کامل نشد. دوباره تلاش کنید.',
+			array(
+				'status'    => 503,
+				'retryable' => true,
+			)
+		);
+	}
+
+	/**
+	 * Build a duplicate stable-ID error without exposing private row content.
+	 *
+	 * @param int $index Duplicate row index.
+	 * @return WP_Error
+	 */
+	private function duplicate_id_error( $index ) {
+		return new WP_Error(
+			'digitalogic_supplier_link_id_duplicate',
+			'شناسه لینک تأمین‌کننده تکراری است.',
+			array(
+				'status' => 400,
+				'index'  => (int) $index,
+			)
+		);
+	}
+
+	/**
+	 * Convert only scalar input to text.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string
+	 */
+	private function scalar_string( $value ) {
+		return is_scalar( $value ) ? (string) $value : '';
+	}
+
+	/**
+	 * Match the protected key using the same ASCII-insensitive semantics as
+	 * typical WordPress postmeta database collations.
+	 *
+	 * @param mixed $key Candidate metadata key.
+	 * @return bool
+	 */
+	private static function is_private_meta_key( $key ) {
+		return is_scalar( $key ) && 0 === strcasecmp( self::META_KEY, (string) $key );
+	}
+}

--- a/includes/cli/class-digitalogic-product-supplier-links-cli.php
+++ b/includes/cli/class-digitalogic-product-supplier-links-cli.php
@@ -1,0 +1,370 @@
+<?php
+/**
+ * WP-CLI access to administrator-only product supplier links.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+/**
+ * Manage private supplier links without placing seller URLs in process arguments.
+ */
+final class Digitalogic_Product_Supplier_Links_CLI {
+
+	/**
+	 * List private links for one exact parent product.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--id=<product_id>]
+	 * : Exact WooCommerce parent product ID.
+	 *
+	 * [--sku=<sku>]
+	 * : Exact WooCommerce parent product SKU.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp digitalogic supplier-links list --id=123 --user=administrator
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 * @return void
+	 * @when after_wp_load
+	 */
+	public function list_links( $args, $assoc_args ) {
+		unset( $args );
+		$product = $this->require_product( $assoc_args );
+		if ( is_wp_error( $product ) ) {
+			$this->output_error( $product );
+			return;
+		}
+
+		$links = Digitalogic_Product_Supplier_Links::instance()->get_links( $product['woocommerce_id'] );
+		if ( is_wp_error( $links ) ) {
+			$this->output_error( $links );
+			return;
+		}
+
+		WP_CLI::line(
+			wp_json_encode(
+				array(
+					'product_id' => (string) $product['woocommerce_id'],
+					'count'      => count( $links ),
+					'links'      => $links,
+				),
+				JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+			)
+		);
+	}
+
+	/**
+	 * Add one private link read as a JSON object from stdin.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--id=<product_id>]
+	 * : Exact WooCommerce parent product ID.
+	 *
+	 * [--sku=<sku>]
+	 * : Exact WooCommerce parent product SKU.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     printf '%s' "$SELLER_LINK_JSON" | wp digitalogic supplier-links add --id=123 --user=administrator
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 * @return void
+	 * @when after_wp_load
+	 */
+	public function add_link( $args, $assoc_args ) {
+		unset( $args );
+		$product = $this->require_product( $assoc_args );
+		if ( is_wp_error( $product ) ) {
+			$this->output_error( $product );
+			return;
+		}
+
+		$input = $this->read_stdin_json( false );
+		if ( is_wp_error( $input ) ) {
+			$this->output_error( $input );
+			return;
+		}
+
+		$result = Digitalogic_Product_Supplier_Links::instance()->add_link( $product['woocommerce_id'], $input );
+		if ( is_wp_error( $result ) ) {
+			$this->output_error( $result );
+			return;
+		}
+
+		$this->output_mutation_summary( $product['woocommerce_id'], $result );
+	}
+
+	/**
+	 * Replace all links with a JSON array read from stdin.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--id=<product_id>]
+	 * : Exact WooCommerce parent product ID.
+	 *
+	 * [--sku=<sku>]
+	 * : Exact WooCommerce parent product SKU.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     printf '%s' "$SELLER_LINKS_JSON" | wp digitalogic supplier-links replace --sku=MODULE-1 --user=administrator
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 * @return void
+	 * @when after_wp_load
+	 */
+	public function replace_links( $args, $assoc_args ) {
+		unset( $args );
+		$product = $this->require_product( $assoc_args );
+		if ( is_wp_error( $product ) ) {
+			$this->output_error( $product );
+			return;
+		}
+
+		$input = $this->read_stdin_json( true );
+		if ( is_wp_error( $input ) ) {
+			$this->output_error( $input );
+			return;
+		}
+
+		$result = Digitalogic_Product_Supplier_Links::instance()->replace_links( $product['woocommerce_id'], $input );
+		if ( is_wp_error( $result ) ) {
+			$this->output_error( $result );
+			return;
+		}
+
+		$this->output_mutation_summary( $product['woocommerce_id'], $result );
+	}
+
+	/**
+	 * Remove one private link by stable ID.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--id=<product_id>]
+	 * : Exact WooCommerce parent product ID.
+	 *
+	 * [--sku=<sku>]
+	 * : Exact WooCommerce parent product SKU.
+	 *
+	 * --link-id=<link_id>
+	 * : Stable ID returned by the list command.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 * @return void
+	 * @when after_wp_load
+	 */
+	public function remove_link( $args, $assoc_args ) {
+		unset( $args );
+		$product = $this->require_product( $assoc_args );
+		if ( is_wp_error( $product ) ) {
+			$this->output_error( $product );
+			return;
+		}
+
+		$link_id = isset( $assoc_args['link-id'] ) ? sanitize_key( $assoc_args['link-id'] ) : '';
+		if ( '' === $link_id ) {
+			$this->output_error(
+				new WP_Error(
+					'digitalogic_supplier_link_id_required',
+					'گزینه --link-id الزامی است.',
+					array( 'status' => 400 )
+				)
+			);
+			return;
+		}
+
+		$result = Digitalogic_Product_Supplier_Links::instance()->remove_link( $product['woocommerce_id'], $link_id );
+		if ( is_wp_error( $result ) ) {
+			$this->output_error( $result );
+			return;
+		}
+
+		$this->output_mutation_summary( $product['woocommerce_id'], $result );
+	}
+
+	/**
+	 * Decode a bounded JSON payload for tests and stdin handling.
+	 *
+	 * @param string $json Raw JSON.
+	 * @param bool   $expect_list Whether the top level must be a list.
+	 * @return array|WP_Error
+	 */
+	public static function decode_json_input( $json, $expect_list ) {
+		if ( ! is_string( $json ) || '' === trim( $json ) || strlen( $json ) > Digitalogic_Product_Supplier_Links::MAX_INPUT_BYTES ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_input_invalid',
+				'ورودی JSON خالی یا بزرگ‌تر از حد مجاز است.',
+				array( 'status' => 400 )
+			);
+		}
+
+		try {
+			$shape   = json_decode( $json, false, 64, JSON_THROW_ON_ERROR );
+			$decoded = json_decode( $json, true, 64, JSON_THROW_ON_ERROR );
+		} catch ( JsonException ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_json_invalid',
+				'ساختار JSON لینک‌های تأمین‌کننده معتبر نیست.',
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! is_array( $decoded ) || ( $expect_list && ! is_array( $shape ) ) || ( ! $expect_list && ! is_object( $shape ) ) ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_json_shape_invalid',
+				$expect_list ? 'برای جایگزینی، یک آرایه JSON ارسال کنید.' : 'برای افزودن، یک شیء JSON ارسال کنید.',
+				array( 'status' => 400 )
+			);
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Require an exact parent product plus administrator capabilities.
+	 *
+	 * @param array $assoc_args Named CLI arguments.
+	 * @return array|WP_Error
+	 */
+	private function require_product( $assoc_args ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_admin_required',
+				'این دستور باید با --user=<administrator> اجرا شود.',
+				array( 'status' => 403 )
+			);
+		}
+
+		$has_id  = isset( $assoc_args['id'] ) && '' !== trim( (string) $assoc_args['id'] );
+		$has_sku = isset( $assoc_args['sku'] ) && '' !== trim( (string) $assoc_args['sku'] );
+		if ( 1 !== (int) $has_id + (int) $has_sku ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_selector_invalid',
+				'دقیقاً یکی از گزینه‌های --id یا --sku را مشخص کنید.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$identifiers = $has_id
+			? array( 'woocommerce_id' => (string) $assoc_args['id'] )
+			: array( 'sku' => (string) $assoc_args['sku'] );
+		$product     = Digitalogic_Product_Identifier_Resolver::instance()->resolve( $identifiers );
+		if ( is_wp_error( $product ) ) {
+			return $product;
+		}
+		if ( 'product' !== $product['post_type'] ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_parent_product_required',
+				'شناسه باید متعلق به محصول اصلی باشد، نه تنوع محصول.',
+				array( 'status' => 400 )
+			);
+		}
+		if ( ! current_user_can( 'edit_post', (int) $product['woocommerce_id'] ) ) {
+			return new WP_Error(
+				'digitalogic_supplier_links_edit_forbidden',
+				'کاربر انتخاب‌شده اجازه ویرایش این محصول را ندارد.',
+				array( 'status' => 403 )
+			);
+		}
+
+		return $product;
+	}
+
+	/**
+	 * Read JSON from a non-interactive stdin stream.
+	 *
+	 * @param bool $expect_list Whether the top level must be a list.
+	 * @return array|WP_Error
+	 */
+	private function read_stdin_json( $expect_list ) {
+		if ( ! defined( 'STDIN' ) || ! is_resource( STDIN ) ) {
+			return $this->stdin_error();
+		}
+		if ( function_exists( 'stream_isatty' ) && stream_isatty( STDIN ) ) {
+			return $this->stdin_error();
+		}
+
+		$input = stream_get_contents( STDIN, Digitalogic_Product_Supplier_Links::MAX_INPUT_BYTES + 1 );
+		if ( false === $input ) {
+			return $this->stdin_error();
+		}
+
+		return self::decode_json_input( $input, $expect_list );
+	}
+
+	/**
+	 * Print a mutation summary with no seller URL or private note.
+	 *
+	 * @param string|int $product_id Product ID.
+	 * @param array      $links Persisted links.
+	 * @return void
+	 */
+	private function output_mutation_summary( $product_id, $links ) {
+		WP_CLI::line(
+			wp_json_encode(
+				array(
+					'product_id' => (string) $product_id,
+					'count'      => count( $links ),
+					'link_ids'   => array_values( array_column( $links, 'id' ) ),
+				),
+				JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+			)
+		);
+	}
+
+	/**
+	 * Send one redacted WP-CLI error.
+	 *
+	 * @param WP_Error $error Error object.
+	 * @return void
+	 */
+	private function output_error( $error ) {
+		WP_CLI::error( $error->get_error_message() );
+	}
+
+	/**
+	 * Build the missing-pipe error.
+	 *
+	 * @return WP_Error
+	 */
+	private function stdin_error() {
+		return new WP_Error(
+			'digitalogic_supplier_links_stdin_required',
+			'JSON لینک تأمین‌کننده را از ورودی استاندارد (stdin) ارسال کنید.',
+			array( 'status' => 400 )
+		);
+	}
+}
+
+WP_CLI::add_command(
+	'digitalogic supplier-links list',
+	array( 'Digitalogic_Product_Supplier_Links_CLI', 'list_links' )
+);
+WP_CLI::add_command(
+	'digitalogic supplier-links add',
+	array( 'Digitalogic_Product_Supplier_Links_CLI', 'add_link' )
+);
+WP_CLI::add_command(
+	'digitalogic supplier-links replace',
+	array( 'Digitalogic_Product_Supplier_Links_CLI', 'replace_links' )
+);
+WP_CLI::add_command(
+	'digitalogic supplier-links remove',
+	array( 'Digitalogic_Product_Supplier_Links_CLI', 'remove_link' )
+);

--- a/tests/ProductSupplierLinksTest.php
+++ b/tests/ProductSupplierLinksTest.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * Private product supplier-link contract tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/** Verify storage, privacy, admin, and CLI boundaries. */
+final class ProductSupplierLinksTest extends TestCase {
+
+	/**
+	 * Service under test.
+	 *
+	 * @var Digitalogic_Product_Supplier_Links
+	 */
+	private $service;
+
+	/** Reset deterministic product fixtures. */
+	protected function setUp(): void {
+		$GLOBALS['digitalogic_test_posts']                = array(
+			101 => array(
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'ماژول تست',
+				'meta'        => array( '_sku' => 'MODULE-101' ),
+			),
+			102 => array(
+				'post_type'   => 'product_variation',
+				'post_status' => 'publish',
+				'post_parent' => 101,
+				'meta'        => array( '_sku' => 'MODULE-101-BLUE' ),
+			),
+		);
+		$GLOBALS['digitalogic_test_post_meta_cache']      = array();
+		$GLOBALS['digitalogic_test_capabilities']         = array(
+			'manage_options' => true,
+			'edit_post'      => true,
+		);
+		$GLOBALS['digitalogic_test_registered_post_meta'] = array();
+		$GLOBALS['digitalogic_test_meta_boxes']           = array();
+		$GLOBALS['digitalogic_test_enqueued_scripts']     = array();
+		$GLOBALS['digitalogic_test_enqueued_styles']      = array();
+		$GLOBALS['digitalogic_test_valid_nonces']         = array();
+		$GLOBALS['digitalogic_test_autosaves']            = array();
+		$GLOBALS['digitalogic_test_revisions']            = array();
+		$GLOBALS['digitalogic_test_current_user_id']      = 7;
+		$GLOBALS['digitalogic_test_current_screen']       = (object) array( 'post_type' => 'product' );
+		$GLOBALS['wpdb']                                  = new Digitalogic_Test_WPDB();
+		WP_CLI::$errors                                   = array();
+		WP_CLI::$logs                                     = array();
+		$_POST         = array();
+		$this->service = Digitalogic_Product_Supplier_Links::instance();
+	}
+
+	/** Verify protected registration and the strict administrator capability pair. */
+	public function test_registered_meta_is_private_and_admin_authorized(): void {
+		$this->service->register_meta();
+
+		$args = $GLOBALS['digitalogic_test_registered_post_meta']['product'][ Digitalogic_Product_Supplier_Links::META_KEY ];
+		$this->assertFalse( $args['show_in_rest'] );
+		$this->assertTrue( $args['single'] );
+		$this->assertSame( 'array', $args['type'] );
+		$this->assertTrue( $this->service->authorize_meta( false, Digitalogic_Product_Supplier_Links::META_KEY, 101 ) );
+
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = false;
+		$this->assertFalse( $this->service->authorize_meta( true, Digitalogic_Product_Supplier_Links::META_KEY, 101 ) );
+	}
+
+	/** Verify Persian data, provider inference, URL normalization, and de-duplication. */
+	public function test_replace_links_normalizes_and_persists_reviewed_rows(): void {
+		$result = $this->service->replace_links(
+			101,
+			array(
+				array(
+					'url'          => 'HTTPS://Item.Taobao.com/item.htm?id=123#tracking',
+					'site_name'    => 'فروشنده چین',
+					'source_title' => 'ماژول بلوتوث اصلی',
+					'source'       => 'purchase_history',
+					'status'       => 'matched',
+					'note'         => "خرید قبلی\nتطبیق‌شده",
+					'last_checked' => '2026-07-24',
+				),
+				array(
+					'url'          => 'https://item.taobao.com/item.htm?id=123',
+					'source_title' => 'ردیف تکراری',
+				),
+				array(
+					'url'       => 'https://example.ir/product/module',
+					'site_name' => 'فروشگاه ایرانی نمونه',
+					'source'    => 'iranian_market',
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'taobao', $result[0]['marketplace'] );
+		$this->assertSame( 'https://item.taobao.com/item.htm?id=123', $result[0]['url'] );
+		$this->assertSame( 'فروشنده چین', $result[0]['site_name'] );
+		$this->assertSame( 'ماژول بلوتوث اصلی', $result[0]['source_title'] );
+		$this->assertSame( 'purchase_history', $result[0]['source'] );
+		$this->assertSame( 'matched', $result[0]['status'] );
+		$this->assertStringStartsWith( 'sl_', $result[0]['id'] );
+		$this->assertSame( 'iranian_market', $result[1]['marketplace'] );
+		$this->assertSame( $result, get_post_meta( 101, Digitalogic_Product_Supplier_Links::META_KEY, true ) );
+	}
+
+	/** Verify imported IDs cannot forge or collide with an existing private row. */
+	public function test_only_existing_ids_are_preserved_and_duplicate_ids_are_rejected(): void {
+		$forged_id = 'sl_0123456789abcdef0123';
+		$initial   = $this->service->replace_links(
+			101,
+			array(
+				array(
+					'id'  => $forged_id,
+					'url' => 'https://item.taobao.com/item.htm?id=400',
+				),
+			)
+		);
+
+		$this->assertNotSame( $forged_id, $initial[0]['id'] );
+		$existing_id = $initial[0]['id'];
+
+		$collision = $this->service->replace_links(
+			101,
+			array(
+				array(
+					'id'  => $existing_id,
+					'url' => 'https://item.taobao.com/item.htm?id=401',
+				),
+				array(
+					'id'  => $existing_id,
+					'url' => 'https://item.taobao.com/item.htm?id=401',
+				),
+			)
+		);
+
+		$this->assertSame( 'digitalogic_supplier_link_id_duplicate', $collision->get_error_code() );
+		$this->assertSame( $initial, $this->service->get_links( 101 ) );
+	}
+
+	/** Verify unsafe URLs and variation targets cannot alter storage. */
+	public function test_invalid_url_and_variation_target_are_rejected(): void {
+		$invalid_url    = $this->service->replace_links(
+			101,
+			array( array( 'url' => 'javascript:alert(1)' ) )
+		);
+		$variation      = $this->service->replace_links(
+			102,
+			array( array( 'url' => 'https://example.com/item' ) )
+		);
+		$non_scalar_url = $this->service->replace_links(
+			101,
+			array( array( 'url' => array( 'https://example.com/item' ) ) )
+		);
+
+		$this->assertSame( 'digitalogic_supplier_link_url_invalid', $invalid_url->get_error_code() );
+		$this->assertSame( 'digitalogic_supplier_link_url_invalid', $non_scalar_url->get_error_code() );
+		$this->assertSame( 'digitalogic_supplier_links_parent_product_required', $variation->get_error_code() );
+		$this->assertSame( '', get_post_meta( 101, Digitalogic_Product_Supplier_Links::META_KEY, true ) );
+		$this->assertSame( '', get_post_meta( 102, Digitalogic_Product_Supplier_Links::META_KEY, true ) );
+	}
+
+	/** Verify WooCommerce REST and webhook payloads never contain private metadata. */
+	public function test_rest_and_webhook_payloads_are_scrubbed_recursively(): void {
+		$private       = array(
+			'id'    => 8,
+			'key'   => Digitalogic_Product_Supplier_Links::META_KEY,
+			'value' => array( array( 'url' => 'https://secret.example/item' ) ),
+		);
+		$public        = array(
+			'id'    => 9,
+			'key'   => '_public_fixture',
+			'value' => 'visible',
+		);
+		$mixed_private = array(
+			'id'    => 10,
+			'key'   => strtoupper( Digitalogic_Product_Supplier_Links::META_KEY ),
+			'value' => array( array( 'url' => 'https://mixed-secret.example/item' ) ),
+		);
+		$response      = new WP_REST_Response(
+			array(
+				'id'        => 101,
+				'meta_data' => array( $private, $mixed_private, $public ),
+				'child'     => array( 'meta_data' => array( $mixed_private ) ),
+			)
+		);
+
+		$this->service->scrub_rest_response( $response );
+		$data = $response->get_data();
+		$this->assertSame( array( $public ), $data['meta_data'] );
+		$this->assertSame( array(), $data['child']['meta_data'] );
+
+		$webhook = $this->service->scrub_webhook_payload( array( 'meta_data' => array( $private, $mixed_private, $public ) ) );
+		$this->assertSame( array( $public ), $webhook['meta_data'] );
+		$this->assertStringNotContainsString( 'secret.example', wp_json_encode( $webhook ) );
+		$this->assertStringNotContainsString( 'mixed-secret.example', wp_json_encode( $webhook ) );
+	}
+
+	/** Verify a REST write attempt restores the existing private value. */
+	public function test_rest_write_attempt_cannot_replace_private_metadata(): void {
+		$stored    = $this->service->replace_links(
+			101,
+			array( array( 'url' => 'https://item.taobao.com/item.htm?id=321' ) )
+		);
+		$product   = new WC_Product( 101 );
+		$mixed_key = strtoupper( Digitalogic_Product_Supplier_Links::META_KEY );
+		$product->update_meta_data(
+			$mixed_key,
+			array( array( 'url' => 'https://attacker.example/item' ) )
+		);
+		$request = new WP_REST_Request(
+			array(),
+			array(
+				'meta_data' => array(
+					array(
+						'key'   => $mixed_key,
+						'value' => array( array( 'url' => 'https://attacker.example/item' ) ),
+					),
+				),
+			)
+		);
+
+		$result = $this->service->prevent_rest_write( $product, $request );
+
+		$this->assertSame( $stored, $result->get_meta( Digitalogic_Product_Supplier_Links::META_KEY ) );
+		$this->assertSame( '', $result->get_meta( $mixed_key ) );
+		$this->assertStringNotContainsString( 'attacker.example', wp_json_encode( $result->get_meta( Digitalogic_Product_Supplier_Links::META_KEY ) ) );
+	}
+
+	/** Verify the WordPress postbox ID cannot shadow the JavaScript repeater root. */
+	public function test_admin_metabox_and_repeater_root_ids_do_not_collide(): void {
+		$admin = Digitalogic_Product_Supplier_Links_Admin::instance();
+		$admin->add_meta_box( get_post( 101 ) );
+
+		$this->assertArrayHasKey( 'digitalogic-private-supplier-links-box', $GLOBALS['digitalogic_test_meta_boxes'] );
+		$this->assertArrayNotHasKey( 'digitalogic-private-supplier-links', $GLOBALS['digitalogic_test_meta_boxes'] );
+
+		ob_start();
+		$admin->render_meta_box( get_post( 101 ) );
+		$output = (string) ob_get_clean();
+
+		$this->assertSame( 1, substr_count( $output, 'id="digitalogic-private-supplier-links"' ) );
+		$this->assertStringContainsString( 'data-next-index="0"', $output );
+	}
+
+	/** Verify nonce-guarded admin save and a redacted list-table column. */
+	public function test_admin_save_and_list_column_never_print_raw_urls(): void {
+		$admin = Digitalogic_Product_Supplier_Links_Admin::instance();
+		$GLOBALS['digitalogic_test_valid_nonces']['digitalogic_save_supplier_links'] = 'valid-nonce';
+		$_POST = array(
+			'digitalogic_supplier_links_nonce' => 'valid-nonce',
+			'digitalogic_supplier_links'       => array(
+				array(
+					'url'          => 'https://www.aliexpress.com/item/100500123.html',
+					'source_title' => 'برد توسعه',
+				),
+			),
+		);
+
+		$admin->save_product( 101, get_post( 101 ), true );
+		$this->assertCount( 1, $this->service->get_links( 101 ) );
+
+		ob_start();
+		$admin->render_product_column( 'digitalogic_supplier_links', 101 );
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'علی‌اکسپرس', $output );
+		$this->assertStringNotContainsString( 'aliexpress.com', $output );
+	}
+
+	/** Verify denied or autosave requests leave existing metadata untouched. */
+	public function test_admin_save_guards_block_unauthorized_and_autosave_writes(): void {
+		$existing = $this->service->replace_links(
+			101,
+			array( array( 'url' => 'https://www.alibaba.com/product-detail/example.html' ) )
+		);
+		$admin    = Digitalogic_Product_Supplier_Links_Admin::instance();
+		$GLOBALS['digitalogic_test_valid_nonces']['digitalogic_save_supplier_links'] = 'valid-nonce';
+		$_POST = array(
+			'digitalogic_supplier_links_nonce' => 'valid-nonce',
+			'digitalogic_supplier_links'       => array(
+				array( 'url' => 'https://example.ir/replacement' ),
+			),
+		);
+
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = false;
+		$admin->save_product( 101, get_post( 101 ), true );
+		$this->assertSame( $existing, $this->service->get_links( 101 ) );
+
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+		$GLOBALS['digitalogic_test_autosaves'][]                    = 101;
+		$admin->save_product( 101, get_post( 101 ), true );
+		$this->assertSame( $existing, $this->service->get_links( 101 ) );
+	}
+
+	/** Verify CLI JSON shape checks and standalone command registration. */
+	public function test_cli_json_decoder_and_command_registration(): void {
+		$single      = Digitalogic_Product_Supplier_Links_CLI::decode_json_input(
+			'{"url":"https://example.ir/کالا","source_title":"ماژول ایرانی"}',
+			false
+		);
+		$list        = Digitalogic_Product_Supplier_Links_CLI::decode_json_input(
+			'[{"url":"https://item.taobao.com/item.htm?id=1"}]',
+			true
+		);
+		$wrong_shape = Digitalogic_Product_Supplier_Links_CLI::decode_json_input( '{}', true );
+
+		$this->assertSame( 'ماژول ایرانی', $single['source_title'] );
+		$this->assertCount( 1, $list );
+		$this->assertSame( 'digitalogic_supplier_links_json_shape_invalid', $wrong_shape->get_error_code() );
+		foreach ( array( 'list', 'add', 'replace', 'remove' ) as $command ) {
+			$this->assertArrayHasKey( 'digitalogic supplier-links ' . $command, WP_CLI::$commands );
+		}
+	}
+
+	/** Verify CLI mutations require admin and never echo a seller URL. */
+	public function test_cli_remove_is_admin_gated_and_mutation_output_is_redacted(): void {
+		$links = $this->service->replace_links(
+			101,
+			array( array( 'url' => 'https://item.taobao.com/item.htm?id=987' ) )
+		);
+		$cli   = new Digitalogic_Product_Supplier_Links_CLI();
+
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = false;
+		$cli->remove_link(
+			array(),
+			array(
+				'id'      => '101',
+				'link-id' => $links[0]['id'],
+			)
+		);
+		$this->assertNotEmpty( WP_CLI::$errors );
+		$this->assertCount( 1, $this->service->get_links( 101 ) );
+
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+		WP_CLI::$errors = array();
+		$cli->remove_link(
+			array(),
+			array(
+				'id'      => '101',
+				'link-id' => $links[0]['id'],
+			)
+		);
+
+		$this->assertSame( array(), WP_CLI::$errors );
+		$this->assertCount( 0, $this->service->get_links( 101 ) );
+		$this->assertStringNotContainsString( 'taobao.com', implode( "\n", WP_CLI::$logs ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -69,6 +69,12 @@ $GLOBALS['digitalogic_test_rewrite_rules'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_rewrite_flushes'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_registered_post_types'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_post_type_meta_caps'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_registered_post_meta'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_meta_boxes'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_current_screen'] = (object) array( 'post_type' => 'product' ); // phpcs:ignore
+$GLOBALS['digitalogic_test_autosaves'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_revisions'] = array(); // phpcs:ignore
+$GLOBALS['digitalogic_test_valid_nonces'] = array(); // phpcs:ignore
 $GLOBALS['digitalogic_test_locale'] = 'en_US';
 $GLOBALS['digitalogic_test_shortcodes'] = array();
 $GLOBALS['digitalogic_test_enqueued_styles'] = array();
@@ -189,6 +195,10 @@ class WP_REST_Response {
         return $this->data;
     }
 
+    public function set_data($data) {
+        $this->data = $data;
+    }
+
     public function get_status() {
         return $this->status;
     }
@@ -291,8 +301,9 @@ function wp_schedule_event($timestamp, $recurrence, $hook, $args = array(), $wp_
 }
 // phpcs:enable
 
-function current_user_can($capability) {
-    $GLOBALS['digitalogic_test_current_user_can_calls']++;
+function current_user_can($capability, ...$args) {
+    unset($args);
+    ++$GLOBALS['digitalogic_test_current_user_can_calls'];
 
     return !empty($GLOBALS['digitalogic_test_capabilities'][$capability]);
 }
@@ -322,12 +333,101 @@ function register_post_type( $post_type, $args = array() ) {
 }
 
 /**
+ * Capture registered post metadata.
+ *
+ * @param string $post_type Post type.
+ * @param string $meta_key Meta key.
+ * @param array  $args Registration arguments.
+ * @return bool
+ */
+function register_post_meta( $post_type, $meta_key, $args ) {
+	$GLOBALS['digitalogic_test_registered_post_meta'][ $post_type ][ $meta_key ] = $args;
+
+	return true;
+}
+
+/**
  * Return the current test user ID.
  *
  * @return int
  */
 function get_current_user_id() {
 	return (int) $GLOBALS['digitalogic_test_current_user_id'];
+}
+
+/**
+ * Return the current test admin screen.
+ *
+ * @return object|null
+ */
+function get_current_screen() {
+	return $GLOBALS['digitalogic_test_current_screen'];
+}
+
+/**
+ * Capture a classic-editor metabox.
+ *
+ * @param string   $id Metabox ID.
+ * @param string   $title Metabox title.
+ * @param callable $callback Render callback.
+ * @param string   $screen Post type.
+ * @param string   $context Metabox context.
+ * @param string   $priority Metabox priority.
+ * @return void
+ */
+function add_meta_box( $id, $title, $callback, $screen = null, $context = 'advanced', $priority = 'default' ) {
+	$GLOBALS['digitalogic_test_meta_boxes'][ $id ] = array(
+		'title'    => $title,
+		'callback' => $callback,
+		'screen'   => is_object( $screen ) && isset( $screen->id ) ? $screen->id : $screen,
+		'context'  => $context,
+		'priority' => $priority,
+	);
+}
+
+/**
+ * Emit a deterministic nonce field.
+ *
+ * @param string $action Nonce action.
+ * @param string $name Field name.
+ * @return void
+ */
+function wp_nonce_field( $action, $name ) {
+	$nonce = 'nonce-' . $action;
+	$GLOBALS['digitalogic_test_valid_nonces'][ $action ] = $nonce;
+	echo '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( $nonce ) . '">';
+}
+
+/**
+ * Verify a deterministic test nonce.
+ *
+ * @param string $nonce Nonce.
+ * @param string $action Nonce action.
+ * @return bool
+ */
+function wp_verify_nonce( $nonce, $action ) {
+	return isset( $GLOBALS['digitalogic_test_valid_nonces'][ $action ] )
+		&& hash_equals( $GLOBALS['digitalogic_test_valid_nonces'][ $action ], (string) $nonce );
+}
+
+/**
+ * Whether the post is a test autosave.
+ *
+ * @param int $post_id Post ID.
+ * @return bool
+ */
+function wp_is_post_autosave( $post_id ) {
+	return in_array( (int) $post_id, $GLOBALS['digitalogic_test_autosaves'], true );
+}
+
+/**
+ * Whether the post is a test revision.
+ *
+ * @param int $post_id Post ID.
+ * @return bool
+ */
+function wp_is_post_revision( $post_id ) {
+	return in_array( (int) $post_id, $GLOBALS['digitalogic_test_revisions'], true );
 }
 
 /**
@@ -409,6 +509,25 @@ function wp_enqueue_style( $handle, $src = '', $dependencies = array(), $version
 		'dependencies' => $dependencies,
 		'version'      => $version,
 		'media'        => $media,
+	);
+}
+
+/**
+ * Capture an enqueued test script.
+ *
+ * @param string       $handle Script handle.
+ * @param string       $src Script URL.
+ * @param array        $dependencies Dependency handles.
+ * @param string|false $version Script version.
+ * @param bool         $in_footer Whether the script belongs in the footer.
+ * @return void
+ */
+function wp_enqueue_script( $handle, $src = '', $dependencies = array(), $version = false, $in_footer = false ) {
+	$GLOBALS['digitalogic_test_enqueued_scripts'][ $handle ] = array(
+		'src'          => $src,
+		'dependencies' => $dependencies,
+		'version'      => $version,
+		'in_footer'    => $in_footer,
 	);
 }
 
@@ -697,6 +816,19 @@ function wp_unslash($value) {
     return $value;
 }
 
+function map_deep($value, $callback) {
+    if (is_array($value)) {
+        return array_map(
+            static function($item) use ($callback) {
+                return map_deep($item, $callback);
+            },
+            $value
+        );
+    }
+
+    return call_user_func($callback, $value);
+}
+
 function wp_generate_password($length = 12, $special_chars = true, $extra_special_chars = false) {
     return substr(str_repeat('test-generated-secret-', 8), 0, (int) $length);
 }
@@ -881,6 +1013,10 @@ function sanitize_text_field($value) {
     return trim(strip_tags((string) $value));
 }
 
+function sanitize_textarea_field($value) {
+    return trim(wp_strip_all_tags((string) $value));
+}
+
 function sanitize_email($value) {
     $email = filter_var((string) $value, FILTER_SANITIZE_EMAIL);
     return filter_var($email, FILTER_VALIDATE_EMAIL) ? $email : '';
@@ -904,6 +1040,22 @@ function esc_attr($value) {
 
 function esc_html($value) {
     return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+function esc_textarea($value) {
+    return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+function number_format_i18n($number, $decimals = 0) {
+    $locale  = strtolower(str_replace('_', '-', determine_locale()));
+    $persian = str_starts_with($locale, 'fa');
+
+    return number_format(
+        (float) $number,
+        (int) $decimals,
+        $persian ? '٫' : '.',
+        $persian ? '٬' : ','
+    );
 }
 
 function wp_http_validate_url($value) {
@@ -2203,6 +2355,7 @@ require_once dirname(__DIR__) . '/includes/class-digitalogic-woocommerce-currenc
 require_once dirname( __DIR__ ) . '/includes/class-digitalogic-access-control.php';
 require_once dirname( __DIR__ ) . '/includes/panel/class-digitalogic-panel-error-page.php';
 require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';
+require_once dirname(__DIR__) . '/includes/class-digitalogic-product-supplier-links.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-query.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-patris-price-policy.php'; // phpcs:ignore
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-column-schema.php'; // phpcs:ignore
@@ -2226,4 +2379,6 @@ require_once dirname(__DIR__) . '/includes/panel/class-panel.php';
 require_once dirname(__DIR__) . '/includes/integrations/class-label-overrides.php';
 require_once dirname(__DIR__) . '/includes/integrations/class-product-identity.php';
 require_once dirname(__DIR__) . '/includes/websocket/class-websocket-server.php';
+require_once dirname(__DIR__) . '/includes/admin/class-digitalogic-product-supplier-links-admin.php';
 require_once dirname(__DIR__) . '/includes/cli/class-cli-commands.php';
+require_once dirname(__DIR__) . '/includes/cli/class-digitalogic-product-supplier-links-cli.php';

--- a/tests/product-supplier-links-admin.test.js
+++ b/tests/product-supplier-links-admin.test.js
@@ -1,0 +1,23 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(
+    path.join(__dirname, '..', 'assets', 'js', 'product-supplier-links-admin.js'),
+    'utf8'
+);
+
+test('private supplier repeater is scoped to its admin metabox', () => {
+    assert.match(source, /getElementById\('digitalogic-private-supplier-links'\)/);
+    assert.match(source, /getElementById\('tmpl-digitalogic-supplier-link-row'\)/);
+    assert.match(source, /replaceAll\('__INDEX__', String\(index\)\)/);
+    assert.match(source, /closest\('\.digitalogic-supplier-link'\)/);
+});
+
+test('private supplier repeater performs no network or browser-storage writes', () => {
+    assert.doesNotMatch(source, /\bfetch\s*\(/);
+    assert.doesNotMatch(source, /\bXMLHttpRequest\b/);
+    assert.doesNotMatch(source, /\blocalStorage\b|\bsessionStorage\b/);
+    assert.doesNotMatch(source, /window\.location/);
+});


### PR DESCRIPTION
Status: **Pending owner approval**. Please keep this PR in draft until the owner explicitly approves it or comments `@codex` with corrections.

## Summary

- add protected parent-product metadata for private supplier links
- add a Persian RTL classic WooCommerce product metabox and a redacted product-list summary
- support Taobao, 1688, Tmall, Alibaba, AliExpress, Iranian markets, and other sources
- add exact-ID/SKU WP-CLI list/add/replace/remove commands; write payloads use stdin and mutation output is redacted
- block variation targets, forged/duplicate link IDs, unsafe URLs, unauthorized saves, autosaves, and revisions
- keep links out of public WordPress REST registration, WooCommerce REST responses/writes, webhooks, storefront output, and structured data
- compare protected meta keys case-insensitively to match typical WordPress postmeta collation behavior

## Privacy

The purchase-derived review manifest and all real seller URLs are intentionally excluded from this repository and PR. Stored values are administrator-restricted but are not encrypted from database administrators.

## Validation

- full PHPUnit: 333 tests, 2,060 assertions (pass; 5 environment skips and 1 Windows socket warning)
- focused PHPUnit: 11 tests, 53 assertions
- Node admin tests: 2/2
- all non-vendor PHP syntax checks: pass
- JavaScript syntax: pass
- focused WordPress PHPCS: pass
- repository PHPCS baseline: 40,575 errors / 3,014 warnings, within existing caps
- `git diff --check`: pass
- public-tree check: pass
- `composer audit --locked`: no advisories

## Deployment state

Not deployed. The live plugin checkout contains unrelated tracked and untracked work, so this change was prepared from a clean `origin/main` clone and must not overwrite production until that checkout is reconciled and the owner approves this PR.

## Known limits

- UI targets the classic WooCommerce product editor.
- Supplier links are attached to parent products only; variations are deliberately rejected.
