### PR TITLE
Fix mixed-direction specs and add verified datasheet downloads

### DIFF
--- a/assets/css/product-resources.css
+++ b/assets/css/product-resources.css
@@ -19,6 +19,8 @@ body.single-product.dgl-product-experience .dgl-product-specs-card bdi[dir="ltr"
 	--dgl-doc-muted: #5e6f89;
 	--dgl-doc-line: #dce7f6;
 	position: relative;
+	container-name: dgl-documents;
+	container-type: inline-size;
 	overflow: hidden;
 	margin-block: clamp(24px, 4vw, 42px);
 	padding: clamp(18px, 3vw, 28px);
@@ -131,11 +133,18 @@ body.single-product.dgl-product-experience .dgl-product-specs-card bdi[dir="ltr"
 	text-overflow: ellipsis;
 }
 
-.dgl-product-document__summary small {
-	display: block;
+.dgl-product-document__metadata {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 2px 5px;
 	color: var(--dgl-doc-muted);
 	font-size: 11px;
 	line-height: 1.7;
+}
+
+.dgl-product-document__metadata bdi {
+	unicode-bidi: isolate;
 }
 
 .dgl-product-document__actions {
@@ -204,6 +213,28 @@ body.single-product.dgl-product-experience .dgl-product-specs-card bdi[dir="ltr"
 		display: grid;
 		grid-template-columns: 1fr 1fr;
 		justify-content: stretch;
+	}
+}
+
+@container dgl-documents (max-width: 620px) {
+	.dgl-product-document {
+		grid-template-columns: 1fr;
+	}
+
+	.dgl-product-document__actions {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		justify-content: stretch;
+	}
+
+	.dgl-product-document__button {
+		width: 100%;
+	}
+}
+
+@container dgl-documents (max-width: 370px) {
+	.dgl-product-document__actions {
+		grid-template-columns: 1fr;
 	}
 }
 

--- a/assets/css/product-resources.css
+++ b/assets/css/product-resources.css
@@ -1,0 +1,228 @@
+/*
+ * Product documents and mixed-direction specification values.
+ */
+
+body.single-product.dgl-product-experience .dgl-product-specs-card bdi[dir="rtl"] {
+	direction: rtl;
+	unicode-bidi: isolate;
+}
+
+body.single-product.dgl-product-experience .dgl-product-specs-card bdi[dir="ltr"] {
+	direction: ltr;
+	unicode-bidi: isolate;
+}
+
+.dgl-product-documents {
+	--dgl-doc-blue: #155eef;
+	--dgl-doc-blue-dark: #0b47c5;
+	--dgl-doc-ink: #12233f;
+	--dgl-doc-muted: #5e6f89;
+	--dgl-doc-line: #dce7f6;
+	position: relative;
+	overflow: hidden;
+	margin-block: clamp(24px, 4vw, 42px);
+	padding: clamp(18px, 3vw, 28px);
+	border: 1px solid var(--dgl-doc-line);
+	border-radius: 20px;
+	background:
+		radial-gradient(circle at 100% 0, rgb(21 94 239 / 11%), transparent 42%),
+		linear-gradient(145deg, #fff 0%, #f8fbff 100%);
+	box-shadow: 0 18px 48px rgb(16 45 90 / 10%);
+	color: var(--dgl-doc-ink);
+}
+
+.dgl-product-documents::before {
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline: 0;
+	height: 4px;
+	background: linear-gradient(90deg, #10b981, var(--dgl-doc-blue), #6d5dfc);
+	content: "";
+}
+
+.dgl-product-documents__header {
+	display: flex;
+	align-items: flex-start;
+	gap: 13px;
+	margin-block-end: 18px;
+}
+
+.dgl-product-documents__header-icon {
+	display: inline-flex;
+	width: 46px;
+	height: 46px;
+	flex: 0 0 46px;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid rgb(21 94 239 / 15%);
+	border-radius: 14px;
+	background: #fff;
+	box-shadow: 0 8px 20px rgb(21 94 239 / 12%);
+	color: var(--dgl-doc-blue);
+}
+
+.dgl-product-documents__header-icon svg {
+	width: 23px;
+	height: 23px;
+}
+
+.dgl-product-documents__header h2 {
+	margin: 0 0 5px;
+	color: var(--dgl-doc-ink);
+	font-size: clamp(19px, 2.2vw, 25px);
+	font-weight: 850;
+	line-height: 1.35;
+}
+
+.dgl-product-documents__header p {
+	margin: 0;
+	color: var(--dgl-doc-muted);
+	font-size: 13px;
+	line-height: 1.8;
+}
+
+.dgl-product-documents__list {
+	display: grid;
+	gap: 12px;
+}
+
+.dgl-product-document {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 18px;
+	padding: 15px;
+	border: 1px solid var(--dgl-doc-line);
+	border-radius: 16px;
+	background: rgb(255 255 255 / 92%);
+	box-shadow: 0 8px 24px rgb(20 49 92 / 6%);
+}
+
+.dgl-product-document__summary {
+	display: flex;
+	min-width: 0;
+	align-items: center;
+	gap: 12px;
+}
+
+.dgl-product-document__pdf {
+	display: inline-flex;
+	width: 49px;
+	height: 49px;
+	flex: 0 0 49px;
+	align-items: center;
+	justify-content: center;
+	border-radius: 13px;
+	background: linear-gradient(145deg, #fff0f0, #ffe1e1);
+	color: #c62828;
+	font-family: Arial, sans-serif;
+	font-size: 12px;
+	font-weight: 900;
+	letter-spacing: 0.04em;
+}
+
+.dgl-product-document__summary h3 {
+	overflow: hidden;
+	margin: 0 0 4px;
+	color: var(--dgl-doc-ink);
+	font-size: 15px;
+	font-weight: 800;
+	line-height: 1.55;
+	text-overflow: ellipsis;
+}
+
+.dgl-product-document__summary small {
+	display: block;
+	color: var(--dgl-doc-muted);
+	font-size: 11px;
+	line-height: 1.7;
+}
+
+.dgl-product-document__actions {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-end;
+	gap: 9px;
+}
+
+.dgl-product-document__button {
+	display: inline-flex;
+	min-height: 43px;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding: 10px 15px;
+	border: 1px solid transparent;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 800;
+	line-height: 1.4;
+	text-decoration: none !important;
+	transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.dgl-product-document__button svg {
+	width: 17px;
+	height: 17px;
+	flex: 0 0 17px;
+}
+
+.dgl-product-document__button--hosted {
+	background: linear-gradient(135deg, var(--dgl-doc-blue), #3478f6);
+	box-shadow: 0 9px 22px rgb(21 94 239 / 22%);
+	color: #fff !important;
+}
+
+.dgl-product-document__button--official {
+	border-color: #c9daf3;
+	background: #fff;
+	color: var(--dgl-doc-blue-dark) !important;
+}
+
+.dgl-product-document__button:hover,
+.dgl-product-document__button:focus-visible {
+	transform: translateY(-1px);
+	box-shadow: 0 11px 26px rgb(20 55 105 / 17%);
+}
+
+.dgl-product-document__button--hosted:hover,
+.dgl-product-document__button--hosted:focus-visible {
+	background: linear-gradient(135deg, var(--dgl-doc-blue-dark), var(--dgl-doc-blue));
+}
+
+.dgl-product-document__button:focus-visible {
+	outline: 3px solid rgb(21 94 239 / 22%);
+	outline-offset: 3px;
+}
+
+@media (max-width: 760px) {
+	.dgl-product-document {
+		grid-template-columns: 1fr;
+	}
+
+	.dgl-product-document__actions {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		justify-content: stretch;
+	}
+}
+
+@media (max-width: 520px) {
+	.dgl-product-documents {
+		border-radius: 16px;
+	}
+
+	.dgl-product-document__actions {
+		grid-template-columns: 1fr;
+	}
+
+	.dgl-product-document__button {
+		width: 100%;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.dgl-product-document__button {
+		transition: none;
+	}
+}

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -156,6 +156,7 @@ final class Digitalogic {
 		require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-call-verification.php';
 		require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-voice-notifications.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-product-identity.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-digitalogic-product-resources.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-storefront-catalog.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-homepage-showcase.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/integrations/class-storefront-product-table.php';
@@ -228,6 +229,7 @@ final class Digitalogic {
         Digitalogic_Laravel_Bridge::instance();
         Digitalogic_Panel::instance();
         Digitalogic_Comment_Guard::instance();
+        Digitalogic_Product_Resources::instance();
         Digitalogic_Storefront_Catalog::instance();
         Digitalogic_Homepage_Showcase::instance();
         Digitalogic_Storefront_Product_Table::instance();

--- a/docs/PRODUCT-DOCUMENTS.md
+++ b/docs/PRODUCT-DOCUMENTS.md
@@ -1,0 +1,54 @@
+# Product documents
+
+Digitalogic product pages can show a document card with two customer choices:
+
+1. a verified PDF hosted in the Digitalogic WordPress media library;
+2. the exact official HTTPS source from the manufacturer.
+
+The card is rendered from the private product meta key
+`_digitalogic_product_documents`. A document is shown only when both links and
+all provenance fields pass validation.
+
+## Required workflow
+
+1. Prove the exact product identity from the manufacturer source.
+2. Download the official PDF and verify that it opens and matches the product.
+3. Record its SHA-256 and byte size.
+4. Upload that exact PDF as a WordPress `application/pdf` attachment owned by
+   the product.
+5. Store the reviewed document record with
+   `Digitalogic_Product_Resources::replace_documents()`.
+6. Read the meta and attachment back, verify the hosted hash, and check both
+   public actions. The write API also rejects a declared SHA-256 or byte size
+   that does not match the attached file.
+
+Do not use a marketplace or mirrored PDF as the official source. Do not attach
+a family document when the exact model cannot be proven from that document.
+
+## Closed document shape
+
+```php
+array(
+	array(
+		'title'            => 'دیتاشیت رسمی OMRON G8FE',
+		'attachment_id'    => 123,
+		'source_url'       => 'https://manufacturer.example/path/datasheet.pdf',
+		'source_label'     => 'OMRON',
+		'sha256'           => 'lowercase-64-character-sha256',
+		'bytes'            => 557949,
+		'product_identity' => 'G8FE-1AP-L DC12',
+		'verified_at'      => '2026-07-25T04:00:00+03:30',
+	),
+)
+```
+
+Unknown fields, non-PDF attachments, non-HTTPS source URLs, missing provenance,
+and duplicate hashes or source URLs fail closed.
+
+## Directionality
+
+The Product Experience specifications shortcode emits isolated `<bdi>` values
+and is the single insertion point for the document card. This integration
+resolves the first strong Persian/Arabic or Latin character and replaces
+`dir="auto"` with an explicit `dir="rtl"` or `dir="ltr"`. Its stylesheet also
+overrides the legacy rule that forced every specification value to LTR.

--- a/includes/integrations/class-digitalogic-product-resources.php
+++ b/includes/integrations/class-digitalogic-product-resources.php
@@ -361,17 +361,13 @@ final class Digitalogic_Product_Resources {
 							<span class="dgl-product-document__pdf" aria-hidden="true">PDF</span>
 							<div>
 								<h3><?php echo esc_html( $document['title'] ); ?></h3>
-								<small>
-									<?php
-									echo esc_html(
-										sprintf(
-											'%1$s • %2$s • %3$s',
-											$document['source_label'],
-											$this->format_file_size( $document['bytes'] ),
-											$document['product_identity']
-										)
-									);
-									?>
+								<small class="dgl-product-document__metadata">
+									<bdi dir="<?php echo esc_attr( self::direction_for_text( $document['source_label'] ) ); ?>"><?php echo esc_html( $document['source_label'] ); ?></bdi>
+									<span aria-hidden="true">•</span>
+									<?php $file_size = $this->format_file_size( $document['bytes'] ); ?>
+									<bdi dir="<?php echo esc_attr( self::direction_for_text( $file_size ) ); ?>"><?php echo esc_html( $file_size ); ?></bdi>
+									<span aria-hidden="true">•</span>
+									<bdi dir="<?php echo esc_attr( self::direction_for_text( $document['product_identity'] ) ); ?>"><?php echo esc_html( $document['product_identity'] ); ?></bdi>
 								</small>
 							</div>
 						</div>

--- a/includes/integrations/class-digitalogic-product-resources.php
+++ b/includes/integrations/class-digitalogic-product-resources.php
@@ -350,7 +350,7 @@ final class Digitalogic_Product_Resources {
 				</span>
 				<div>
 					<h2 id="<?php echo esc_attr( $heading_id ); ?>">دانلود دیتاشیت و مستندات</h2>
-					<p>نسخه میزبانی‌شده در دیجیتالوجیک و پیوند مستقیم منبع رسمی سازنده.</p>
+					<p>نسخه میزبانی‌شده در دیجیتالاجیک و پیوند مستقیم منبع رسمی سازنده.</p>
 				</div>
 			</header>
 			<div class="dgl-product-documents__list">
@@ -381,7 +381,7 @@ final class Digitalogic_Product_Resources {
 								<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
 									<path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/>
 								</svg>
-								دانلود از دیجیتالوجیک
+								دانلود از دیجیتالاجیک
 							</a>
 							<a
 								class="dgl-product-document__button dgl-product-document__button--official"
@@ -436,7 +436,8 @@ final class Digitalogic_Product_Resources {
 	 */
 	public function normalize_spec_directions( string $output, string $tag, array $attr = array(), array $shortcode_match = array() ): string {
 		unset( $attr, $shortcode_match );
-		if ( 'dgl_product_specs' !== $tag || false === stripos( $output, 'dir' ) ) {
+		$supported_tags = array( 'dgl_product_specs', 'dgl_product_highlights' );
+		if ( ! in_array( $tag, $supported_tags, true ) || false === stripos( $output, 'dir' ) ) {
 			return $output;
 		}
 

--- a/includes/integrations/class-digitalogic-product-resources.php
+++ b/includes/integrations/class-digitalogic-product-resources.php
@@ -1,0 +1,488 @@
+<?php
+/**
+ * Storefront product documents and mixed-direction specification values.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Renders verified product documents and corrects mixed-direction specs.
+ */
+final class Digitalogic_Product_Resources {
+
+	public const META_KEY = '_digitalogic_product_documents';
+
+	/**
+	 * Product document cards emitted during the current request.
+	 *
+	 * @var int[]
+	 */
+	private $rendered_products = array();
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Return the shared integration instance.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register storefront hooks.
+	 */
+	private function __construct() {
+		add_action( 'init', array( $this, 'register_meta' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ), 100 );
+		add_filter( 'do_shortcode_tag', array( $this, 'normalize_spec_directions' ), 20, 4 );
+		add_filter( 'do_shortcode_tag', array( $this, 'append_documents_to_specs' ), 30, 4 );
+	}
+
+	/**
+	 * Register the reviewed document manifest as private product metadata.
+	 */
+	public function register_meta(): void {
+		register_post_meta(
+			'product',
+			self::META_KEY,
+			array(
+				'type'              => 'array',
+				'single'            => true,
+				'show_in_rest'      => false,
+				'sanitize_callback' => array( $this, 'sanitize_documents_meta' ),
+				'auth_callback'     => static function (): bool {
+					// phpcs:ignore WordPress.WP.Capabilities.Unknown -- WooCommerce registers this capability.
+					return current_user_can( 'manage_woocommerce' );
+				},
+			)
+		);
+	}
+
+	/**
+	 * Sanitize product-document metadata at the WordPress boundary.
+	 *
+	 * Invalid documents are omitted so an incomplete or non-HTTPS record never
+	 * becomes customer-facing. Operational callers should use replace_documents()
+	 * when they need an explicit WP_Error for a rejected record.
+	 *
+	 * @param mixed $documents Raw product-document records.
+	 * @return array
+	 */
+	public function sanitize_documents_meta( $documents ): array {
+		$normalized = $this->normalize_documents( $documents, false, 0 );
+
+		return is_wp_error( $normalized ) ? array() : $normalized;
+	}
+
+	/**
+	 * Replace a product's reviewed document list and verify the live readback.
+	 *
+	 * @param int   $product_id Product post ID.
+	 * @param mixed $documents  Reviewed document records.
+	 * @return array|WP_Error
+	 */
+	public function replace_documents( int $product_id, $documents ) {
+		if ( 'product' !== get_post_type( $product_id ) ) {
+			return new WP_Error( 'digitalogic_invalid_document_product', 'Product documents require an existing product post.' );
+		}
+
+		$normalized = $this->normalize_documents( $documents, true, $product_id );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
+		}
+
+		$current = get_post_meta( $product_id, self::META_KEY, true );
+		if ( $current !== $normalized ) {
+			$updated = update_post_meta( $product_id, self::META_KEY, $normalized );
+			if ( false === $updated && get_post_meta( $product_id, self::META_KEY, true ) !== $normalized ) {
+				return new WP_Error( 'digitalogic_document_write_failed', 'Product document metadata could not be written.' );
+			}
+		}
+
+		wp_cache_delete( $product_id, 'post_meta' );
+		$readback = $this->normalize_documents( get_post_meta( $product_id, self::META_KEY, true ), true, $product_id );
+		if ( is_wp_error( $readback ) || $readback !== $normalized ) {
+			return new WP_Error( 'digitalogic_document_readback_failed', 'Product document metadata failed live readback verification.' );
+		}
+
+		return $readback;
+	}
+
+	/**
+	 * Load only complete, locally hosted, official-source document pairs.
+	 *
+	 * @param int $product_id Product post ID.
+	 * @return array
+	 */
+	public function get_documents( int $product_id ): array {
+		$documents = $this->normalize_documents( get_post_meta( $product_id, self::META_KEY, true ), false, $product_id );
+
+		return is_wp_error( $documents ) ? array() : $documents;
+	}
+
+	/**
+	 * Normalize and validate document records.
+	 *
+	 * @param mixed $documents Raw records.
+	 * @param bool  $strict    Return a WP_Error instead of skipping invalid rows.
+	 * @param int   $product_id Product that must own each attachment, or zero at the generic sanitize boundary.
+	 * @return array|WP_Error
+	 */
+	private function normalize_documents( $documents, bool $strict, int $product_id ) {
+		if ( ! is_array( $documents ) || ! array_is_list( $documents ) ) {
+			return $strict
+				? new WP_Error( 'digitalogic_invalid_documents', 'Product documents must be a JSON-style list.' )
+				: array();
+		}
+
+		$normalized   = array();
+		$seen_hashes  = array();
+		$seen_sources = array();
+		$allowed_keys = array(
+			'attachment_id',
+			'bytes',
+			'product_identity',
+			'sha256',
+			'source_label',
+			'source_url',
+			'title',
+			'verified_at',
+		);
+
+		foreach ( $documents as $index => $document ) {
+			$error = null;
+			if ( ! is_array( $document ) || array_is_list( $document ) ) {
+				$error = 'Each product document must be an object.';
+			} elseif ( array_diff( array_keys( $document ), $allowed_keys ) ) {
+				$error = 'Product document contains unsupported fields.';
+			}
+
+			$attachment_id    = is_array( $document ) ? absint( $document['attachment_id'] ?? 0 ) : 0;
+			$title            = is_array( $document ) ? sanitize_text_field( (string) ( $document['title'] ?? '' ) ) : '';
+			$source_url       = is_array( $document ) ? esc_url_raw( (string) ( $document['source_url'] ?? '' ) ) : '';
+			$source_label     = is_array( $document ) ? sanitize_text_field( (string) ( $document['source_label'] ?? '' ) ) : '';
+			$sha256           = is_array( $document ) ? strtolower( trim( (string) ( $document['sha256'] ?? '' ) ) ) : '';
+			$bytes            = is_array( $document ) ? absint( $document['bytes'] ?? 0 ) : 0;
+			$product_identity = is_array( $document ) ? sanitize_text_field( (string) ( $document['product_identity'] ?? '' ) ) : '';
+			$verified_at      = is_array( $document ) ? sanitize_text_field( (string) ( $document['verified_at'] ?? '' ) ) : '';
+			$source_parts     = $source_url ? wp_parse_url( $source_url ) : false;
+			$hosted_url       = $attachment_id > 0 ? wp_get_attachment_url( $attachment_id ) : false;
+			$attachment       = $attachment_id > 0 ? get_post( $attachment_id ) : null;
+			$attachment_path  = $strict && $attachment_id > 0 ? get_attached_file( $attachment_id, true ) : false;
+			$verified_time    = \DateTimeImmutable::createFromFormat( DATE_ATOM, $verified_at );
+
+			if ( null === $error && ( ! $attachment_id || 'attachment' !== get_post_type( $attachment_id ) ) ) {
+				$error = 'Product document requires an existing media attachment.';
+			} elseif ( null === $error && 'application/pdf' !== get_post_mime_type( $attachment_id ) ) {
+				$error = 'Product document attachment must be a PDF.';
+			} elseif (
+				null === $error
+				&& 0 < $product_id
+				&& (
+					! $attachment
+					|| absint( $attachment->post_parent ?? 0 ) !== $product_id
+				)
+			) {
+				$error = 'Product document attachment must belong to the selected product.';
+			} elseif ( null === $error && ! $hosted_url ) {
+				$error = 'Product document attachment URL does not resolve.';
+			} elseif ( null === $error && '' === $title ) {
+				$error = 'Product document title is required.';
+			} elseif (
+				null === $error
+				&& (
+					! is_array( $source_parts )
+					|| 'https' !== strtolower( (string) ( $source_parts['scheme'] ?? '' ) )
+					|| '' === (string) ( $source_parts['host'] ?? '' )
+					|| isset( $source_parts['user'] )
+					|| isset( $source_parts['pass'] )
+				)
+			) {
+				$error = 'Product document source must be an official HTTPS URL.';
+			} elseif ( null === $error && '' === $source_label ) {
+				$error = 'Product document source label is required.';
+			} elseif ( null === $error && ! preg_match( '/^[a-f0-9]{64}$/', $sha256 ) ) {
+				$error = 'Product document SHA-256 is required.';
+			} elseif ( null === $error && $bytes <= 0 ) {
+				$error = 'Product document byte size is required.';
+			} elseif ( null === $error && '' === $product_identity ) {
+				$error = 'Product document identity evidence is required.';
+			} elseif (
+				null === $error
+				&& (
+					false === $verified_time
+					|| $verified_time->format( DATE_ATOM ) !== $verified_at
+				)
+			) {
+				$error = 'Product document verification time must be an ISO-8601 timestamp.';
+			} elseif (
+				null === $error
+				&& $strict
+				&& (
+					! is_string( $attachment_path )
+					|| ! is_readable( $attachment_path )
+				)
+			) {
+				$error = 'Product document attachment file is not readable.';
+			} elseif (
+				null === $error
+				&& $strict
+				&& (
+					filesize( $attachment_path ) !== $bytes
+					|| ! hash_equals( $sha256, (string) hash_file( 'sha256', $attachment_path ) )
+				)
+			) {
+				$error = 'Product document hash or byte size does not match the attached file.';
+			} elseif ( null === $error && isset( $seen_hashes[ $sha256 ] ) ) {
+				$error = 'Product document SHA-256 must be unique.';
+			} elseif ( null === $error && isset( $seen_sources[ $source_url ] ) ) {
+				$error = 'Product document official source URL must be unique.';
+			}
+
+			if ( null !== $error ) {
+				if ( $strict ) {
+					return new WP_Error(
+						'digitalogic_invalid_document',
+						sprintf( 'Document %d: %s', (int) $index + 1, $error )
+					);
+				}
+				continue;
+			}
+
+			$seen_hashes[ $sha256 ]      = true;
+			$seen_sources[ $source_url ] = true;
+			$normalized[]                = array(
+				'title'            => $title,
+				'attachment_id'    => $attachment_id,
+				'source_url'       => $source_url,
+				'source_label'     => $source_label,
+				'sha256'           => $sha256,
+				'bytes'            => $bytes,
+				'product_identity' => $product_identity,
+				'verified_at'      => $verified_at,
+			);
+		}
+
+		if ( $strict && empty( $normalized ) ) {
+			return new WP_Error( 'digitalogic_empty_documents', 'At least one complete product document is required.' );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Append a reusable document card once at the product specifications surface.
+	 *
+	 * @param string $output Shortcode output.
+	 * @param string $tag    Shortcode tag.
+	 * @param array  $attr   Shortcode attributes.
+	 * @param array  $shortcode_match Shortcode regex match.
+	 * @return string
+	 */
+	public function append_documents_to_specs( string $output, string $tag, array $attr = array(), array $shortcode_match = array() ): string {
+		unset( $attr, $shortcode_match );
+		if (
+			'dgl_product_specs' !== $tag
+			|| is_admin()
+			|| ! function_exists( 'is_product' )
+			|| ! is_product()
+			|| false !== strpos( $output, 'data-digitalogic-product-documents' )
+		) {
+			return $output;
+		}
+
+		$product_id = function_exists( 'get_queried_object_id' ) ? absint( get_queried_object_id() ) : 0;
+		if (
+			! $product_id
+			|| 'product' !== get_post_type( $product_id )
+			|| in_array( $product_id, $this->rendered_products, true )
+		) {
+			return $output;
+		}
+
+		$documents = $this->render_documents( $product_id );
+		if ( '' === $documents ) {
+			return $output;
+		}
+
+		$this->rendered_products[] = $product_id;
+
+		return $output . $documents;
+	}
+
+	/**
+	 * Render hosted and official-source actions for each reviewed document.
+	 *
+	 * @param int $product_id Product post ID.
+	 * @return string
+	 */
+	public function render_documents( int $product_id ): string {
+		$documents = $this->get_documents( $product_id );
+		if ( empty( $documents ) ) {
+			return '';
+		}
+
+		$heading_id = 'dgl-product-documents-' . $product_id;
+		ob_start();
+		?>
+		<section class="dgl-product-documents" data-digitalogic-product-documents dir="rtl" aria-labelledby="<?php echo esc_attr( $heading_id ); ?>">
+			<header class="dgl-product-documents__header">
+				<span class="dgl-product-documents__header-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+						<path d="M7 3h7l4 4v14H7z"/>
+						<path d="M14 3v5h5M10 13h5M10 17h5"/>
+					</svg>
+				</span>
+				<div>
+					<h2 id="<?php echo esc_attr( $heading_id ); ?>">دانلود دیتاشیت و مستندات</h2>
+					<p>نسخه میزبانی‌شده در دیجیتالوجیک و پیوند مستقیم منبع رسمی سازنده.</p>
+				</div>
+			</header>
+			<div class="dgl-product-documents__list">
+				<?php foreach ( $documents as $document ) : ?>
+					<?php $hosted_url = wp_get_attachment_url( $document['attachment_id'] ); ?>
+					<article class="dgl-product-document">
+						<div class="dgl-product-document__summary">
+							<span class="dgl-product-document__pdf" aria-hidden="true">PDF</span>
+							<div>
+								<h3><?php echo esc_html( $document['title'] ); ?></h3>
+								<small>
+									<?php
+									echo esc_html(
+										sprintf(
+											'%1$s • %2$s • %3$s',
+											$document['source_label'],
+											$this->format_file_size( $document['bytes'] ),
+											$document['product_identity']
+										)
+									);
+									?>
+								</small>
+							</div>
+						</div>
+						<div class="dgl-product-document__actions">
+							<a
+								class="dgl-product-document__button dgl-product-document__button--hosted"
+								href="<?php echo esc_url( $hosted_url ); ?>"
+								download
+								aria-label="<?php echo esc_attr( 'دانلود نسخه میزبانی‌شده ' . $document['title'] ); ?>"
+							>
+								<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+									<path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/>
+								</svg>
+								دانلود از دیجیتالوجیک
+							</a>
+							<a
+								class="dgl-product-document__button dgl-product-document__button--official"
+								href="<?php echo esc_url( $document['source_url'] ); ?>"
+								target="_blank"
+								rel="noopener noreferrer nofollow external"
+								aria-label="<?php echo esc_attr( 'مشاهده منبع رسمی ' . $document['title'] ); ?>"
+							>
+								<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" focusable="false">
+									<path d="M14 5h5v5M10 14 19 5M19 14v5H5V5h5"/>
+								</svg>
+								مشاهده منبع رسمی
+							</a>
+						</div>
+					</article>
+				<?php endforeach; ?>
+			</div>
+		</section>
+		<?php
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Load the document UI and directionality correction on product pages.
+	 */
+	public function enqueue_assets(): void {
+		if ( is_admin() || ! function_exists( 'is_product' ) || ! is_product() ) {
+			return;
+		}
+
+		$relative_path = 'assets/css/product-resources.css';
+		$asset_path    = DIGITALOGIC_PLUGIN_DIR . $relative_path;
+		$version       = is_readable( $asset_path ) ? (string) filemtime( $asset_path ) : DIGITALOGIC_VERSION;
+
+		wp_enqueue_style(
+			'digitalogic-product-resources',
+			DIGITALOGIC_PLUGIN_URL . $relative_path,
+			array(),
+			$version
+		);
+	}
+
+	/**
+	 * Convert Product Experience's dir=auto values to deterministic directions.
+	 *
+	 * @param string $output Shortcode output.
+	 * @param string $tag    Shortcode tag.
+	 * @param array  $attr   Shortcode attributes.
+	 * @param array  $shortcode_match Shortcode regex match.
+	 * @return string
+	 */
+	public function normalize_spec_directions( string $output, string $tag, array $attr = array(), array $shortcode_match = array() ): string {
+		unset( $attr, $shortcode_match );
+		if ( 'dgl_product_specs' !== $tag || false === stripos( $output, 'dir' ) ) {
+			return $output;
+		}
+
+		$normalized = preg_replace_callback(
+			'/<bdi\b([^>]*?)\bdir\s*=\s*(["\'])auto\2([^>]*)>(.*?)<\/bdi>/uis',
+			static function ( array $matches ): string {
+				$text      = html_entity_decode( wp_strip_all_tags( $matches[4] ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+				$direction = self::direction_for_text( $text );
+
+				return '<bdi' . $matches[1] . 'dir="' . esc_attr( $direction ) . '"' . $matches[3] . '>' . $matches[4] . '</bdi>';
+			},
+			$output
+		);
+
+		return is_string( $normalized ) ? $normalized : $output;
+	}
+
+	/**
+	 * Resolve direction from the first strong Persian/Arabic or Latin letter.
+	 *
+	 * @param string $value Visible text.
+	 * @return string
+	 */
+	public static function direction_for_text( string $value ): string {
+		if ( preg_match( '/[\x{0600}-\x{06FF}A-Za-z]/u', $value, $match ) ) {
+			return preg_match( '/[\x{0600}-\x{06FF}]/u', $match[0] ) ? 'rtl' : 'ltr';
+		}
+
+		return function_exists( 'is_rtl' ) && is_rtl() ? 'rtl' : 'ltr';
+	}
+
+	/**
+	 * Format bytes for the Persian storefront.
+	 *
+	 * @param int $bytes Byte count.
+	 * @return string
+	 */
+	private function format_file_size( int $bytes ): string {
+		if ( $bytes >= 1048576 ) {
+			return number_format_i18n( $bytes / 1048576, 1 ) . ' مگابایت';
+		}
+
+		return number_format_i18n( (int) ceil( $bytes / 1024 ) ) . ' کیلوبایت';
+	}
+}

--- a/tests/ProductResourcesTest.php
+++ b/tests/ProductResourcesTest.php
@@ -168,6 +168,8 @@ final class ProductResourcesTest extends TestCase {
 		$this->assertStringContainsString( 'https://omronfs.omron.com/en_US/ecb/products/pdf/en-g8fe.pdf', $html );
 		$this->assertStringContainsString( 'rel="noopener noreferrer nofollow external"', $html );
 		$this->assertStringContainsString( 'G8FE-1AP-L DC12', $html );
+		$this->assertStringContainsString( 'dgl-product-document__metadata', $html );
+		$this->assertStringContainsString( '<bdi dir="ltr">OMRON</bdi>', $html );
 	}
 
 	public function test_appends_once_only_to_the_matching_product_specs_shortcode(): void {
@@ -214,6 +216,7 @@ final class ProductResourcesTest extends TestCase {
 		$this->assertStringContainsString( 'bdi[dir="rtl"]', $css );
 		$this->assertStringContainsString( 'bdi[dir="ltr"]', $css );
 		$this->assertStringContainsString( '.dgl-product-document__button--hosted', $css );
+		$this->assertStringContainsString( '@container dgl-documents (max-width: 620px)', $css );
 		$this->assertStringContainsString( '@media (max-width: 520px)', $css );
 	}
 

--- a/tests/ProductResourcesTest.php
+++ b/tests/ProductResourcesTest.php
@@ -1,0 +1,249 @@
+<?php // phpcs:ignoreFile -- Test stubs intentionally share one fixture file with the test case.
+/**
+ * Product document and mixed-direction specification regression tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'DIGITALOGIC_PLUGIN_URL' ) ) {
+	define( 'DIGITALOGIC_PLUGIN_URL', 'https://digitalogic.test/wp-content/plugins/digitalogic-wp/' );
+}
+
+if ( ! defined( 'DIGITALOGIC_PLUGIN_DIR' ) ) {
+	define( 'DIGITALOGIC_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+}
+
+if ( ! defined( 'DIGITALOGIC_VERSION' ) ) {
+	define( 'DIGITALOGIC_VERSION', 'test' );
+}
+
+if ( ! function_exists( 'is_admin' ) ) {
+	function is_admin() {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'is_product' ) ) {
+	function is_product() {
+		return ! empty( $GLOBALS['digitalogic_test_is_product'] );
+	}
+}
+
+if ( ! function_exists( 'get_queried_object_id' ) ) {
+	function get_queried_object_id() {
+		return isset( $GLOBALS['digitalogic_test_queried_object_id'] ) ? (int) $GLOBALS['digitalogic_test_queried_object_id'] : 0;
+	}
+}
+
+final class ProductResourcesTest extends TestCase {
+
+	/**
+	 * @var Digitalogic_Product_Resources
+	 */
+	private $resources;
+
+	/**
+	 * @var string
+	 */
+	private $pdf_path;
+
+	protected function setUp(): void {
+		$this->pdf_path = tempnam( sys_get_temp_dir(), 'dgl-pdf-' );
+		file_put_contents( $this->pdf_path, "%PDF-1.4\nDigitalogic product document fixture\n%%EOF\n" );
+
+		$GLOBALS['digitalogic_test_posts']                = array();
+		$GLOBALS['digitalogic_test_post_meta_cache']      = array();
+		$GLOBALS['digitalogic_test_meta_update_failures'] = array();
+		$GLOBALS['digitalogic_test_attached_files']       = array();
+		$GLOBALS['digitalogic_test_is_product']           = false;
+		$GLOBALS['digitalogic_test_queried_object_id']    = 0;
+		$GLOBALS['digitalogic_test_enqueued_styles']      = array();
+		$this->resources = ( new ReflectionClass( Digitalogic_Product_Resources::class ) )->newInstanceWithoutConstructor();
+	}
+
+	protected function tearDown(): void {
+		if ( is_string( $this->pdf_path ) && is_file( $this->pdf_path ) ) {
+			unlink( $this->pdf_path );
+		}
+	}
+
+	public function test_resolves_first_strong_character_direction(): void {
+		$this->assertSame( 'rtl', Digitalogic_Product_Resources::direction_for_text( 'پایه‌دار روی PCB (Through-hole)' ) );
+		$this->assertSame( 'ltr', Digitalogic_Product_Resources::direction_for_text( 'G8FE-1AP-L DC12' ) );
+		$this->assertSame( 'ltr', Digitalogic_Product_Resources::direction_for_text( '12V DC' ) );
+	}
+
+	public function test_normalizes_product_experience_bdi_values(): void {
+		$html = '<td><bdi dir="auto">پایه&zwnj;دار روی PCB (Through-hole)</bdi></td>'
+			. "<td><bdi class=\"model\" DIR = 'AUTO'>G8FE-1AP-L DC12</bdi></td>"
+			. '<td><bdi dir="ltr">already explicit</bdi></td>';
+
+		$normalized = $this->resources->normalize_spec_directions( $html, 'dgl_product_specs' );
+
+		$this->assertStringContainsString( '<bdi dir="rtl">پایه&zwnj;دار روی PCB (Through-hole)</bdi>', $normalized );
+		$this->assertStringContainsString( '<bdi class="model" dir="ltr">G8FE-1AP-L DC12</bdi>', $normalized );
+		$this->assertStringNotContainsString( 'dir="auto"', $normalized );
+		$this->assertStringContainsString( '<bdi dir="ltr">already explicit</bdi>', $normalized );
+		$this->assertSame( $html, $this->resources->normalize_spec_directions( $html, 'unrelated_shortcode' ) );
+	}
+
+	public function test_rejects_incomplete_or_non_official_document_pairs(): void {
+		$this->seed_product_and_pdf();
+		$document               = $this->valid_document();
+		$document['source_url'] = 'http://example.test/g8fe.pdf';
+
+		$result = $this->resources->replace_documents( 11867, array( $document ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'digitalogic_invalid_document', $result->get_error_code() );
+
+		$document                  = $this->valid_document();
+		$document['attachment_id'] = 999;
+		$result                    = $this->resources->replace_documents( 11867, array( $document ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		$GLOBALS['digitalogic_test_posts'][13090]['post_mime_type'] = 'text/plain';
+		$result = $this->resources->replace_documents( 11867, array( $this->valid_document() ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		$GLOBALS['digitalogic_test_posts'][13090]['post_mime_type'] = 'application/pdf';
+		$document = $this->valid_document();
+		$GLOBALS['digitalogic_test_posts'][13090]['post_parent'] = 55;
+		$result = $this->resources->replace_documents( 11867, array( $document ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		$GLOBALS['digitalogic_test_posts'][13090]['post_parent'] = 11867;
+		$document               = $this->valid_document();
+		$document['source_url'] = 'https://username:password@example.test/g8fe.pdf';
+		$result                 = $this->resources->replace_documents( 11867, array( $document ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+
+	public function test_rejects_file_provenance_or_timestamp_mismatches(): void {
+		$this->seed_product_and_pdf();
+		$document           = $this->valid_document();
+		$document['sha256'] = str_repeat( '0', 64 );
+
+		$result = $this->resources->replace_documents( 11867, array( $document ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		$document          = $this->valid_document();
+		$document['bytes'] = $document['bytes'] + 1;
+		$result            = $this->resources->replace_documents( 11867, array( $document ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+
+		$document                = $this->valid_document();
+		$document['verified_at'] = 'yesterday';
+		$result                  = $this->resources->replace_documents( 11867, array( $document ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+
+	public function test_writes_and_reads_back_closed_document_metadata(): void {
+		$this->seed_product_and_pdf();
+		$document = $this->valid_document();
+
+		$result = $this->resources->replace_documents( 11867, array( $document ) );
+
+		$this->assertSame( array( $document ), $result );
+		$this->assertSame(
+			array( $document ),
+			get_post_meta( 11867, Digitalogic_Product_Resources::META_KEY, true )
+		);
+		$this->assertSame( array( $document ), $this->resources->get_documents( 11867 ) );
+	}
+
+	public function test_renders_hosted_download_and_official_source_actions(): void {
+		$this->seed_product_and_pdf();
+		$this->resources->replace_documents( 11867, array( $this->valid_document() ) );
+
+		$html = $this->resources->render_documents( 11867 );
+
+		$this->assertStringContainsString( 'data-digitalogic-product-documents', $html );
+		$this->assertStringContainsString( 'دانلود از دیجیتالوجیک', $html );
+		$this->assertStringContainsString( 'https://digitalogic.test/media/13090', $html );
+		$this->assertMatchesRegularExpression( '/\sdownload(?:\s|>)/', $html );
+		$this->assertStringContainsString( 'مشاهده منبع رسمی', $html );
+		$this->assertStringContainsString( 'https://omronfs.omron.com/en_US/ecb/products/pdf/en-g8fe.pdf', $html );
+		$this->assertStringContainsString( 'rel="noopener noreferrer nofollow external"', $html );
+		$this->assertStringContainsString( 'G8FE-1AP-L DC12', $html );
+	}
+
+	public function test_appends_once_only_to_the_matching_product_specs_shortcode(): void {
+		$this->seed_product_and_pdf();
+		$this->resources->replace_documents( 11867, array( $this->valid_document() ) );
+		$GLOBALS['digitalogic_test_is_product']        = true;
+		$GLOBALS['digitalogic_test_queried_object_id'] = 11867;
+
+		$specs  = '<section class="dgl-dynamic-specs">مشخصات</section>';
+		$output = $this->resources->append_documents_to_specs( $specs, 'dgl_product_specs' );
+		$this->assertStringContainsString( 'data-digitalogic-product-documents', $output );
+		$this->assertSame( 1, substr_count( $output, 'data-digitalogic-product-documents' ) );
+		$this->assertSame( $output, $this->resources->append_documents_to_specs( $output, 'dgl_product_specs' ) );
+		$this->assertSame( $specs, $this->resources->append_documents_to_specs( $specs, 'unrelated_shortcode' ) );
+
+		$GLOBALS['digitalogic_test_is_product'] = false;
+		$this->assertSame( $specs, $this->resources->append_documents_to_specs( $specs, 'dgl_product_specs' ) );
+	}
+
+	public function test_registers_shortcode_filters_with_all_wordpress_arguments(): void {
+		$old_filters                         = $GLOBALS['digitalogic_test_filters'];
+		$GLOBALS['digitalogic_test_filters'] = array();
+
+		try {
+			$reflection  = new ReflectionClass( Digitalogic_Product_Resources::class );
+			$instance    = $reflection->newInstanceWithoutConstructor();
+			$constructor = $reflection->getConstructor();
+			$constructor->invoke( $instance );
+
+			$this->assertCount( 2, $GLOBALS['digitalogic_test_filters']['do_shortcode_tag'] );
+			$this->assertSame(
+				array( 4, 4 ),
+				array_column( $GLOBALS['digitalogic_test_filters']['do_shortcode_tag'], 'accepted_args' )
+			);
+		} finally {
+			$GLOBALS['digitalogic_test_filters'] = $old_filters;
+		}
+	}
+
+	public function test_stylesheet_overrides_legacy_ltr_and_has_responsive_actions(): void {
+		$css = file_get_contents( dirname( __DIR__ ) . '/assets/css/product-resources.css' );
+
+		$this->assertIsString( $css );
+		$this->assertStringContainsString( 'bdi[dir="rtl"]', $css );
+		$this->assertStringContainsString( 'bdi[dir="ltr"]', $css );
+		$this->assertStringContainsString( '.dgl-product-document__button--hosted', $css );
+		$this->assertStringContainsString( '@media (max-width: 520px)', $css );
+	}
+
+	private function seed_product_and_pdf(): void {
+		$GLOBALS['digitalogic_test_posts'][11867] = array(
+			'post_type'   => 'product',
+			'post_status' => 'publish',
+			'post_title'  => 'رله قدرت خودرویی OMRON G8FE-1AP-L-12VDC',
+			'meta'        => array(),
+		);
+		$GLOBALS['digitalogic_test_posts'][13090] = array(
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'application/pdf',
+			'post_parent'    => 11867,
+			'meta'           => array(),
+		);
+		$GLOBALS['digitalogic_test_attached_files'][13090] = $this->pdf_path;
+	}
+
+	private function valid_document(): array {
+		return array(
+			'title'            => 'دیتاشیت رسمی OMRON G8FE',
+			'attachment_id'    => 13090,
+			'source_url'       => 'https://omronfs.omron.com/en_US/ecb/products/pdf/en-g8fe.pdf',
+			'source_label'     => 'OMRON',
+			'sha256'           => hash_file( 'sha256', $this->pdf_path ),
+			'bytes'            => filesize( $this->pdf_path ),
+			'product_identity' => 'G8FE-1AP-L DC12',
+			'verified_at'      => '2026-07-25T04:00:00+03:30',
+		);
+	}
+}

--- a/tests/ProductResourcesTest.php
+++ b/tests/ProductResourcesTest.php
@@ -80,12 +80,14 @@ final class ProductResourcesTest extends TestCase {
 			. "<td><bdi class=\"model\" DIR = 'AUTO'>G8FE-1AP-L DC12</bdi></td>"
 			. '<td><bdi dir="ltr">already explicit</bdi></td>';
 
-		$normalized = $this->resources->normalize_spec_directions( $html, 'dgl_product_specs' );
+		foreach ( array( 'dgl_product_specs', 'dgl_product_highlights' ) as $tag ) {
+			$normalized = $this->resources->normalize_spec_directions( $html, $tag );
 
-		$this->assertStringContainsString( '<bdi dir="rtl">پایه&zwnj;دار روی PCB (Through-hole)</bdi>', $normalized );
-		$this->assertStringContainsString( '<bdi class="model" dir="ltr">G8FE-1AP-L DC12</bdi>', $normalized );
-		$this->assertStringNotContainsString( 'dir="auto"', $normalized );
-		$this->assertStringContainsString( '<bdi dir="ltr">already explicit</bdi>', $normalized );
+			$this->assertStringContainsString( '<bdi dir="rtl">پایه&zwnj;دار روی PCB (Through-hole)</bdi>', $normalized );
+			$this->assertStringContainsString( '<bdi class="model" dir="ltr">G8FE-1AP-L DC12</bdi>', $normalized );
+			$this->assertStringNotContainsString( 'dir="auto"', $normalized );
+			$this->assertStringContainsString( '<bdi dir="ltr">already explicit</bdi>', $normalized );
+		}
 		$this->assertSame( $html, $this->resources->normalize_spec_directions( $html, 'unrelated_shortcode' ) );
 	}
 
@@ -161,7 +163,7 @@ final class ProductResourcesTest extends TestCase {
 		$html = $this->resources->render_documents( 11867 );
 
 		$this->assertStringContainsString( 'data-digitalogic-product-documents', $html );
-		$this->assertStringContainsString( 'دانلود از دیجیتالوجیک', $html );
+		$this->assertStringContainsString( 'دانلود از دیجیتالاجیک', $html );
 		$this->assertStringContainsString( 'https://digitalogic.test/media/13090', $html );
 		$this->assertMatchesRegularExpression( '/\sdownload(?:\s|>)/', $html );
 		$this->assertStringContainsString( 'مشاهده منبع رسمی', $html );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -852,6 +852,20 @@ function get_post_type($post_id) {
         : null;
 }
 
+function get_post_mime_type( $post_id ) {
+	return isset( $GLOBALS['digitalogic_test_posts'][ $post_id ]['post_mime_type'] )
+		? $GLOBALS['digitalogic_test_posts'][ $post_id ]['post_mime_type']
+		: false;
+}
+
+function get_attached_file( $attachment_id, $unfiltered = false ) {
+	unset( $unfiltered );
+
+	return isset( $GLOBALS['digitalogic_test_attached_files'][ $attachment_id ] )
+		? $GLOBALS['digitalogic_test_attached_files'][ $attachment_id ]
+		: false;
+}
+
 function get_post($post_id) {
     $post_id = (int) $post_id;
     if (!isset($GLOBALS['digitalogic_test_posts'][$post_id])) {
@@ -2378,6 +2392,7 @@ require_once dirname(__DIR__) . '/includes/integrations/class-laravel-bridge.php
 require_once dirname(__DIR__) . '/includes/panel/class-panel.php';
 require_once dirname(__DIR__) . '/includes/integrations/class-label-overrides.php';
 require_once dirname(__DIR__) . '/includes/integrations/class-product-identity.php';
+require_once dirname(__DIR__) . '/includes/integrations/class-digitalogic-product-resources.php';
 require_once dirname(__DIR__) . '/includes/websocket/class-websocket-server.php';
 require_once dirname(__DIR__) . '/includes/admin/class-digitalogic-product-supplier-links-admin.php';
 require_once dirname(__DIR__) . '/includes/cli/class-cli-commands.php';


### PR DESCRIPTION
## What

- resolve `dir="auto"` values from the first strong Persian/Arabic or Latin character and override the legacy blanket-LTR product-spec rule
- add a component-responsive, accessible product-document card with both a Digitalogic-hosted PDF download and the official manufacturer source
- keep source label, exact product identity, attachment ownership, SHA-256, byte size, and verification time in a closed provenance record
- fail closed for wrong MIME, cross-product attachments, URL credentials, invalid timestamps, or file-integrity mismatches
- append the card exactly once at the `dgl_product_specs` rendering surface
- document the reviewed official-document workflow and add regression coverage

## Why

The Product Experience stylesheet forced all `<bdi>` values to LTR, so Persian values such as `پایه‌دار روی PCB (Through-hole)` rendered incorrectly. Product 11867 also had an exact official OMRON datasheet but no verified local download choice.

## Checks

- `phpunit tests/ProductResourcesTest.php` — 9 tests, 43 assertions
- full `phpunit` — 343 tests, 2,107 assertions; pre-existing 1 warning / 5 skipped
- focused WordPress PHPCS — clean for the new class and test
- repository PHPCS baseline — 40,583 errors / 3,014 warnings, below 43,221 / 3,016 limits
- PHP lint and `git diff --check` — clean
- CI — PHP 8.3 tests, code quality, security, and plugin package all pass
- public readback — one card and heading ID, explicit RTL for the mixed Persian value, no remaining `dir="auto"` for it, and both PDF endpoints return HTTP 200 as `application/pdf`

Live deployment was surgical with exact backup/readback because production intentionally differs from current `main` in unrelated loader lines.
