### PR TITLE
Fix catalog manifest and product SEO integration

### DIFF
--- a/includes/class-patris-catalog-materializer.php
+++ b/includes/class-patris-catalog-materializer.php
@@ -16,6 +16,8 @@ final class Digitalogic_Patris_Catalog_Materializer {
 
 	public const MANIFEST_SCHEMA = 'digitalogic.patris-catalog-enrichment';
 
+	public const MANIFEST_SCHEMA_VERSION = '1.0';
+
 	public const CATEGORY_CODE_META    = '_digitalogic_patris_category_code';
 	public const CATEGORY_KEY_META     = '_digitalogic_catalog_category_key';
 	public const CATEGORY_TERM_META    = '_digitalogic_patris_category_term_id';
@@ -106,13 +108,16 @@ final class Digitalogic_Patris_Catalog_Materializer {
 		}
 
 		$required = array( 'schema', 'source', 'products', 'categories' );
-		$allowed  = array_merge( $required, array( 'source_revision' ) );
+		$allowed  = array_merge( $required, array( 'schema_version', 'source_revision' ) );
 		$shape    = $this->validate_object_shape( $manifest, $required, $allowed, 'root' );
 		if ( is_wp_error( $shape ) ) {
 			return $shape;
 		}
 		if ( self::MANIFEST_SCHEMA !== $manifest['schema'] ) {
 			return $this->manifest_error( 'schema', 'must identify the living enrichment manifest' );
+		}
+		if ( array_key_exists( 'schema_version', $manifest ) && self::MANIFEST_SCHEMA_VERSION !== $manifest['schema_version'] ) {
+			return $this->manifest_error( 'schema_version', 'must identify the supported manifest contract version' );
 		}
 
 		if ( ! is_array( $manifest['source'] ) || array_is_list( $manifest['source'] ) ) {
@@ -146,11 +151,14 @@ final class Digitalogic_Patris_Catalog_Materializer {
 		}
 
 		$normalized = array(
-			'schema'     => self::MANIFEST_SCHEMA,
-			'source'     => $manifest['source'],
-			'products'   => $products,
-			'categories' => $categories,
+			'schema' => self::MANIFEST_SCHEMA,
 		);
+		if ( array_key_exists( 'schema_version', $manifest ) ) {
+			$normalized['schema_version'] = self::MANIFEST_SCHEMA_VERSION;
+		}
+		$normalized['source']     = $manifest['source'];
+		$normalized['products']   = $products;
+		$normalized['categories'] = $categories;
 		if ( isset( $manifest['source_revision'] ) ) {
 			$normalized['source_revision'] = $manifest['source_revision'];
 		}
@@ -456,7 +464,7 @@ final class Digitalogic_Patris_Catalog_Materializer {
 						'deferred_products' => (int) ( $receiver['deferred_products'] ?? 0 ),
 					);
 				}
-				do_action( 'rank_math/sitemap/flush_cache' );
+				$this->invalidate_sitemap_cache();
 			}
 		} finally {
 			if ( $locked ) {
@@ -1605,6 +1613,27 @@ final class Digitalogic_Patris_Catalog_Materializer {
 			wc_delete_product_transients( (int) $product_id );
 		}
 		clean_post_cache( (int) $product_id );
+	}
+
+	/**
+	 * Invalidate Rank Math sitemap storage after an applied catalog batch.
+	 *
+	 * Current Rank Math versions expose a cache API rather than a flush action.
+	 * Keep the former action as a guarded fallback for older or custom
+	 * integrations that registered it.
+	 */
+	private function invalidate_sitemap_cache() {
+		if (
+			class_exists( '\RankMath\Sitemap\Cache' )
+			&& is_callable( array( '\RankMath\Sitemap\Cache', 'invalidate_storage' ) )
+		) {
+			\RankMath\Sitemap\Cache::invalidate_storage();
+			return;
+		}
+
+		if ( has_action( 'rank_math/sitemap/flush_cache' ) ) {
+			do_action( 'rank_math/sitemap/flush_cache' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- Preserve the former integration hook only as a compatibility fallback.
+		}
 	}
 
 	/**

--- a/includes/integrations/class-product-identity.php
+++ b/includes/integrations/class-product-identity.php
@@ -37,6 +37,7 @@ final class Digitalogic_Product_Identity {
 		add_filter( 'woocommerce_get_item_data', array( $this, 'add_cart_item_patris_code' ), 10, 2 );
 		add_action( 'woocommerce_checkout_create_order_line_item', array( $this, 'add_order_item_patris_code' ), 10, 4 );
 		add_filter( 'woocommerce_structured_data_product', array( $this, 'add_product_schema_identity' ), 10, 2 );
+		add_filter( 'rank_math/snippet/rich_snippet_product_entity', array( $this, 'normalize_product_schema_attribute_names' ), 9, 2 );
 		add_filter( 'rank_math/snippet/rich_snippet_product_entity', array( $this, 'add_product_schema_identity' ), 10, 2 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ), 90 );
 	}
@@ -152,6 +153,48 @@ final class Digitalogic_Product_Identity {
 	}
 
 	/**
+	 * Replace Rank Math's encoded attribute keys with saved WooCommerce labels.
+	 *
+	 * Rank Math builds additionalProperty names from the get_attributes() array
+	 * keys. Custom Persian keys are URL-encoded slugs, while the corresponding
+	 * WC_Product_Attribute retains the administrator-entered display name.
+	 * Only existing PropertyValue names are changed; no properties are added.
+	 *
+	 * @param array      $entity Existing Rank Math Product entity.
+	 * @param WC_Product $product Product when supplied by the integration.
+	 * @return array
+	 */
+	public function normalize_product_schema_attribute_names( $entity, $product = null ) {
+		if ( ! is_array( $entity ) || ! isset( $entity['additionalProperty'] ) || ! is_array( $entity['additionalProperty'] ) ) {
+			return $entity;
+		}
+		if ( ! $product instanceof WC_Product && isset( $GLOBALS['product'] ) && $GLOBALS['product'] instanceof WC_Product ) {
+			$product = $GLOBALS['product'];
+		}
+		if ( ! $product instanceof WC_Product ) {
+			return $entity;
+		}
+
+		$labels = $this->get_product_schema_attribute_labels( $product );
+		if ( empty( $labels ) ) {
+			return $entity;
+		}
+
+		foreach ( $entity['additionalProperty'] as &$property ) {
+			if ( ! is_array( $property ) || ! isset( $property['name'] ) || ! is_string( $property['name'] ) ) {
+				continue;
+			}
+			$key = $this->schema_attribute_lookup_key( $property['name'] );
+			if ( isset( $labels[ $key ] ) ) {
+				$property['name'] = $labels[ $key ];
+			}
+		}
+		unset( $property );
+
+		return $entity;
+	}
+
+	/**
 	 * Add reviewed identities and remove only an impossible offer for unpriced products.
 	 *
 	 * @param array      $entity Existing WooCommerce or Rank Math Product entity.
@@ -190,6 +233,49 @@ final class Digitalogic_Product_Identity {
 		}
 
 		return $entity;
+	}
+
+	/**
+	 * Build encoded-key-to-display-label mappings from saved attributes.
+	 *
+	 * @param WC_Product $product Product whose existing attributes are mapped.
+	 * @return array
+	 */
+	private function get_product_schema_attribute_labels( $product ) {
+		$labels = array();
+		foreach ( (array) $product->get_attributes() as $key => $attribute ) {
+			if ( ! $attribute instanceof WC_Product_Attribute ) {
+				continue;
+			}
+
+			$name  = trim( (string) $attribute->get_name() );
+			$label = function_exists( 'wc_attribute_label' )
+				? trim( wp_strip_all_tags( (string) wc_attribute_label( $name, $product ) ) )
+				: $name;
+			$label = sanitize_text_field( $label );
+			if ( '' === $name || '' === $label ) {
+				continue;
+			}
+
+			foreach ( array( $key, $name ) as $candidate ) {
+				$candidate = $this->schema_attribute_lookup_key( $candidate );
+				if ( '' !== $candidate && ! isset( $labels[ $candidate ] ) ) {
+					$labels[ $candidate ] = $label;
+				}
+			}
+		}
+
+		return $labels;
+	}
+
+	/**
+	 * Normalize only ASCII casing around a WooCommerce attribute key.
+	 *
+	 * @param mixed $key Attribute array key or PropertyValue name.
+	 * @return string
+	 */
+	private function schema_attribute_lookup_key( $key ) {
+		return strtolower( trim( (string) $key ) );
 	}
 
 	/**

--- a/tests/PatrisCatalogMaterializerTest.php
+++ b/tests/PatrisCatalogMaterializerTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 final class PatrisCatalogMaterializerTest extends TestCase {
 
@@ -45,6 +47,7 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 				'digitalogic_test_primed_post_ids',
 				'digitalogic_test_transients',
 				'digitalogic_test_transient_deletes',
+				'digitalogic_test_rank_math_invalidations',
 			) as $global_name
 		) {
 			$GLOBALS[ $global_name ] = array();
@@ -122,6 +125,64 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 		$rejected               = $service->validate_manifest( $manifest );
 		$this->assertInstanceOf( WP_Error::class, $rejected );
 		$this->assertSame( 'digitalogic_patris_materializer_manifest_shape', $rejected->get_error_code() );
+	}
+
+	/** Verify the producer's version marker remains optional but strictly typed. */
+	public function test_manifest_accepts_the_supported_optional_schema_version_and_rejects_other_versions(): void {
+		$service                    = Digitalogic_Patris_Catalog_Materializer::instance();
+		$manifest                   = $this->manifest();
+		$manifest['schema_version'] = Digitalogic_Patris_Catalog_Materializer::MANIFEST_SCHEMA_VERSION;
+		$validated                  = $service->validate_manifest( $manifest );
+
+		$this->assertNotInstanceOf( WP_Error::class, $validated );
+		$this->assertSame(
+			array( 'schema', 'schema_version', 'source', 'products', 'categories' ),
+			array_keys( $validated )
+		);
+		$this->assertSame( '1.0', $validated['schema_version'] );
+
+		foreach ( array( null, 1.0, '1', '1.0 ', '2.0' ) as $unsupported ) {
+			$manifest['schema_version'] = $unsupported;
+			$rejected                   = $service->validate_manifest( $manifest );
+
+			$this->assertInstanceOf( WP_Error::class, $rejected );
+			$this->assertSame( 'digitalogic_patris_materializer_manifest_invalid', $rejected->get_error_code() );
+			$this->assertSame( 'schema_version', $rejected->get_error_data()['path'] );
+		}
+	}
+
+	/** Verify current Rank Math releases use their supported cache API. */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_apply_prefers_the_current_rank_math_sitemap_cache_api(): void {
+		$this->assertFalse( class_exists( '\RankMath\Sitemap\Cache', false ) );
+		require_once __DIR__ . '/fixtures/rank-math/class-cache.php';
+		$this->receiveFixture();
+
+		$result = Digitalogic_Patris_Catalog_Materializer::instance()->run( $this->manifest(), array( 'apply' => true ) );
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertSame( array( null ), $GLOBALS['digitalogic_test_rank_math_invalidations'] );
+		$this->assertArrayNotHasKey( 'rank_math/sitemap/flush_cache', $GLOBALS['digitalogic_test_actions'] );
+	}
+
+	/** Verify a pre-existing listener still works when Rank Math's API is absent. */
+	public function test_apply_uses_a_registered_legacy_rank_math_sitemap_flush_listener_as_fallback(): void {
+		$this->assertFalse( class_exists( '\RankMath\Sitemap\Cache', false ) );
+		$invalidations = 0;
+		add_action(
+			'rank_math/sitemap/flush_cache',
+			static function () use ( &$invalidations ) {
+				++$invalidations;
+			}
+		);
+		$this->receiveFixture();
+
+		$result = Digitalogic_Patris_Catalog_Materializer::instance()->run( $this->manifest(), array( 'apply' => true ) );
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 1, $invalidations );
+		$this->assertCount( 1, $GLOBALS['digitalogic_test_actions']['rank_math/sitemap/flush_cache'] );
 	}
 
 	public function test_apply_creates_an_idempotent_draft_with_exact_feed_category_and_air_express(): void {

--- a/tests/ProductIdentitySearchTest.php
+++ b/tests/ProductIdentitySearchTest.php
@@ -65,6 +65,8 @@ final class ProductIdentitySearchTest extends TestCase {
 		$GLOBALS['digitalogic_test_enqueued_styles']   = array();
 		$GLOBALS['digitalogic_test_enqueued_scripts']  = array();
 		$GLOBALS['digitalogic_test_localized_scripts'] = array();
+
+		$GLOBALS['digitalogic_test_wc_attribute_labels'] = array();
 	}
 
 	public function test_localizes_single_product_patris_name_for_woodmart_fallback(): void {
@@ -239,6 +241,72 @@ final class ProductIdentitySearchTest extends TestCase {
 		$slot = ob_get_clean();
 		$this->assertStringContainsString( 'data-digitalogic-variation-identity', $slot );
 		$this->assertStringContainsString( 'aria-live="polite"', $slot );
+	}
+
+	/** Ensure Rank Math uses saved labels without changing any PropertyValue data. */
+	public function test_normalizes_rank_math_additional_property_names_from_saved_woocommerce_attributes(): void {
+		// phpcs:disable Generic.Formatting.MultipleStatementAlignment -- Keep the schema fixture's setup groups compact.
+		$custom_label = "\u{062A}\u{0648}\u{0627}\u{0646} \u{062E}\u{0631}\u{0648}\u{062C}\u{06CC}";
+		$model_label  = "\u{0645}\u{062F}\u{0644}";
+		$custom_key   = strtolower( rawurlencode( $custom_label ) );
+
+		$custom_attribute = new WC_Product_Attribute();
+		$custom_attribute->set_name( $custom_label );
+		$custom_attribute->set_visible( true );
+		$model_attribute = new WC_Product_Attribute();
+		$model_attribute->set_id( 7 );
+		$model_attribute->set_name( 'pa_model' );
+		$model_attribute->set_visible( true );
+
+		$GLOBALS['digitalogic_test_posts'][19] = array(
+			'post_type'    => 'product',
+			'post_status'  => 'publish',
+			'product_type' => 'simple',
+			'post_title'   => 'Schema attribute labels',
+			'attributes'   => array(
+				$custom_key => $custom_attribute,
+				'pa_model'  => $model_attribute,
+			),
+			'meta'         => array(),
+		);
+		$GLOBALS['digitalogic_test_wc_attribute_labels']['pa_model'] = $model_label;
+		$GLOBALS['product'] = wc_get_product( 19 );
+
+		$identity = ( new ReflectionClass( Digitalogic_Product_Identity::class ) )->newInstanceWithoutConstructor();
+		$entity   = array(
+			'@type'              => 'Product',
+			'brand'              => array(
+				'@type' => 'Brand',
+				'name'  => 'Existing brand',
+			),
+			'gtin13'             => '1234567890123',
+			'image'              => 'https://digitalogic.test/existing.jpg',
+			'additionalProperty' => array(
+				array(
+					'@type' => 'PropertyValue',
+					'name'  => strtoupper( $custom_key ),
+					'value' => '60 W',
+				),
+				array(
+					'@type' => 'PropertyValue',
+					'name'  => 'pa_model',
+					'value' => 'TPA3118',
+				),
+				array(
+					'@type' => 'PropertyValue',
+					'name'  => 'unrelated-key',
+					'value' => 'preserved',
+				),
+			),
+		);
+		$expected           = $entity;
+		$expected['additionalProperty'][0]['name'] = $custom_label;
+		$expected['additionalProperty'][1]['name'] = $model_label;
+
+		$normalized = $identity->normalize_product_schema_attribute_names( $entity );
+		// phpcs:enable Generic.Formatting.MultipleStatementAlignment
+
+		$this->assertSame( $expected, $normalized );
 	}
 
 	/** Ensure the selected Code follows a customer line through the order flow. */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1956,6 +1956,7 @@ class WC_Product_Attribute {
     public function set_position($value) { $this->position = (int) $value; }
     public function set_visible($value) { $this->visible = (bool) $value; }
     public function set_variation($value) { $this->variation = (bool) $value; }
+    public function get_name() { return $this->name; }
     public function get_options() { return $this->options; }
     public function get_visible() { return $this->visible; }
     public function get_variation() { return $this->variation; }
@@ -2250,6 +2251,23 @@ function get_woocommerce_currency_symbol($currency = '') {
     $currency = strtoupper((string) $currency);
 
     return 'IRT' === $currency ? 'Toman' : $currency;
+}
+
+/** Resolve a test attribute label from the in-memory taxonomy registry. */
+function wc_attribute_label($name, $product = '') {
+    $labels = $GLOBALS['digitalogic_test_wc_attribute_labels'] ?? array();
+    if (array_key_exists((string) $name, $labels)) {
+        return (string) $labels[(string) $name];
+    }
+    if ($product instanceof WC_Product) {
+        foreach ($product->get_attributes() as $attribute) {
+            if ($attribute instanceof WC_Product_Attribute && (string) $attribute->get_name() === (string) $name) {
+                return (string) $attribute->get_name();
+            }
+        }
+    }
+
+    return (string) $name;
 }
 
 function wc_get_weight($weight, $to_unit, $from_unit = '') {

--- a/tests/fixtures/rank-math/class-cache.php
+++ b/tests/fixtures/rank-math/class-cache.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Rank Math sitemap cache test double.
+ *
+ * @package Digitalogic
+ */
+
+namespace RankMath\Sitemap;
+
+/**
+ * Record sitemap invalidations requested by the materializer.
+ */
+final class Cache {
+
+	/**
+	 * Record one cache invalidation.
+	 *
+	 * @param null|string $type Optional sitemap type.
+	 */
+	public static function invalidate_storage( $type = null ) {
+		$GLOBALS['digitalogic_test_rank_math_invalidations'][] = $type;
+	}
+}


### PR DESCRIPTION
## What changed

- accept the reviewed `digitalogic.patris-catalog-enrichment` manifest schema version `1.0` without weakening legacy validation
- invalidate Rank Math sitemap storage through the current supported cache API
- expose readable WooCommerce attribute labels in Product `additionalProperty` while preserving stored values
- add focused materializer, Rank Math, and product-identity regressions

## Why

The current production materializer rejects the reviewed catalog manifest solely because of its explicit root schema version. Product structured data can also emit encoded attribute names, and sitemap refresh must use Rank Math's current cache API.

## Validation

- Patris materializer: 23 tests, 257 assertions
- Product identity/search: 15 tests, 67 assertions
- PHP syntax: passed
- `git diff --check`: passed