### PR TITLE
Require evidence for exact category overrides

### DIFF
--- a/docs/PATRIS-CATALOG-MATERIALIZER.md
+++ b/docs/PATRIS-CATALOG-MATERIALIZER.md
@@ -107,9 +107,11 @@ shown below is required even when its value is empty or `null`.
 }
 ```
 
-`source_revision` is the only optional root key. Omit it when the same reviewed
-manifest must be deliberately reused after a fresh sync, such as the second
-publication phase. The source ID and dataset still remain exact.
+`source_revision` is the only optional root key for manifests without product
+category overrides. Every manifest containing a `category_override` must pin it:
+classification approval is valid only for the exact reviewed source revision.
+For a deliberately reusable manifest without overrides, the source ID and
+dataset still remain exact.
 
 ## Product rows
 
@@ -162,7 +164,12 @@ reviewed target:
 ```json
 {
   "category_code": "101001",
-  "target_term_id": null
+  "target_term_id": null,
+  "approved_name_fa": "ماژول مبدل سطح منطقی چهار کاناله",
+  "approved_source_revision": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "evidence_urls": [
+    "https://manufacturer.example/products/logic-level-converter"
+  ]
 }
 ```
 
@@ -171,13 +178,23 @@ or:
 ```json
 {
   "category_code": null,
-  "target_term_id": "84"
+  "target_term_id": "84",
+  "approved_name_fa": "ماژول مبدل سطح منطقی چهار کاناله",
+  "approved_source_revision": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "evidence_urls": [
+    "https://manufacturer.example/products/logic-level-converter"
+  ]
 }
 ```
 
 The category Code can reference a source category or a synthetic
 `digitalogic:*` category declared in the manifest. A direct term override must
-name an existing product category by exact term ID.
+name an existing product category by exact term ID. Override approval is
+fail-closed: `approved_name_fa` must exactly equal the product row's `name_fa`,
+`approved_source_revision` must equal the root `source_revision`, and
+`evidence_urls` must contain at least one unique HTTPS reference. This prevents
+a category-wide generated title or stale review from silently overriding an
+exact product classification.
 
 `parent_enrichment` is `null` for simple products and is otherwise:
 

--- a/includes/class-patris-catalog-materializer.php
+++ b/includes/class-patris-catalog-materializer.php
@@ -136,7 +136,8 @@ final class Digitalogic_Patris_Catalog_Materializer {
 			return $this->manifest_error( 'source_revision', 'must be a lowercase sha256 identity when supplied' );
 		}
 
-		$products = $this->validate_manifest_products( $manifest['products'] );
+		$source_revision = isset( $manifest['source_revision'] ) ? (string) $manifest['source_revision'] : '';
+		$products        = $this->validate_manifest_products( $manifest['products'], $source_revision );
 		if ( is_wp_error( $products ) ) {
 			return $products;
 		}
@@ -470,10 +471,11 @@ final class Digitalogic_Patris_Catalog_Materializer {
 	/**
 	 * Validate product rows and explicit target ownership.
 	 *
-	 * @param mixed $rows Manifest products object.
+	 * @param mixed  $rows            Manifest products object.
+	 * @param string $source_revision Reviewed source revision, when pinned.
 	 * @return array|WP_Error
 	 */
-	private function validate_manifest_products( $rows ) {
+	private function validate_manifest_products( $rows, $source_revision ) {
 		if ( ! is_array( $rows ) || array_is_list( $rows ) ) {
 			return $this->manifest_error( 'products', 'must be an object keyed by exact Patris Code' );
 		}
@@ -559,7 +561,12 @@ final class Digitalogic_Patris_Catalog_Materializer {
 			if ( $row['convert_empty_variable_to_simple'] && ( null === $target_id || null !== $parent_id ) ) {
 				return $this->manifest_error( $path, 'empty-variable conversion requires one exact target_product_id and no parent' );
 			}
-			$category_override = $this->validate_category_override( $row['category_override'], $path . '.category_override' );
+			$category_override = $this->validate_category_override(
+				$row['category_override'],
+				$path . '.category_override',
+				$row['name_fa'],
+				$source_revision
+			);
 			if ( is_wp_error( $category_override ) ) {
 				return $category_override;
 			}
@@ -682,11 +689,13 @@ final class Digitalogic_Patris_Catalog_Materializer {
 	/**
 	 * Validate an optional reviewed product-specific category override.
 	 *
-	 * @param mixed  $override Raw override.
-	 * @param string $path Manifest path.
+	 * @param mixed  $override        Raw override.
+	 * @param string $path            Manifest path.
+	 * @param string $product_name_fa Exact reviewed product title.
+	 * @param string $source_revision Reviewed manifest source revision.
 	 * @return array|null|WP_Error
 	 */
-	private function validate_category_override( $override, $path ) {
+	private function validate_category_override( $override, $path, $product_name_fa, $source_revision ) {
 		if ( null === $override ) {
 			return null;
 		}
@@ -695,8 +704,8 @@ final class Digitalogic_Patris_Catalog_Materializer {
 		}
 		$shape = $this->validate_object_shape(
 			$override,
-			array( 'category_code', 'target_term_id' ),
-			array( 'category_code', 'target_term_id' ),
+			array( 'category_code', 'target_term_id', 'approved_name_fa', 'approved_source_revision', 'evidence_urls' ),
+			array( 'category_code', 'target_term_id', 'approved_name_fa', 'approved_source_revision', 'evidence_urls' ),
 			$path
 		);
 		if ( is_wp_error( $shape ) ) {
@@ -713,10 +722,54 @@ final class Digitalogic_Patris_Catalog_Materializer {
 		if ( ( null === $category_code ) === ( null === $target_term_id ) ) {
 			return $this->manifest_error( $path, 'must select exactly one category_code or target_term_id' );
 		}
+		if ( '' === $source_revision ) {
+			return $this->manifest_error( $path . '.approved_source_revision', 'requires a pinned root source_revision' );
+		}
+		$approved_source_revision = $override['approved_source_revision'];
+		if ( ! is_string( $approved_source_revision ) || ! preg_match( '/^sha256:[a-f0-9]{64}$/', $approved_source_revision ) ) {
+			return $this->manifest_error( $path . '.approved_source_revision', 'must be a lowercase sha256 identity' );
+		}
+		if ( ! hash_equals( $source_revision, $approved_source_revision ) ) {
+			return $this->manifest_error( $path . '.approved_source_revision', 'must match the pinned root source_revision' );
+		}
+		$approved_name_fa = $override['approved_name_fa'];
+		if (
+			! is_string( $approved_name_fa )
+			|| '' === trim( wp_strip_all_tags( $approved_name_fa ) )
+			|| trim( $approved_name_fa ) !== $approved_name_fa
+			|| ! $this->contains_persian( wp_strip_all_tags( $approved_name_fa ) )
+		) {
+			return $this->manifest_error( $path . '.approved_name_fa', 'must be an exact reviewed Persian title' );
+		}
+		if ( ! hash_equals( $approved_name_fa, $product_name_fa ) ) {
+			return $this->manifest_error( $path . '.approved_name_fa', 'must exactly match the product name_fa' );
+		}
+		if ( ! is_array( $override['evidence_urls'] ) || ! array_is_list( $override['evidence_urls'] ) || empty( $override['evidence_urls'] ) ) {
+			return $this->manifest_error( $path . '.evidence_urls', 'must be a non-empty list of HTTPS references' );
+		}
+		$evidence_urls = array();
+		foreach ( $override['evidence_urls'] as $index => $url ) {
+			if (
+				! is_string( $url )
+				|| trim( $url ) !== $url
+				|| false === filter_var( $url, FILTER_VALIDATE_URL )
+				|| 'https' !== strtolower( (string) wp_parse_url( $url, PHP_URL_SCHEME ) )
+				|| '' === (string) wp_parse_url( $url, PHP_URL_HOST )
+			) {
+				return $this->manifest_error( $path . '.evidence_urls.' . $index, 'must be a trimmed HTTPS URL' );
+			}
+			$evidence_urls[] = $url;
+		}
+		if ( count( array_unique( $evidence_urls ) ) !== count( $evidence_urls ) ) {
+			return $this->manifest_error( $path . '.evidence_urls', 'must not contain duplicate references' );
+		}
 
 		return array(
-			'category_code'  => $category_code,
-			'target_term_id' => $target_term_id,
+			'category_code'            => $category_code,
+			'target_term_id'           => $target_term_id,
+			'approved_name_fa'         => $approved_name_fa,
+			'approved_source_revision' => $approved_source_revision,
+			'evidence_urls'            => $evidence_urls,
 		);
 	}
 

--- a/tests/PatrisCatalogMaterializerTest.php
+++ b/tests/PatrisCatalogMaterializerTest.php
@@ -672,6 +672,7 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 		$manifest = $this->manifest();
 
 		$manifest['source_revision'] = self::$fixture['source']['revision'];
+
 		$manifest['products']['101001001']['category_override'] = $this->reviewedCategoryOverride(
 			$manifest,
 			array(
@@ -694,6 +695,7 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 		$manifest = $this->manifest();
 
 		$manifest['source_revision'] = self::$fixture['source']['revision'];
+
 		$manifest['products']['101001001']['category_override'] = $this->reviewedCategoryOverride(
 			$manifest,
 			array(
@@ -749,6 +751,7 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 				'target_term_id' => null,
 			)
 		);
+
 		$manifest['products']['101001001']['category_override']['approved_name_fa'] = 'عنوان تأییدشده متفاوت';
 
 		$title_mismatch = $service->validate_manifest( $manifest );
@@ -762,6 +765,7 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 				'target_term_id' => null,
 			)
 		);
+
 		$manifest['products']['101001001']['category_override']['approved_source_revision'] =
 			'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
@@ -776,6 +780,7 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 				'target_term_id' => null,
 			)
 		);
+
 		$manifest['products']['101001001']['category_override']['evidence_urls'] = array( 'http://example.test/product' );
 
 		$invalid_evidence = $service->validate_manifest( $manifest );

--- a/tests/PatrisCatalogMaterializerTest.php
+++ b/tests/PatrisCatalogMaterializerTest.php
@@ -670,9 +670,14 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 		$this->receiveFixture();
 		$this->addTerm( 70, 'دسته‌بندی دقیق', 0 );
 		$manifest = $this->manifest();
-		$manifest['products']['101001001']['category_override'] = array(
-			'category_code'  => null,
-			'target_term_id' => '70',
+
+		$manifest['source_revision'] = self::$fixture['source']['revision'];
+		$manifest['products']['101001001']['category_override'] = $this->reviewedCategoryOverride(
+			$manifest,
+			array(
+				'category_code'  => null,
+				'target_term_id' => '70',
+			)
 		);
 
 		$result  = Digitalogic_Patris_Catalog_Materializer::instance()->run( $manifest, array( 'apply' => true ) );
@@ -687,9 +692,14 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 		$this->receiveFixture();
 		$this->addTerm( 80, 'تجهیزات پزشکی', 0 );
 		$manifest = $this->manifest();
-		$manifest['products']['101001001']['category_override'] = array(
-			'category_code'  => 'digitalogic:medical-sensors',
-			'target_term_id' => null,
+
+		$manifest['source_revision'] = self::$fixture['source']['revision'];
+		$manifest['products']['101001001']['category_override'] = $this->reviewedCategoryOverride(
+			$manifest,
+			array(
+				'category_code'  => 'digitalogic:medical-sensors',
+				'target_term_id' => null,
+			)
 		);
 		$manifest['categories']['digitalogic:medical-sensors']  = array(
 			'patris_name'           => '',
@@ -715,6 +725,62 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 		$term_id = (int) $created[0]['term_id'];
 		$this->assertSame( 'digitalogic:medical-sensors', get_term_meta( $term_id, Digitalogic_Patris_Catalog_Materializer::CATEGORY_KEY_META, true ) );
 		$this->assertSame( '', get_term_meta( $term_id, Digitalogic_Patris_Catalog_Materializer::CATEGORY_CODE_META, true ) );
+	}
+
+	/** Exact category decisions fail closed unless their title, evidence and source revision were approved. */
+	public function test_category_override_requires_revision_bound_evidence_and_exact_approved_title(): void {
+		$service  = Digitalogic_Patris_Catalog_Materializer::instance();
+		$manifest = $this->manifest();
+		$manifest['products']['101001001']['category_override'] = array(
+			'category_code'  => '101001',
+			'target_term_id' => null,
+		);
+
+		$missing_evidence = $service->validate_manifest( $manifest );
+		$this->assertInstanceOf( WP_Error::class, $missing_evidence );
+		$this->assertSame( 'digitalogic_patris_materializer_manifest_shape', $missing_evidence->get_error_code() );
+
+		$manifest['source_revision'] = self::$fixture['source']['revision'];
+
+		$manifest['products']['101001001']['category_override'] = $this->reviewedCategoryOverride(
+			$manifest,
+			array(
+				'category_code'  => '101001',
+				'target_term_id' => null,
+			)
+		);
+		$manifest['products']['101001001']['category_override']['approved_name_fa'] = 'عنوان تأییدشده متفاوت';
+
+		$title_mismatch = $service->validate_manifest( $manifest );
+		$this->assertInstanceOf( WP_Error::class, $title_mismatch );
+		$this->assertStringContainsString( 'approved_name_fa', $title_mismatch->get_error_data()['path'] );
+
+		$manifest['products']['101001001']['category_override'] = $this->reviewedCategoryOverride(
+			$manifest,
+			array(
+				'category_code'  => '101001',
+				'target_term_id' => null,
+			)
+		);
+		$manifest['products']['101001001']['category_override']['approved_source_revision'] =
+			'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+		$stale_revision = $service->validate_manifest( $manifest );
+		$this->assertInstanceOf( WP_Error::class, $stale_revision );
+		$this->assertStringContainsString( 'approved_source_revision', $stale_revision->get_error_data()['path'] );
+
+		$manifest['products']['101001001']['category_override'] = $this->reviewedCategoryOverride(
+			$manifest,
+			array(
+				'category_code'  => '101001',
+				'target_term_id' => null,
+			)
+		);
+		$manifest['products']['101001001']['category_override']['evidence_urls'] = array( 'http://example.test/product' );
+
+		$invalid_evidence = $service->validate_manifest( $manifest );
+		$this->assertInstanceOf( WP_Error::class, $invalid_evidence );
+		$this->assertStringContainsString( 'evidence_urls.0', $invalid_evidence->get_error_data()['path'] );
 	}
 
 	private function receiveFixture(): void {
@@ -753,6 +819,18 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 				'101'    => $this->categoryRow( 'Synthetic components', 'قطعات آزمایشی' ),
 				'101001' => $this->categoryRow( 'Synthetic modules', 'ماژول‌های آزمایشی' ),
 			),
+		);
+	}
+
+	/** Build one exact, revision-bound category decision for the synthetic fixture. */
+	private function reviewedCategoryOverride( array $manifest, array $selector ): array {
+		return array_merge(
+			$selector,
+			array(
+				'approved_name_fa'         => $manifest['products']['101001001']['name_fa'],
+				'approved_source_revision' => $manifest['source_revision'],
+				'evidence_urls'            => array( 'https://example.test/evidence/101001001' ),
+			)
 		);
 	}
 


### PR DESCRIPTION
Closes #148.

## Summary

- makes every product-specific category override revision-bound and fail-closed
- requires the exact approved Persian product title to match the emitted `name_fa`
- requires at least one unique HTTPS evidence reference
- rejects overrides when the root source revision is absent or stale
- documents the executable manifest contract and keeps source/meta identifiers unchanged

This prevents a category-wide title builder or stale review from silently publishing a contradictory exact-product classification.

## Verification

- `php -l includes/class-patris-catalog-materializer.php`
- `php -l tests/PatrisCatalogMaterializerTest.php`
- full PHPUnit suite: 334 tests, 2,068 assertions, 5 existing skips, 1 existing warning
- `git diff --check`

The complementary operational builder update is coordinated separately so the reviewed manifest can emit the new approval fields before any production materialization. No live catalog write is included in this PR.

