### PR TITLE
Add sanitized SEO monitor status bridge

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -99,6 +99,14 @@ jobs:
         npm --prefix ops/office-automation test
         bash -n ops/office-automation/scripts/deploy.sh
         bash -n ops/office-automation/scripts/rollback.sh
+        npm --prefix ops/seo-monitor run check
+        npm --prefix ops/seo-monitor test
+        sudoers_candidate="$(mktemp /tmp/digitalogic-seo-monitor-sudoers.XXXXXX)"
+        helper_digest="$(printf '0%.0s' {1..64})"
+        sed "s/__HELPER_SHA256__/$helper_digest/" \
+          ops/seo-monitor/sudoers.d/digitalogic-seo-monitor-status \
+          > "$sudoers_candidate"
+        /usr/sbin/visudo -cf "$sudoers_candidate"
 
     - name: Reject non-synthetic mobile fixtures
       run: |

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -58,6 +58,14 @@ jobs:
           node --test tests/product-query.test.js
           node --test tests/admin-branding-auth-nav.test.js
           node --test tests/sidebar-login-style.test.js
+          npm --prefix ops/seo-monitor run check
+          npm --prefix ops/seo-monitor test
+          sudoers_candidate="$(mktemp /tmp/digitalogic-seo-monitor-sudoers.XXXXXX)"
+          helper_digest="$(printf '0%.0s' {1..64})"
+          sed "s/__HELPER_SHA256__/$helper_digest/" \
+            ops/seo-monitor/sudoers.d/digitalogic-seo-monitor-status \
+            > "$sudoers_candidate"
+          /usr/sbin/visudo -cf "$sudoers_candidate"
 
       - name: Run PHPUnit tests
         run: composer test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a capability-gated `wp digitalogic seo-monitor status` command backed
+  by a fixed privileged declassifier that exposes only bounded counters,
+  controlled state, and keyed fingerprints while preserving the private
+  root-owned state boundary.
 - Added administrator-only WooCommerce product supplier links with a Persian
   classic-editor panel, redacted product-list summaries, protected metadata,
   exact product targeting, and stdin-only WP-CLI write commands.

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -177,6 +177,7 @@ final class Digitalogic {
         if (defined('WP_CLI') && WP_CLI) {
             require_once DIGITALOGIC_PLUGIN_DIR . 'includes/cli/class-cli-commands.php';
             require_once DIGITALOGIC_PLUGIN_DIR . 'includes/cli/class-digitalogic-product-supplier-links-cli.php';
+            require_once DIGITALOGIC_PLUGIN_DIR . 'includes/cli/class-digitalogic-seo-monitor-status-cli.php';
         }
     }
 

--- a/includes/cli/class-digitalogic-seo-monitor-status-cli.php
+++ b/includes/cli/class-digitalogic-seo-monitor-status-cli.php
@@ -1,0 +1,637 @@
+<?php
+/**
+ * Capability-gated WP-CLI transport for the sanitized SEO monitor status.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+/**
+ * Expose only the reviewed, sanitized SEO monitor status contract.
+ */
+final class Digitalogic_SEO_Monitor_Status_CLI {
+
+	private const BRIDGE_COMMAND = array(
+		'/usr/bin/sudo',
+		'-n',
+		'--',
+		'/usr/local/libexec/digitalogic-seo-monitor-status',
+	);
+
+	private const BRIDGE_ENVIRONMENT = array(
+		'PATH'   => '/usr/sbin:/usr/bin:/sbin:/bin',
+		'LANG'   => 'C',
+		'LC_ALL' => 'C',
+	);
+
+	private const BRIDGE_TIMEOUT_SECONDS = 5.0;
+	private const MAX_BRIDGE_BYTES       = 32768;
+	private const MAX_SAFE_INTEGER       = 9007199254740991;
+	private const STATUS_SCHEMA          = 'digitalogic.seo-monitor.status/v1';
+
+	private const SOURCE_KEYS = array(
+		'latest_completed',
+		'owner_approvals',
+		'pending_decisions',
+		'google_docs_scan_state',
+		'google_docs_migration_ledger',
+	);
+
+	private const READ_STATES = array(
+		'available',
+		'missing',
+		'invalid',
+		'unsupported_schema',
+		'unsafe',
+		'too_large',
+		'changed_during_read',
+	);
+
+	private const SNAPSHOT_STATES = array(
+		'complete',
+		'partial',
+		'unavailable',
+	);
+
+	private const RUN_STATES = array(
+		'completed',
+		'attention',
+		'blocked',
+		'failed',
+		'unknown',
+	);
+
+	/**
+	 * Test-only runner seam. Production command registration never supplies it.
+	 *
+	 * @var callable|null
+	 */
+	private $runner;
+
+	/**
+	 * Construct the command.
+	 *
+	 * @param callable|null $runner Test-only bridge runner.
+	 * @throws InvalidArgumentException When the test runner is not callable.
+	 */
+	public function __construct( $runner = null ) {
+		if ( null !== $runner && ! is_callable( $runner ) ) {
+			throw new InvalidArgumentException( 'The SEO monitor status runner must be callable.' );
+		}
+
+		$this->runner = $runner;
+	}
+
+	/**
+	 * Return one sanitized SEO monitor status snapshot.
+	 *
+	 * This command intentionally accepts no command-specific arguments. The
+	 * WP-CLI global --user argument supplies the WordPress identity used for the
+	 * capability check.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp digitalogic seo-monitor status --user=<administrator>
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args Positional command arguments.
+	 * @param array $assoc_args Named command arguments.
+	 * @return void
+	 */
+	public function status( $args, $assoc_args ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			WP_CLI::error( 'Run this command with --user=<administrator>.' );
+			return;
+		}
+
+		if ( ! empty( $args ) || ! empty( $assoc_args ) ) {
+			WP_CLI::error( 'This command does not accept command-specific arguments.' );
+			return;
+		}
+
+		$result = null === $this->runner
+			? self::run_bridge()
+			: call_user_func(
+				$this->runner,
+				self::BRIDGE_COMMAND,
+				self::BRIDGE_ENVIRONMENT,
+				self::BRIDGE_TIMEOUT_SECONDS,
+				self::MAX_BRIDGE_BYTES
+			);
+
+		$projection = self::project_bridge_result( $result );
+		if ( false === $projection ) {
+			WP_CLI::error( 'SEO monitor status is unavailable.' );
+			return;
+		}
+
+		$output = wp_json_encode( $projection, JSON_UNESCAPED_SLASHES );
+		if ( ! is_string( $output ) ) {
+			WP_CLI::error( 'SEO monitor status is unavailable.' );
+			return;
+		}
+
+		WP_CLI::line( $output );
+	}
+
+	/**
+	 * Execute the fixed privileged sanitizer without a shell.
+	 *
+	 * @return array|false Bounded process result, or false on launch failure.
+	 */
+	private static function run_bridge() {
+		$descriptors = array(
+			0 => array( 'pipe', 'r' ),
+			1 => array( 'pipe', 'w' ),
+			2 => array( 'pipe', 'w' ),
+		);
+		$pipes       = array();
+		$process     = @proc_open( // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open -- The fixed bridge emits one stable error instead of leaking a local process warning.
+			self::BRIDGE_COMMAND,
+			$descriptors,
+			$pipes,
+			null,
+			self::BRIDGE_ENVIRONMENT,
+			array( 'bypass_shell' => true )
+		);
+
+		if ( ! is_resource( $process ) || 3 !== count( $pipes ) ) {
+			return false;
+		}
+
+		fclose( $pipes[0] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- This closes a proc_open pipe, not a WordPress filesystem path.
+		stream_set_blocking( $pipes[1], false );
+		stream_set_blocking( $pipes[2], false );
+
+		$stdout      = '';
+		$stderr      = '';
+		$overflow    = false;
+		$timed_out   = false;
+		$exit_code   = null;
+		$started_at  = microtime( true );
+		$last_status = null;
+
+		while ( true ) {
+			self::append_bounded_stream( $pipes[1], $stdout, $overflow );
+			self::append_bounded_stream( $pipes[2], $stderr, $overflow );
+
+			$last_status = proc_get_status( $process );
+			if ( ! is_array( $last_status ) || empty( $last_status['running'] ) ) {
+				if ( is_array( $last_status ) && isset( $last_status['exitcode'] ) && 0 <= $last_status['exitcode'] ) {
+					$exit_code = (int) $last_status['exitcode'];
+				}
+				break;
+			}
+
+			if ( $overflow ) {
+				break;
+			}
+
+			if ( microtime( true ) - $started_at >= self::BRIDGE_TIMEOUT_SECONDS ) {
+				$timed_out = true;
+				break;
+			}
+
+			usleep( 10000 );
+		}
+
+		if ( $overflow || $timed_out ) {
+			self::terminate_process( $process );
+		}
+
+		self::append_bounded_stream( $pipes[1], $stdout, $overflow );
+		self::append_bounded_stream( $pipes[2], $stderr, $overflow );
+		fclose( $pipes[1] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- This closes a proc_open pipe, not a WordPress filesystem path.
+		fclose( $pipes[2] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose -- This closes a proc_open pipe, not a WordPress filesystem path.
+
+		$closed_exit_code = proc_close( $process );
+		if ( null === $exit_code && is_int( $closed_exit_code ) && 0 <= $closed_exit_code ) {
+			$exit_code = $closed_exit_code;
+		}
+
+		return array(
+			'exit_code' => $exit_code,
+			'stdout'    => $stdout,
+			'stderr'    => $stderr,
+			'timed_out' => $timed_out,
+			'overflow'  => $overflow,
+		);
+	}
+
+	/**
+	 * Append one nonblocking pipe read without retaining more than the cap.
+	 *
+	 * @param resource $stream Pipe stream.
+	 * @param string   $buffer Captured buffer.
+	 * @param bool     $overflow Whether either stream exceeded the cap.
+	 * @return void
+	 */
+	private static function append_bounded_stream( $stream, &$buffer, &$overflow ) {
+		if ( $overflow ) {
+			return;
+		}
+
+		$chunk = stream_get_contents( $stream );
+		if ( false === $chunk || '' === $chunk ) {
+			return;
+		}
+
+		$remaining = self::MAX_BRIDGE_BYTES - strlen( $buffer );
+		if ( strlen( $chunk ) > $remaining ) {
+			if ( 0 < $remaining ) {
+				$buffer .= substr( $chunk, 0, $remaining );
+			}
+			$overflow = true;
+			return;
+		}
+
+		$buffer .= $chunk;
+	}
+
+	/**
+	 * Stop a timed-out or overproducing sanitizer process.
+	 *
+	 * @param resource $process Process handle.
+	 * @return void
+	 */
+	private static function terminate_process( $process ) {
+		proc_terminate( $process );
+		$deadline = microtime( true ) + 0.2;
+		do {
+			$status = proc_get_status( $process );
+			if ( ! is_array( $status ) || empty( $status['running'] ) ) {
+				return;
+			}
+			usleep( 10000 );
+		} while ( microtime( true ) < $deadline );
+
+		proc_terminate( $process, 9 );
+	}
+
+	/**
+	 * Validate a process result and reconstruct the fixed public projection.
+	 *
+	 * Raw stdout and stderr are never returned.
+	 *
+	 * @param mixed $result Bridge process result.
+	 * @return array|false
+	 */
+	private static function project_bridge_result( $result ) {
+		if (
+			! self::has_exact_keys(
+				$result,
+				array( 'exit_code', 'stdout', 'stderr', 'timed_out', 'overflow' )
+			)
+			|| 0 !== $result['exit_code']
+			|| ! is_string( $result['stdout'] )
+			|| ! is_string( $result['stderr'] )
+			|| ! is_bool( $result['timed_out'] )
+			|| ! is_bool( $result['overflow'] )
+			|| $result['timed_out']
+			|| $result['overflow']
+			|| '' !== $result['stderr']
+			|| self::MAX_BRIDGE_BYTES < strlen( $result['stdout'] )
+		) {
+			return false;
+		}
+
+		if ( 1 !== preg_match( '/\A[^\r\n]+\r?\n?\z/D', $result['stdout'] ) ) {
+			return false;
+		}
+
+		$document = rtrim( $result['stdout'], "\r\n" );
+		$payload  = json_decode( $document, true, 64, JSON_BIGINT_AS_STRING );
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			return false;
+		}
+
+		return self::project_payload( $payload );
+	}
+
+	/**
+	 * Validate and reconstruct the complete v1 payload.
+	 *
+	 * @param mixed $payload Decoded bridge payload.
+	 * @return array|false
+	 */
+	private static function project_payload( $payload ) {
+		if (
+			! self::has_exact_keys(
+				$payload,
+				array( 'schema', 'generated_at', 'snapshot_state', 'sources' )
+			)
+			|| self::STATUS_SCHEMA !== $payload['schema']
+			|| ! self::is_utc_timestamp( $payload['generated_at'] )
+			|| ! in_array( $payload['snapshot_state'], self::SNAPSHOT_STATES, true )
+			|| ! self::has_exact_keys( $payload['sources'], self::SOURCE_KEYS )
+		) {
+			return false;
+		}
+
+		$sources         = array();
+		$available_count = 0;
+		foreach ( self::SOURCE_KEYS as $source_key ) {
+			$source = self::project_source( $source_key, $payload['sources'][ $source_key ] );
+			if ( false === $source ) {
+				return false;
+			}
+			if ( 'available' === $source['read_state'] ) {
+				++$available_count;
+			}
+			$sources[ $source_key ] = $source;
+		}
+
+		$derived_snapshot_state = 0 === $available_count
+			? 'unavailable'
+			: ( count( self::SOURCE_KEYS ) === $available_count ? 'complete' : 'partial' );
+		if ( $derived_snapshot_state !== $payload['snapshot_state'] ) {
+			return false;
+		}
+
+		return array(
+			'schema'         => self::STATUS_SCHEMA,
+			'generated_at'   => $payload['generated_at'],
+			'snapshot_state' => $derived_snapshot_state,
+			'sources'        => $sources,
+		);
+	}
+
+	/**
+	 * Validate and reconstruct one fixed source envelope.
+	 *
+	 * @param string $source_key Source identifier.
+	 * @param mixed  $source Source envelope.
+	 * @return array|false
+	 */
+	private static function project_source( $source_key, $source ) {
+		if (
+			! self::has_exact_keys(
+				$source,
+				array( 'read_state', 'updated_at', 'summary', 'fingerprint' )
+			)
+			|| ! in_array( $source['read_state'], self::READ_STATES, true )
+			|| ( null !== $source['updated_at'] && ! self::is_utc_timestamp( $source['updated_at'] ) )
+		) {
+			return false;
+		}
+
+		if ( 'available' !== $source['read_state'] ) {
+			if (
+				null !== $source['updated_at']
+				|| null !== $source['summary']
+				|| null !== $source['fingerprint']
+			) {
+				return false;
+			}
+
+			return array(
+				'read_state'  => $source['read_state'],
+				'updated_at'  => $source['updated_at'],
+				'summary'     => null,
+				'fingerprint' => null,
+			);
+		}
+
+		if (
+			! self::is_utc_timestamp( $source['updated_at'] )
+			|| ! is_string( $source['fingerprint'] )
+			|| 1 !== preg_match( '/\Ahmac-sha256:[0-9a-f]{64}\z/D', $source['fingerprint'] )
+		) {
+			return false;
+		}
+
+		$summary = self::project_summary( $source_key, $source['summary'] );
+		if ( false === $summary ) {
+			return false;
+		}
+
+		return array(
+			'read_state'  => 'available',
+			'updated_at'  => $source['updated_at'],
+			'summary'     => $summary,
+			'fingerprint' => $source['fingerprint'],
+		);
+	}
+
+	/**
+	 * Validate and reconstruct a source-specific summary.
+	 *
+	 * @param string $source_key Source identifier.
+	 * @param mixed  $summary Source summary.
+	 * @return array|false
+	 */
+	private static function project_summary( $source_key, $summary ) {
+		switch ( $source_key ) {
+			case 'latest_completed':
+				return self::project_latest_completed_summary( $summary );
+			case 'owner_approvals':
+				return self::project_integer_summary(
+					$summary,
+					array( 'total', 'pending', 'approved', 'rejected', 'expired' )
+				);
+			case 'pending_decisions':
+				return self::project_integer_summary(
+					$summary,
+					array( 'total', 'critical', 'significant', 'tracked', 'other' )
+				);
+			case 'google_docs_scan_state':
+				return self::project_google_docs_scan_summary( $summary );
+			case 'google_docs_migration_ledger':
+				return self::project_integer_summary(
+					$summary,
+					array(
+						'total',
+						'discovered',
+						'not_product_content',
+						'needs_mapping',
+						'staged_conflict',
+						'applied_verified',
+						'failed_retryable',
+						'blocked',
+						'other',
+					)
+				);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Validate the latest completed run summary.
+	 *
+	 * @param mixed $summary Source summary.
+	 * @return array|false
+	 */
+	private static function project_latest_completed_summary( $summary ) {
+		$integer_keys = array(
+			'critical_findings',
+			'significant_findings',
+			'tracked_findings',
+			'owner_decisions',
+		);
+		$expected     = array_merge( array( 'run_state' ), $integer_keys );
+		if (
+			! self::has_exact_keys( $summary, $expected )
+			|| ! in_array( $summary['run_state'], self::RUN_STATES, true )
+		) {
+			return false;
+		}
+
+		$projection = array( 'run_state' => $summary['run_state'] );
+		foreach ( $integer_keys as $key ) {
+			if ( ! self::is_unsigned_safe_integer( $summary[ $key ] ) ) {
+				return false;
+			}
+			$projection[ $key ] = $summary[ $key ];
+		}
+
+		return $projection;
+	}
+
+	/**
+	 * Validate an exact all-integer summary.
+	 *
+	 * @param mixed $summary Source summary.
+	 * @param array $keys Exact summary keys.
+	 * @return array|false
+	 */
+	private static function project_integer_summary( $summary, $keys ) {
+		if ( ! self::has_exact_keys( $summary, $keys ) ) {
+			return false;
+		}
+
+		$projection = array();
+		foreach ( $keys as $key ) {
+			if ( ! self::is_unsigned_safe_integer( $summary[ $key ] ) ) {
+				return false;
+			}
+			$projection[ $key ] = $summary[ $key ];
+		}
+
+		if ( in_array( 'total', $keys, true ) ) {
+			$partition_total = 0;
+			foreach ( $keys as $key ) {
+				if ( 'total' !== $key ) {
+					$partition_total += $summary[ $key ];
+				}
+			}
+			if ( $summary['total'] !== $partition_total ) {
+				return false;
+			}
+		}
+
+		return $projection;
+	}
+
+	/**
+	 * Validate the Google Docs inventory summary.
+	 *
+	 * @param mixed $summary Source summary.
+	 * @return array|false
+	 */
+	private static function project_google_docs_scan_summary( $summary ) {
+		$boolean_keys = array(
+			'inventory_complete',
+			'access_blocked',
+			'cursor_pending',
+		);
+		$integer_keys = array(
+			'documents_seen',
+			'documents_changed',
+			'tabs_seen',
+			'errors',
+		);
+		$expected     = array_merge( $boolean_keys, $integer_keys );
+		if ( ! self::has_exact_keys( $summary, $expected ) ) {
+			return false;
+		}
+
+		$projection = array();
+		foreach ( $boolean_keys as $key ) {
+			if ( ! is_bool( $summary[ $key ] ) ) {
+				return false;
+			}
+			$projection[ $key ] = $summary[ $key ];
+		}
+		foreach ( $integer_keys as $key ) {
+			if ( ! self::is_unsigned_safe_integer( $summary[ $key ] ) ) {
+				return false;
+			}
+			$projection[ $key ] = $summary[ $key ];
+		}
+
+		if (
+			$summary['documents_changed'] > $summary['documents_seen']
+			|| $summary['errors'] > $summary['documents_seen']
+		) {
+			return false;
+		}
+
+		return $projection;
+	}
+
+	/**
+	 * Check an exact JSON-object key set.
+	 *
+	 * @param mixed $value Candidate object.
+	 * @param array $expected_keys Expected keys.
+	 * @return bool
+	 */
+	private static function has_exact_keys( $value, $expected_keys ) {
+		if ( ! is_array( $value ) || array_is_list( $value ) ) {
+			return false;
+		}
+
+		$actual_keys = array_keys( $value );
+		sort( $actual_keys );
+		sort( $expected_keys );
+
+		return $actual_keys === $expected_keys;
+	}
+
+	/**
+	 * Check a strict UTC ISO timestamp with millisecond precision.
+	 *
+	 * @param mixed $value Candidate timestamp.
+	 * @return bool
+	 */
+	private static function is_utc_timestamp( $value ) {
+		if (
+			! is_string( $value )
+			|| 1 !== preg_match( '/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z/D', $value )
+		) {
+			return false;
+		}
+
+		$parsed = DateTimeImmutable::createFromFormat(
+			'!Y-m-d\TH:i:s.v\Z',
+			$value,
+			new DateTimeZone( 'UTC' )
+		);
+
+		return false !== $parsed && $value === $parsed->format( 'Y-m-d\TH:i:s.v\Z' );
+	}
+
+	/**
+	 * Check an unsigned JavaScript-safe integer.
+	 *
+	 * @param mixed $value Candidate count.
+	 * @return bool
+	 */
+	private static function is_unsigned_safe_integer( $value ) {
+		return is_int( $value ) && 0 <= $value && self::MAX_SAFE_INTEGER >= $value;
+	}
+}
+
+WP_CLI::add_command(
+	'digitalogic seo-monitor status',
+	array( 'Digitalogic_SEO_Monitor_Status_CLI', 'status' )
+);

--- a/ops/seo-monitor/README.md
+++ b/ops/seo-monitor/README.md
@@ -1,0 +1,143 @@
+# SEO monitor status declassifier
+
+Status: **pending owner approval**. These files are review artifacts only.
+Do not install or deploy the helper, HMAC key, or sudoers rule from an
+unmerged branch. A merge or issue closure does not itself record owner
+approval.
+
+## Purpose and trust boundary
+
+The SEO monitor keeps private state under
+`/var/lib/digitalogic/seo-monitor` as `root:root` with directory mode `0700`
+and file mode `0600`. Those permissions remain unchanged.
+
+The direct executable in `bin/digitalogic-seo-monitor-status.cjs` is a
+least-information declassifier. It reads five fixed JSON files as root and
+returns only counters, booleans, controlled states, timestamps, and keyed
+fingerprints. It never returns file paths, record identifiers, product data,
+document or tab identifiers, source URLs, content, collaborator information,
+credentials, or notification routing.
+
+The WordPress command must perform its administrator and `manage_options`
+checks before invoking this executable. That application-level identity does
+not cross the `sudo` boundary: every local process running as `www-data` can
+invoke a permitted fixed helper. The output and every failure shape therefore
+must remain safe for any local UID 33 caller.
+
+## Fixed inputs
+
+The executable accepts no arguments, configuration environment variables, or
+stdin data. It uses only these paths:
+
+| Logical source | Fixed private path | Maximum size |
+| --- | --- | ---: |
+| `latest_completed` | `/var/lib/digitalogic/seo-monitor/latest-completed.json` | 1 MiB |
+| `owner_approvals` | `/var/lib/digitalogic/seo-monitor/owner-approvals.json` | 4 MiB |
+| `pending_decisions` | `/var/lib/digitalogic/seo-monitor/pending-decisions.json` | 4 MiB |
+| `google_docs_scan_state` | `/var/lib/digitalogic/seo-monitor/google-docs-scan-state.json` | 8 MiB |
+| `google_docs_migration_ledger` | `/var/lib/digitalogic/seo-monitor/google-docs-migration-ledger.json` | 16 MiB |
+
+The HMAC key is a raw, exactly 32-byte file at
+`/etc/digitalogic/seo-monitor-status.hmac`. It must be provisioned outside the
+repository as `root:root` mode `0600`. The status helper never creates,
+rotates, or prints it.
+
+The private directory must be a real `root:root` directory with exact mode
+`0700`. Every input and the key must be a regular, non-symlink, single-link
+`root:root` file with exact mode `0600`. Files are opened read-only with
+`O_NOFOLLOW`, checked with `fstat`, size-bounded, and checked again after the
+read. Each fixed parent path component is also required to be a real
+root-owned directory that is not group/other writable. A file that changes
+during both bounded attempts is not parsed.
+
+## Producer contracts
+
+Each producer file is a JSON object with `schema_version` exactly `1.0` or
+`1.1`; every other version is `unsupported_schema`. Timestamps are
+millisecond-precision UTC. The source-specific required projections are:
+
+- Latest completed: an opaque bounded `audit_id`, `completed_at`, a controlled `status`, and direct
+  nonnegative integer `critical_findings`, `significant_findings`,
+  `tracked_findings`, and `owner_decisions` counters. Producer status
+  `completed` maps to `completed`; `completed_with_findings` and `attention`
+  map to `attention`; `blocked`, `failed`, and `unknown` map to themselves.
+  Other source statuses are rejected instead of being echoed.
+- Owner approvals: `updated_at` and `approvals[]` with opaque `fingerprint` and one of
+  `pending`, `approved`, `rejected`, or `expired`.
+- Pending decisions: `updated_at` and `decisions[]` with opaque `fingerprint`,
+  a controlled `severity`, and a bounded `status`; unrecognized but bounded
+  severities count only as `other`. Private `current`, `recommended_reply`,
+  and `blocked_workflows` data is ignored.
+- Google Docs scan: `updated_at`, `inventory_complete`,
+  `google_docs_access_blocked`, an opaque or null `cursor`, and `documents[]`
+  with opaque document and revision fingerprints, `changed`, `tabs_seen`, and
+  `error`.
+- Google Docs ledger: `updated_at` and `entries[]` with opaque `fingerprint` and status.
+  Unrecognized but bounded statuses count only as `other`.
+
+Additional private producer fields are ignored and never fingerprinted or
+emitted. An unknown schema is `unsupported_schema`; malformed required data is
+`invalid`. The included fixtures cover both accepted producer revisions and
+contain deliberately sensitive ignored fields to exercise non-disclosure.
+
+## Output contract
+
+Stdout contains exactly one compact JSON line:
+
+```json
+{
+  "schema": "digitalogic.seo-monitor.status/v1",
+  "generated_at": "2026-07-26T10:00:00.000Z",
+  "snapshot_state": "complete",
+  "sources": {
+    "latest_completed": {
+      "read_state": "available",
+      "updated_at": "2026-07-26T09:59:00.000Z",
+      "summary": {
+        "run_state": "attention",
+        "critical_findings": 1,
+        "significant_findings": 2,
+        "tracked_findings": 3,
+        "owner_decisions": 1
+      },
+      "fingerprint": "hmac-sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  }
+}
+```
+
+The real `sources` object always has exactly these five keys, each with exactly
+`read_state`, `updated_at`, `summary`, and `fingerprint`. Read state is one of
+`available`, `missing`, `invalid`, `unsupported_schema`, `unsafe`,
+`too_large`, or `changed_during_read`. A non-available source always has null
+`updated_at`, `summary`, and `fingerprint`; zero is never used to represent
+unavailable data.
+
+`snapshot_state` is `complete` when all five sources are available, `partial`
+when some are available, and `unavailable` when none are available.
+
+Fingerprints are domain-separated HMAC-SHA-256 values over canonical,
+whitelisted projections and sorted per-record HMAC tokens. Raw identifiers and
+URLs are not emitted or directly hashed into an unkeyed public digest.
+
+## Reviewed deployment prerequisites
+
+Deployment remains a separate, explicitly approved operation:
+
+1. Run `npm run check` and `npm test` in this directory.
+2. Install the reviewed executable atomically as
+   `/usr/local/libexec/digitalogic-seo-monitor-status`, owned by `root:root`
+   and mode `0555` or `0755`. All parent directories must be root-owned and
+   not group/other writable.
+3. Provision the 32-byte HMAC key outside source control as `root:root` mode
+   `0600`.
+4. Calculate the installed helper digest, replace the sudoers template
+   placeholder, and validate the completed file with `visudo -cf`.
+5. Install the completed sudoers file as `root:root` mode `0440`.
+6. Confirm `www-data` can run only the exact no-argument executable. Any
+   argument, alternate executable, environment preservation, or modified
+   helper digest must be denied.
+7. Exercise the capability-checked WP-CLI command and confirm its response
+   matches the exact output allowlist without exposing private fixture values.
+
+No step above authorizes weakening the existing `0700` or `0600` permissions.

--- a/ops/seo-monitor/bin/digitalogic-seo-monitor-status.cjs
+++ b/ops/seo-monitor/bin/digitalogic-seo-monitor-status.cjs
@@ -1,0 +1,916 @@
+#!/usr/bin/node
+"use strict";
+
+const fs = require("node:fs");
+const { createHmac } = require("node:crypto");
+const { TextDecoder } = require("node:util");
+
+const OUTPUT_SCHEMA = "digitalogic.seo-monitor.status/v1";
+const PRIVATE_ROOT = "/var/lib/digitalogic/seo-monitor";
+const HMAC_KEY_PATH = "/etc/digitalogic/seo-monitor-status.hmac";
+const PRIVATE_PARENT_DIRS = Object.freeze([
+  "/var",
+  "/var/lib",
+  "/var/lib/digitalogic",
+]);
+const KEY_PARENT_DIRS = Object.freeze([
+  "/etc",
+  "/etc/digitalogic",
+]);
+const MAX_RECORDS = 100000;
+const MAX_OPAQUE_LENGTH = 4096;
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
+const EARLIEST_TIMESTAMP_MS = Date.parse("2000-01-01T00:00:00.000Z");
+
+const SOURCE_ORDER = Object.freeze([
+  "latest_completed",
+  "owner_approvals",
+  "pending_decisions",
+  "google_docs_scan_state",
+  "google_docs_migration_ledger",
+]);
+
+const SOURCE_CONFIG = Object.freeze({
+  latest_completed: Object.freeze({
+    path: `${PRIVATE_ROOT}/latest-completed.json`,
+    maxBytes: 1024 * 1024,
+    versions: Object.freeze(["1.0", "1.1"]),
+  }),
+  owner_approvals: Object.freeze({
+    path: `${PRIVATE_ROOT}/owner-approvals.json`,
+    maxBytes: 4 * 1024 * 1024,
+    versions: Object.freeze(["1.0", "1.1"]),
+  }),
+  pending_decisions: Object.freeze({
+    path: `${PRIVATE_ROOT}/pending-decisions.json`,
+    maxBytes: 4 * 1024 * 1024,
+    versions: Object.freeze(["1.0", "1.1"]),
+  }),
+  google_docs_scan_state: Object.freeze({
+    path: `${PRIVATE_ROOT}/google-docs-scan-state.json`,
+    maxBytes: 8 * 1024 * 1024,
+    versions: Object.freeze(["1.0", "1.1"]),
+  }),
+  google_docs_migration_ledger: Object.freeze({
+    path: `${PRIVATE_ROOT}/google-docs-migration-ledger.json`,
+    maxBytes: 16 * 1024 * 1024,
+    versions: Object.freeze(["1.0", "1.1"]),
+  }),
+});
+
+const READ_STATES = new Set([
+  "available",
+  "missing",
+  "invalid",
+  "unsupported_schema",
+  "unsafe",
+  "too_large",
+  "changed_during_read",
+]);
+
+const RUN_STATES = new Set([
+  "completed",
+  "attention",
+  "blocked",
+  "failed",
+  "unknown",
+]);
+
+const PRODUCER_RUN_STATE_MAP = Object.freeze({
+  completed: "completed",
+  completed_with_findings: "attention",
+  attention: "attention",
+  blocked: "blocked",
+  failed: "failed",
+  unknown: "unknown",
+});
+
+const APPROVAL_STATES = new Set([
+  "pending",
+  "approved",
+  "rejected",
+  "expired",
+]);
+
+const FINDING_STATES = new Set([
+  "critical",
+  "significant",
+  "tracked",
+]);
+
+const LEDGER_STATES = new Set([
+  "discovered",
+  "not_product_content",
+  "needs_mapping",
+  "staged_conflict",
+  "applied_verified",
+  "failed_retryable",
+  "blocked",
+]);
+
+class StatusError extends Error {
+  constructor(readState) {
+    super(readState);
+    this.name = "StatusError";
+    this.readState = READ_STATES.has(readState) ? readState : "invalid";
+  }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireObject(value) {
+  if (!isObject(value)) {
+    throw new StatusError("invalid");
+  }
+  return value;
+}
+
+function requireBoolean(value) {
+  if (typeof value !== "boolean") {
+    throw new StatusError("invalid");
+  }
+  return value;
+}
+
+function requireArray(value) {
+  if (!Array.isArray(value) || value.length > MAX_RECORDS) {
+    throw new StatusError("invalid");
+  }
+  return value;
+}
+
+function requireOpaque(value) {
+  if (
+    typeof value !== "string" ||
+    value.length < 1 ||
+    value.length > MAX_OPAQUE_LENGTH
+  ) {
+    throw new StatusError("invalid");
+  }
+  return value;
+}
+
+function requireSmallToken(value) {
+  if (typeof value !== "string" || value.length < 1 || value.length > 64) {
+    throw new StatusError("invalid");
+  }
+  return value;
+}
+
+function requireUnsignedInteger(value) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new StatusError("invalid");
+  }
+  return value;
+}
+
+function checkedAdd(left, right) {
+  const result = left + right;
+  if (!Number.isSafeInteger(result) || result < 0) {
+    throw new StatusError("invalid");
+  }
+  return result;
+}
+
+function requireUtcTimestamp(value, nowMs) {
+  if (
+    typeof value !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)
+  ) {
+    throw new StatusError("invalid");
+  }
+
+  const parsed = Date.parse(value);
+  if (
+    !Number.isFinite(parsed) ||
+    new Date(parsed).toISOString() !== value ||
+    parsed < EARLIEST_TIMESTAMP_MS ||
+    parsed > nowMs + MAX_FUTURE_SKEW_MS
+  ) {
+    throw new StatusError("invalid");
+  }
+
+  return value;
+}
+
+function requireSupportedSchema(value, sourceName) {
+  if (typeof value !== "string") {
+    throw new StatusError("unsupported_schema");
+  }
+  if (!SOURCE_CONFIG[sourceName].versions.includes(value)) {
+    throw new StatusError("unsupported_schema");
+  }
+  return value;
+}
+
+function decodeJson(buffer) {
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+  } catch {
+    throw new StatusError("invalid");
+  }
+
+  try {
+    return requireObject(JSON.parse(text));
+  } catch (error) {
+    if (error instanceof StatusError) {
+      throw error;
+    }
+    throw new StatusError("invalid");
+  }
+}
+
+function hmacHex(key, domain, payload) {
+  return createHmac("sha256", key)
+    .update(domain, "utf8")
+    .update("\0", "utf8")
+    .update(payload, "utf8")
+    .digest("hex");
+}
+
+function recordToken(key, domain, values) {
+  return hmacHex(key, `${domain}/record`, JSON.stringify(values));
+}
+
+function sourceFingerprint(key, domain, projection, tokens) {
+  const sortedTokens = [...tokens].sort();
+  const digest = hmacHex(
+    key,
+    `${domain}/source`,
+    JSON.stringify([projection, sortedTokens]),
+  );
+  return `hmac-sha256:${digest}`;
+}
+
+function parseLatestCompleted(data, key, nowMs) {
+  requireSupportedSchema(data.schema_version, "latest_completed");
+  const updatedAt = requireUtcTimestamp(data.completed_at, nowMs);
+  const producerStatus = requireSmallToken(data.status);
+  const runState = PRODUCER_RUN_STATE_MAP[producerStatus];
+  if (!RUN_STATES.has(runState)) {
+    throw new StatusError("invalid");
+  }
+
+  const summary = {
+    run_state: runState,
+    critical_findings: requireUnsignedInteger(data.critical_findings),
+    significant_findings: requireUnsignedInteger(data.significant_findings),
+    tracked_findings: requireUnsignedInteger(data.tracked_findings),
+    owner_decisions: requireUnsignedInteger(data.owner_decisions),
+  };
+  const auditToken = recordToken(
+    key,
+    "latest_completed/audit",
+    [requireOpaque(data.audit_id)],
+  );
+
+  return {
+    updated_at: updatedAt,
+    summary,
+    fingerprint: sourceFingerprint(
+      key,
+      "latest_completed",
+      [
+        summary.run_state,
+        summary.critical_findings,
+        summary.significant_findings,
+        summary.tracked_findings,
+        summary.owner_decisions,
+      ],
+      [auditToken],
+    ),
+  };
+}
+
+function parseOwnerApprovals(data, key, nowMs) {
+  requireSupportedSchema(data.schema_version, "owner_approvals");
+  const updatedAt = requireUtcTimestamp(data.updated_at, nowMs);
+  const counts = {
+    pending: 0,
+    approved: 0,
+    rejected: 0,
+    expired: 0,
+  };
+  const tokens = [];
+  const approvals = requireArray(data.approvals);
+
+  for (const rawApproval of approvals) {
+    const approval = requireObject(rawApproval);
+    const opaque = requireOpaque(approval.fingerprint);
+    const status = requireSmallToken(approval.status);
+    if (!APPROVAL_STATES.has(status)) {
+      throw new StatusError("invalid");
+    }
+    counts[status] = checkedAdd(counts[status], 1);
+    tokens.push(recordToken(key, "owner_approvals/approval", [opaque, status]));
+  }
+
+  const summary = {
+    total: approvals.length,
+    pending: counts.pending,
+    approved: counts.approved,
+    rejected: counts.rejected,
+    expired: counts.expired,
+  };
+
+  return {
+    updated_at: updatedAt,
+    summary,
+    fingerprint: sourceFingerprint(
+      key,
+      "owner_approvals",
+      [
+        summary.total,
+        summary.pending,
+        summary.approved,
+        summary.rejected,
+        summary.expired,
+      ],
+      tokens,
+    ),
+  };
+}
+
+function parsePendingDecisions(data, key, nowMs) {
+  requireSupportedSchema(data.schema_version, "pending_decisions");
+  const updatedAt = requireUtcTimestamp(data.updated_at, nowMs);
+  const counts = {
+    critical: 0,
+    significant: 0,
+    tracked: 0,
+    other: 0,
+  };
+  const tokens = [];
+  const decisions = requireArray(data.decisions);
+
+  for (const rawDecision of decisions) {
+    const decision = requireObject(rawDecision);
+    const opaque = requireOpaque(decision.fingerprint);
+    const severity = requireSmallToken(decision.severity);
+    const status = requireSmallToken(decision.status);
+    const bucket = FINDING_STATES.has(severity) ? severity : "other";
+    counts[bucket] = checkedAdd(counts[bucket], 1);
+    tokens.push(
+      recordToken(
+        key,
+        "pending_decisions/decision",
+        [opaque, severity, status],
+      ),
+    );
+  }
+
+  const summary = {
+    total: decisions.length,
+    critical: counts.critical,
+    significant: counts.significant,
+    tracked: counts.tracked,
+    other: counts.other,
+  };
+
+  return {
+    updated_at: updatedAt,
+    summary,
+    fingerprint: sourceFingerprint(
+      key,
+      "pending_decisions",
+      [
+        summary.total,
+        summary.critical,
+        summary.significant,
+        summary.tracked,
+        summary.other,
+      ],
+      tokens,
+    ),
+  };
+}
+
+function parseGoogleDocsScanState(data, key, nowMs) {
+  requireSupportedSchema(data.schema_version, "google_docs_scan_state");
+  const updatedAt = requireUtcTimestamp(data.updated_at, nowMs);
+  const inventoryComplete = requireBoolean(data.inventory_complete);
+  const accessBlocked = requireBoolean(data.google_docs_access_blocked);
+  const cursorPending = data.cursor !== null;
+  const tokens = [];
+
+  if (cursorPending) {
+    tokens.push(
+      recordToken(
+        key,
+        "google_docs_scan_state/cursor",
+        [requireOpaque(data.cursor)],
+      ),
+    );
+  }
+
+  let documentsChanged = 0;
+  let tabsSeen = 0;
+  let errors = 0;
+  const documents = requireArray(data.documents);
+
+  for (const rawDocument of documents) {
+    const document = requireObject(rawDocument);
+    const opaque = requireOpaque(document.fingerprint);
+    const revision = requireOpaque(document.revision_fingerprint);
+    const changed = requireBoolean(document.changed);
+    const documentTabs = requireUnsignedInteger(document.tabs_seen);
+    const hasError = requireBoolean(document.error);
+
+    if (changed) {
+      documentsChanged = checkedAdd(documentsChanged, 1);
+    }
+    if (hasError) {
+      errors = checkedAdd(errors, 1);
+    }
+    tabsSeen = checkedAdd(tabsSeen, documentTabs);
+    tokens.push(
+      recordToken(
+        key,
+        "google_docs_scan_state/document",
+        [opaque, revision, changed, documentTabs, hasError],
+      ),
+    );
+  }
+
+  const summary = {
+    inventory_complete: inventoryComplete,
+    access_blocked: accessBlocked,
+    cursor_pending: cursorPending,
+    documents_seen: documents.length,
+    documents_changed: documentsChanged,
+    tabs_seen: tabsSeen,
+    errors,
+  };
+
+  return {
+    updated_at: updatedAt,
+    summary,
+    fingerprint: sourceFingerprint(
+      key,
+      "google_docs_scan_state",
+      [
+        summary.inventory_complete,
+        summary.access_blocked,
+        summary.cursor_pending,
+        summary.documents_seen,
+        summary.documents_changed,
+        summary.tabs_seen,
+        summary.errors,
+      ],
+      tokens,
+    ),
+  };
+}
+
+function parseGoogleDocsMigrationLedger(data, key, nowMs) {
+  requireSupportedSchema(data.schema_version, "google_docs_migration_ledger");
+  const updatedAt = requireUtcTimestamp(data.updated_at, nowMs);
+  const counts = {
+    discovered: 0,
+    not_product_content: 0,
+    needs_mapping: 0,
+    staged_conflict: 0,
+    applied_verified: 0,
+    failed_retryable: 0,
+    blocked: 0,
+    other: 0,
+  };
+  const tokens = [];
+  const entries = requireArray(data.entries);
+
+  for (const rawEntry of entries) {
+    const entry = requireObject(rawEntry);
+    const opaque = requireOpaque(entry.fingerprint);
+    const status = requireSmallToken(entry.status);
+    const bucket = LEDGER_STATES.has(status) ? status : "other";
+    counts[bucket] = checkedAdd(counts[bucket], 1);
+    tokens.push(
+      recordToken(
+        key,
+        "google_docs_migration_ledger/entry",
+        [opaque, status],
+      ),
+    );
+  }
+
+  const summary = {
+    total: entries.length,
+    discovered: counts.discovered,
+    not_product_content: counts.not_product_content,
+    needs_mapping: counts.needs_mapping,
+    staged_conflict: counts.staged_conflict,
+    applied_verified: counts.applied_verified,
+    failed_retryable: counts.failed_retryable,
+    blocked: counts.blocked,
+    other: counts.other,
+  };
+
+  return {
+    updated_at: updatedAt,
+    summary,
+    fingerprint: sourceFingerprint(
+      key,
+      "google_docs_migration_ledger",
+      [
+        summary.total,
+        summary.discovered,
+        summary.not_product_content,
+        summary.needs_mapping,
+        summary.staged_conflict,
+        summary.applied_verified,
+        summary.failed_retryable,
+        summary.blocked,
+        summary.other,
+      ],
+      tokens,
+    ),
+  };
+}
+
+const SOURCE_PARSERS = Object.freeze({
+  latest_completed: parseLatestCompleted,
+  owner_approvals: parseOwnerApprovals,
+  pending_decisions: parsePendingDecisions,
+  google_docs_scan_state: parseGoogleDocsScanState,
+  google_docs_migration_ledger: parseGoogleDocsMigrationLedger,
+});
+
+function parseSource(sourceName, buffer, key, nowMs) {
+  if (!Object.prototype.hasOwnProperty.call(SOURCE_PARSERS, sourceName)) {
+    throw new StatusError("invalid");
+  }
+  return SOURCE_PARSERS[sourceName](decodeJson(buffer), key, nowMs);
+}
+
+function fileTypeMatches(stats, expectedType) {
+  if (expectedType === "directory") {
+    return typeof stats.isDirectory === "function" && stats.isDirectory();
+  }
+  return typeof stats.isFile === "function" && stats.isFile();
+}
+
+function verifyTrustedStats(stats, options) {
+  if (
+    !stats ||
+    (typeof stats.isSymbolicLink === "function" && stats.isSymbolicLink()) ||
+    !fileTypeMatches(stats, options.type) ||
+    stats.uid !== 0 ||
+    stats.gid !== 0 ||
+    (stats.mode & 0o7777) !== options.mode
+  ) {
+    throw new StatusError("unsafe");
+  }
+
+  if (options.type === "file") {
+    if (stats.nlink !== 1) {
+      throw new StatusError("unsafe");
+    }
+    if (!Number.isSafeInteger(stats.size) || stats.size < 0) {
+      throw new StatusError("unsafe");
+    }
+    if (stats.size > options.maxBytes) {
+      throw new StatusError("too_large");
+    }
+    if (
+      Number.isSafeInteger(options.exactBytes) &&
+      stats.size !== options.exactBytes
+    ) {
+      throw new StatusError("unsafe");
+    }
+  }
+}
+
+function verifyTrustedParentDirectory(stats) {
+  if (
+    !stats ||
+    (typeof stats.isSymbolicLink === "function" && stats.isSymbolicLink()) ||
+    !fileTypeMatches(stats, "directory") ||
+    stats.uid !== 0 ||
+    stats.gid !== 0 ||
+    (stats.mode & 0o022) !== 0
+  ) {
+    throw new StatusError("unsafe");
+  }
+}
+
+function sameIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameSnapshot(left, right) {
+  return (
+    sameIdentity(left, right) &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  );
+}
+
+function mapFileError(error) {
+  if (error instanceof StatusError) {
+    return error;
+  }
+  if (error && error.code === "ENOENT") {
+    return new StatusError("missing");
+  }
+  if (error && error.code === "EFBIG") {
+    return new StatusError("too_large");
+  }
+  if (error && (error.code === "ELOOP" || error.code === "ENOTDIR")) {
+    return new StatusError("unsafe");
+  }
+  return new StatusError("unsafe");
+}
+
+function validatePrivateRoot(fsImpl = fs) {
+  for (const parentPath of PRIVATE_PARENT_DIRS) {
+    try {
+      verifyTrustedParentDirectory(fsImpl.lstatSync(parentPath));
+    } catch (error) {
+      throw mapFileError(error);
+    }
+  }
+  try {
+    verifyTrustedStats(
+      fsImpl.lstatSync(PRIVATE_ROOT),
+      { type: "directory", mode: 0o700 },
+    );
+  } catch (error) {
+    throw mapFileError(error);
+  }
+}
+
+function validateKeyParents(fsImpl = fs) {
+  for (const parentPath of KEY_PARENT_DIRS) {
+    try {
+      verifyTrustedParentDirectory(fsImpl.lstatSync(parentPath));
+    } catch (error) {
+      throw mapFileError(error);
+    }
+  }
+}
+
+function readTrustedFileOnce(filePath, options, fsImpl) {
+  const constants = fsImpl.constants || fs.constants;
+  if (
+    !Number.isInteger(constants.O_RDONLY) ||
+    !Number.isInteger(constants.O_NOFOLLOW)
+  ) {
+    throw new StatusError("unsafe");
+  }
+
+  let pathStats;
+  try {
+    pathStats = fsImpl.lstatSync(filePath);
+    verifyTrustedStats(pathStats, {
+      type: "file",
+      mode: 0o600,
+      maxBytes: options.maxBytes,
+      exactBytes: options.exactBytes,
+    });
+  } catch (error) {
+    throw mapFileError(error);
+  }
+
+  const closeOnExec = Number.isInteger(constants.O_CLOEXEC)
+    ? constants.O_CLOEXEC
+    : 0;
+  const flags = constants.O_RDONLY | constants.O_NOFOLLOW | closeOnExec;
+  let descriptor;
+
+  try {
+    descriptor = fsImpl.openSync(filePath, flags);
+    const before = fsImpl.fstatSync(descriptor);
+    verifyTrustedStats(before, {
+      type: "file",
+      mode: 0o600,
+      maxBytes: options.maxBytes,
+      exactBytes: options.exactBytes,
+    });
+    if (!sameIdentity(pathStats, before)) {
+      throw new StatusError("changed_during_read");
+    }
+
+    const buffer = Buffer.alloc(before.size);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const read = fsImpl.readSync(
+        descriptor,
+        buffer,
+        offset,
+        buffer.length - offset,
+        offset,
+      );
+      if (!Number.isSafeInteger(read) || read <= 0) {
+        throw new StatusError("changed_during_read");
+      }
+      offset += read;
+    }
+
+    const after = fsImpl.fstatSync(descriptor);
+    verifyTrustedStats(after, {
+      type: "file",
+      mode: 0o600,
+      maxBytes: options.maxBytes,
+      exactBytes: options.exactBytes,
+    });
+    if (!sameSnapshot(before, after)) {
+      throw new StatusError("changed_during_read");
+    }
+
+    let finalPathStats;
+    try {
+      finalPathStats = fsImpl.lstatSync(filePath);
+      verifyTrustedStats(finalPathStats, {
+        type: "file",
+        mode: 0o600,
+        maxBytes: options.maxBytes,
+        exactBytes: options.exactBytes,
+      });
+    } catch (error) {
+      const mapped = mapFileError(error);
+      if (mapped.readState === "missing") {
+        throw new StatusError("changed_during_read");
+      }
+      throw mapped;
+    }
+    if (!sameSnapshot(after, finalPathStats)) {
+      throw new StatusError("changed_during_read");
+    }
+    return buffer;
+  } catch (error) {
+    throw mapFileError(error);
+  } finally {
+    if (descriptor !== undefined) {
+      try {
+        fsImpl.closeSync(descriptor);
+      } catch {
+        // A close failure cannot make untrusted data safe.
+      }
+    }
+  }
+}
+
+function readTrustedFile(filePath, options, fsImpl = fs) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return readTrustedFileOnce(filePath, options, fsImpl);
+    } catch (error) {
+      const mapped = mapFileError(error);
+      if (mapped.readState === "changed_during_read" && attempt === 0) {
+        continue;
+      }
+      throw mapped;
+    }
+  }
+  throw new StatusError("changed_during_read");
+}
+
+function unavailableSource(readState) {
+  return {
+    read_state: READ_STATES.has(readState) ? readState : "invalid",
+    updated_at: null,
+    summary: null,
+    fingerprint: null,
+  };
+}
+
+function availableSource(parsed) {
+  return {
+    read_state: "available",
+    updated_at: parsed.updated_at,
+    summary: parsed.summary,
+    fingerprint: parsed.fingerprint,
+  };
+}
+
+function documentForState(generatedAt, readState) {
+  const sources = {};
+  for (const sourceName of SOURCE_ORDER) {
+    sources[sourceName] = unavailableSource(readState);
+  }
+  return {
+    schema: OUTPUT_SCHEMA,
+    generated_at: generatedAt,
+    snapshot_state: "unavailable",
+    sources,
+  };
+}
+
+function snapshotState(sources) {
+  let available = 0;
+  for (const sourceName of SOURCE_ORDER) {
+    if (sources[sourceName].read_state === "available") {
+      available += 1;
+    }
+  }
+  if (available === SOURCE_ORDER.length) {
+    return "complete";
+  }
+  return available === 0 ? "unavailable" : "partial";
+}
+
+function collectStatus(options = {}) {
+  const fsImpl = options.fsImpl || fs;
+  const now = options.now instanceof Date ? options.now : new Date();
+  if (!Number.isFinite(now.getTime())) {
+    throw new StatusError("invalid");
+  }
+  const generatedAt = now.toISOString();
+
+  try {
+    validatePrivateRoot(fsImpl);
+  } catch (error) {
+    const mapped = mapFileError(error);
+    return documentForState(generatedAt, mapped.readState);
+  }
+
+  let key;
+  try {
+    validateKeyParents(fsImpl);
+    key = readTrustedFile(
+      HMAC_KEY_PATH,
+      { maxBytes: 32, exactBytes: 32 },
+      fsImpl,
+    );
+  } catch {
+    return documentForState(generatedAt, "unsafe");
+  }
+
+  const sources = {};
+  for (const sourceName of SOURCE_ORDER) {
+    try {
+      const config = SOURCE_CONFIG[sourceName];
+      const buffer = readTrustedFile(
+        config.path,
+        { maxBytes: config.maxBytes },
+        fsImpl,
+      );
+      sources[sourceName] = availableSource(
+        parseSource(sourceName, buffer, key, now.getTime()),
+      );
+    } catch (error) {
+      const mapped = error instanceof StatusError
+        ? error
+        : new StatusError("invalid");
+      sources[sourceName] = unavailableSource(mapped.readState);
+    }
+  }
+
+  return {
+    schema: OUTPUT_SCHEMA,
+    generated_at: generatedAt,
+    snapshot_state: snapshotState(sources),
+    sources,
+  };
+}
+
+function emit(document) {
+  process.stdout.write(`${JSON.stringify(document)}\n`);
+}
+
+function main() {
+  process.umask(0o077);
+  const now = new Date();
+
+  if (process.argv.length !== 2) {
+    emit(documentForState(now.toISOString(), "unsafe"));
+    process.exitCode = 64;
+    return;
+  }
+
+  try {
+    emit(collectStatus({ now }));
+  } catch {
+    emit(documentForState(now.toISOString(), "invalid"));
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  process.stdout.on("error", () => {
+    process.exitCode = 1;
+  });
+  main();
+}
+
+module.exports = Object.freeze({
+  HMAC_KEY_PATH,
+  OUTPUT_SCHEMA,
+  PRIVATE_ROOT,
+  READ_STATES,
+  SOURCE_CONFIG,
+  SOURCE_ORDER,
+  StatusError,
+  collectStatus,
+  decodeJson,
+  documentForState,
+  parseSource,
+  readTrustedFile,
+  sourceFingerprint,
+  validateKeyParents,
+  validatePrivateRoot,
+});

--- a/ops/seo-monitor/package.json
+++ b/ops/seo-monitor/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "digitalogic-seo-monitor-status-declassifier",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Read-only, fixed-path declassifier for Digitalogic SEO monitor operator status.",
+  "scripts": {
+    "check": "node --check bin/digitalogic-seo-monitor-status.cjs && node --check test/status.test.cjs",
+    "test": "node --test test/*.test.cjs"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/ops/seo-monitor/sudoers.d/digitalogic-seo-monitor-status
+++ b/ops/seo-monitor/sudoers.d/digitalogic-seo-monitor-status
@@ -1,0 +1,9 @@
+# REVIEW TEMPLATE ONLY. Do not install until the feature PR is merged and approved.
+# Replace __HELPER_SHA256__ with the sha256 digest of the exact installed helper.
+Cmnd_Alias DIGITALOGIC_SEO_MONITOR_STATUS = sha256:__HELPER_SHA256__ /usr/local/libexec/digitalogic-seo-monitor-status ""
+
+Defaults!DIGITALOGIC_SEO_MONITOR_STATUS env_reset
+Defaults!DIGITALOGIC_SEO_MONITOR_STATUS secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults!DIGITALOGIC_SEO_MONITOR_STATUS env_delete+="NODE_OPTIONS NODE_PATH"
+
+www-data ALL=(root:root) NOPASSWD:NOEXEC:NOSETENV: DIGITALOGIC_SEO_MONITOR_STATUS

--- a/ops/seo-monitor/test/fixtures/v1.1/google-docs-migration-ledger.json
+++ b/ops/seo-monitor/test/fixtures/v1.1/google-docs-migration-ledger.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.1",
+  "updated_at": "2026-07-26T09:44:00.000Z",
+  "entries": [
+    {
+      "fingerprint": "v11-ledger-applied",
+      "status": "applied_verified",
+      "document_id": "PRIVATE-V11-LEDGER-DOC"
+    },
+    {
+      "fingerprint": "v11-ledger-blocked",
+      "status": "blocked",
+      "content": "PRIVATE-V11-LEDGER-CONTENT"
+    }
+  ],
+  "routing": "PRIVATE-V11-LEDGER-ROUTE"
+}

--- a/ops/seo-monitor/test/fixtures/v1.1/google-docs-scan-state.json
+++ b/ops/seo-monitor/test/fixtures/v1.1/google-docs-scan-state.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1.1",
+  "updated_at": "2026-07-26T09:45:00.000Z",
+  "inventory_complete": true,
+  "google_docs_access_blocked": false,
+  "cursor": null,
+  "documents": [
+    {
+      "fingerprint": "v11-document-opaque-a",
+      "revision_fingerprint": "v11-revision-opaque-a",
+      "changed": false,
+      "tabs_seen": 3,
+      "error": false,
+      "source_url": "https://docs.google.com/private-v11",
+      "collaborators": ["PRIVATE-V11-GOOGLE-COLLABORATOR"]
+    }
+  ],
+  "credential": "PRIVATE-V11-GOOGLE-CREDENTIAL"
+}

--- a/ops/seo-monitor/test/fixtures/v1.1/latest-completed.json
+++ b/ops/seo-monitor/test/fixtures/v1.1/latest-completed.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.1",
+  "audit_id": "latest-audit-opaque-v11",
+  "completed_at": "2026-07-26T09:48:00.000Z",
+  "status": "completed",
+  "critical_findings": 2,
+  "significant_findings": 0,
+  "tracked_findings": 0,
+  "owner_decisions": 2,
+  "source_url": "https://private.example/v11-latest",
+  "content": "PRIVATE-V11-LATEST-CONTENT",
+  "collaborator": "PRIVATE-V11-LATEST-COLLABORATOR",
+  "routing": "PRIVATE-V11-LATEST-ROUTE",
+  "credential": "PRIVATE-V11-LATEST-CREDENTIAL"
+}

--- a/ops/seo-monitor/test/fixtures/v1.1/owner-approvals.json
+++ b/ops/seo-monitor/test/fixtures/v1.1/owner-approvals.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.1",
+  "updated_at": "2026-07-26T09:47:00.000Z",
+  "approvals": [
+    {
+      "fingerprint": "v11-approval-pending-a",
+      "status": "pending",
+      "owner": "PRIVATE-V11-OWNER-A"
+    },
+    {
+      "fingerprint": "v11-approval-pending-b",
+      "status": "pending",
+      "owner": "PRIVATE-V11-OWNER-B"
+    }
+  ],
+  "source_url": "https://private.example/v11-approvals"
+}

--- a/ops/seo-monitor/test/fixtures/v1.1/pending-decisions.json
+++ b/ops/seo-monitor/test/fixtures/v1.1/pending-decisions.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "1.1",
+  "updated_at": "2026-07-26T09:46:00.000Z",
+  "decisions": [
+    {
+      "fingerprint": "v11-decision-tracked-a",
+      "severity": "tracked",
+      "status": "pending",
+      "current": "PRIVATE-V11-CURRENT-TRACKED",
+      "recommended_reply": "PRIVATE-V11-REPLY-TRACKED",
+      "blocked_workflows": ["PRIVATE-V11-WORKFLOW-TRACKED"],
+      "content": "PRIVATE-V11-DECISION-CONTENT"
+    },
+    {
+      "fingerprint": "v11-decision-other-a",
+      "severity": "informational",
+      "status": "open",
+      "current": "PRIVATE-V11-CURRENT-OTHER",
+      "recommended_reply": "PRIVATE-V11-REPLY-OTHER",
+      "blocked_workflows": ["PRIVATE-V11-WORKFLOW-OTHER"],
+      "notification_route": "PRIVATE-V11-DECISION-ROUTE"
+    }
+  ],
+  "collaborator": "PRIVATE-V11-DECISION-COLLABORATOR"
+}

--- a/ops/seo-monitor/test/fixtures/v1/google-docs-migration-ledger.json
+++ b/ops/seo-monitor/test/fixtures/v1/google-docs-migration-ledger.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "1.0",
+  "updated_at": "2026-07-26T09:54:00.000Z",
+  "entries": [
+    {
+      "fingerprint": "ledger-opaque-discovered",
+      "status": "discovered",
+      "document_id": "PRIVATE-LEDGER-DOC-ID"
+    },
+    {
+      "fingerprint": "ledger-opaque-not-content",
+      "status": "not_product_content",
+      "content": "PRIVATE-NOT-PRODUCT-CONTENT"
+    },
+    {
+      "fingerprint": "ledger-opaque-needs-mapping",
+      "status": "needs_mapping",
+      "source_url": "https://private.example/mapping"
+    },
+    {
+      "fingerprint": "ledger-opaque-staged",
+      "status": "staged_conflict",
+      "collaborator": "PRIVATE-LEDGER-COLLABORATOR"
+    },
+    {
+      "fingerprint": "ledger-opaque-applied",
+      "status": "applied_verified",
+      "product": "PRIVATE-PRODUCT"
+    },
+    {
+      "fingerprint": "ledger-opaque-retryable",
+      "status": "failed_retryable",
+      "credential": "PRIVATE-LEDGER-CREDENTIAL"
+    },
+    {
+      "fingerprint": "ledger-opaque-blocked",
+      "status": "blocked",
+      "routing": "PRIVATE-LEDGER-ROUTE"
+    },
+    {
+      "fingerprint": "ledger-opaque-other",
+      "status": "archived",
+      "raw": "PRIVATE-LEDGER-RAW"
+    }
+  ]
+}

--- a/ops/seo-monitor/test/fixtures/v1/google-docs-scan-state.json
+++ b/ops/seo-monitor/test/fixtures/v1/google-docs-scan-state.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0",
+  "updated_at": "2026-07-26T09:55:00.000Z",
+  "inventory_complete": false,
+  "google_docs_access_blocked": true,
+  "cursor": "PRIVATE-GOOGLE-CURSOR",
+  "documents": [
+    {
+      "fingerprint": "document-opaque-a",
+      "revision_fingerprint": "revision-opaque-a",
+      "changed": true,
+      "tabs_seen": 2,
+      "error": false,
+      "document_id": "PRIVATE-GOOGLE-DOC-ID",
+      "source_url": "https://docs.google.com/private-a",
+      "collaborators": ["PRIVATE-GOOGLE-COLLABORATOR"]
+    },
+    {
+      "fingerprint": "document-opaque-b",
+      "revision_fingerprint": "revision-opaque-b",
+      "changed": false,
+      "tabs_seen": 1,
+      "error": true,
+      "content": "PRIVATE-GOOGLE-DOC-CONTENT"
+    }
+  ],
+  "credential": "PRIVATE-GOOGLE-CREDENTIAL"
+}

--- a/ops/seo-monitor/test/fixtures/v1/latest-completed.json
+++ b/ops/seo-monitor/test/fixtures/v1/latest-completed.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "1.0",
+  "audit_id": "latest-audit-opaque-v1",
+  "completed_at": "2026-07-26T09:58:00.000Z",
+  "status": "completed_with_findings",
+  "critical_findings": 1,
+  "significant_findings": 1,
+  "tracked_findings": 1,
+  "owner_decisions": 1,
+  "content": "PRIVATE-CONTENT-LATEST",
+  "source_url": "https://private.example/latest",
+  "collaborator": "PRIVATE-COLLABORATOR-LATEST",
+  "notification_route": "PRIVATE-ROUTE-LATEST",
+  "credential": "PRIVATE-CREDENTIAL-LATEST",
+  "raw_report": "PRIVATE-RAW-REPORT-LATEST"
+}

--- a/ops/seo-monitor/test/fixtures/v1/owner-approvals.json
+++ b/ops/seo-monitor/test/fixtures/v1/owner-approvals.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "updated_at": "2026-07-26T09:57:00.000Z",
+  "approvals": [
+    {
+      "fingerprint": "approval-opaque-pending",
+      "status": "pending",
+      "owner": "PRIVATE-OWNER-PENDING"
+    },
+    {
+      "fingerprint": "approval-opaque-approved",
+      "status": "approved",
+      "source_url": "https://private.example/approved"
+    },
+    {
+      "fingerprint": "approval-opaque-rejected",
+      "status": "rejected",
+      "content": "PRIVATE-REJECTION-CONTENT"
+    },
+    {
+      "fingerprint": "approval-opaque-expired",
+      "status": "expired",
+      "routing": "PRIVATE-APPROVAL-ROUTE"
+    }
+  ],
+  "credentials": "PRIVATE-APPROVAL-CREDENTIAL"
+}

--- a/ops/seo-monitor/test/fixtures/v1/pending-decisions.json
+++ b/ops/seo-monitor/test/fixtures/v1/pending-decisions.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "1.0",
+  "updated_at": "2026-07-26T09:56:00.000Z",
+  "decisions": [
+    {
+      "fingerprint": "decision-opaque-critical",
+      "severity": "critical",
+      "status": "pending",
+      "current": "PRIVATE-CURRENT-CRITICAL",
+      "recommended_reply": "PRIVATE-REPLY-CRITICAL",
+      "blocked_workflows": ["PRIVATE-WORKFLOW-CRITICAL"],
+      "title": "PRIVATE-DECISION-TITLE"
+    },
+    {
+      "fingerprint": "decision-opaque-significant",
+      "severity": "significant",
+      "status": "pending_owner_approval",
+      "current": "PRIVATE-CURRENT-SIGNIFICANT",
+      "recommended_reply": "PRIVATE-REPLY-SIGNIFICANT",
+      "blocked_workflows": ["PRIVATE-WORKFLOW-SIGNIFICANT"],
+      "source_url": "https://private.example/decision"
+    },
+    {
+      "fingerprint": "decision-opaque-tracked",
+      "severity": "tracked",
+      "status": "blocked",
+      "current": "PRIVATE-CURRENT-TRACKED",
+      "recommended_reply": "PRIVATE-REPLY-TRACKED",
+      "blocked_workflows": ["PRIVATE-WORKFLOW-TRACKED"],
+      "collaborator": "PRIVATE-DECISION-COLLABORATOR"
+    },
+    {
+      "fingerprint": "decision-opaque-other",
+      "severity": "advisory",
+      "status": "open",
+      "current": "PRIVATE-CURRENT-OTHER",
+      "recommended_reply": "PRIVATE-REPLY-OTHER",
+      "blocked_workflows": ["PRIVATE-WORKFLOW-OTHER"],
+      "notification_route": "PRIVATE-DECISION-ROUTE"
+    }
+  ],
+  "raw_content": "PRIVATE-DECISION-CONTENT"
+}

--- a/ops/seo-monitor/test/status.test.cjs
+++ b/ops/seo-monitor/test/status.test.cjs
@@ -1,0 +1,896 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const HELPER_PATH = path.join(
+  __dirname,
+  "..",
+  "bin",
+  "digitalogic-seo-monitor-status.cjs",
+);
+const {
+  HMAC_KEY_PATH,
+  OUTPUT_SCHEMA,
+  PRIVATE_ROOT,
+  SOURCE_CONFIG,
+  SOURCE_ORDER,
+  StatusError,
+  collectStatus,
+  decodeJson,
+  parseSource,
+  readTrustedFile,
+} = require(HELPER_PATH);
+
+const NOW = new Date("2026-07-26T10:00:00.000Z");
+const KEY_A = Buffer.alloc(32, 0x11);
+const KEY_B = Buffer.alloc(32, 0x22);
+const FIXTURE_ROOT = path.join(__dirname, "fixtures");
+const SOURCE_FIXTURE_NAMES = Object.freeze({
+  latest_completed: "latest-completed.json",
+  owner_approvals: "owner-approvals.json",
+  pending_decisions: "pending-decisions.json",
+  google_docs_scan_state: "google-docs-scan-state.json",
+  google_docs_migration_ledger: "google-docs-migration-ledger.json",
+});
+
+const SUMMARY_KEYS = Object.freeze({
+  latest_completed: [
+    "run_state",
+    "critical_findings",
+    "significant_findings",
+    "tracked_findings",
+    "owner_decisions",
+  ],
+  owner_approvals: [
+    "total",
+    "pending",
+    "approved",
+    "rejected",
+    "expired",
+  ],
+  pending_decisions: [
+    "total",
+    "critical",
+    "significant",
+    "tracked",
+    "other",
+  ],
+  google_docs_scan_state: [
+    "inventory_complete",
+    "access_blocked",
+    "cursor_pending",
+    "documents_seen",
+    "documents_changed",
+    "tabs_seen",
+    "errors",
+  ],
+  google_docs_migration_ledger: [
+    "total",
+    "discovered",
+    "not_product_content",
+    "needs_mapping",
+    "staged_conflict",
+    "applied_verified",
+    "failed_retryable",
+    "blocked",
+    "other",
+  ],
+});
+
+const EXPECTED_SUMMARIES = Object.freeze({
+  v1: Object.freeze({
+    latest_completed: {
+      run_state: "attention",
+      critical_findings: 1,
+      significant_findings: 1,
+      tracked_findings: 1,
+      owner_decisions: 1,
+    },
+    owner_approvals: {
+      total: 4,
+      pending: 1,
+      approved: 1,
+      rejected: 1,
+      expired: 1,
+    },
+    pending_decisions: {
+      total: 4,
+      critical: 1,
+      significant: 1,
+      tracked: 1,
+      other: 1,
+    },
+    google_docs_scan_state: {
+      inventory_complete: false,
+      access_blocked: true,
+      cursor_pending: true,
+      documents_seen: 2,
+      documents_changed: 1,
+      tabs_seen: 3,
+      errors: 1,
+    },
+    google_docs_migration_ledger: {
+      total: 8,
+      discovered: 1,
+      not_product_content: 1,
+      needs_mapping: 1,
+      staged_conflict: 1,
+      applied_verified: 1,
+      failed_retryable: 1,
+      blocked: 1,
+      other: 1,
+    },
+  }),
+  "v1.1": Object.freeze({
+    latest_completed: {
+      run_state: "completed",
+      critical_findings: 2,
+      significant_findings: 0,
+      tracked_findings: 0,
+      owner_decisions: 2,
+    },
+    owner_approvals: {
+      total: 2,
+      pending: 2,
+      approved: 0,
+      rejected: 0,
+      expired: 0,
+    },
+    pending_decisions: {
+      total: 2,
+      critical: 0,
+      significant: 0,
+      tracked: 1,
+      other: 1,
+    },
+    google_docs_scan_state: {
+      inventory_complete: true,
+      access_blocked: false,
+      cursor_pending: false,
+      documents_seen: 1,
+      documents_changed: 0,
+      tabs_seen: 3,
+      errors: 0,
+    },
+    google_docs_migration_ledger: {
+      total: 2,
+      discovered: 0,
+      not_product_content: 0,
+      needs_mapping: 0,
+      staged_conflict: 0,
+      applied_verified: 1,
+      failed_retryable: 0,
+      blocked: 1,
+      other: 0,
+    },
+  }),
+});
+
+function fixtureBuffer(version, sourceName) {
+  return fs.readFileSync(
+    path.join(FIXTURE_ROOT, version, SOURCE_FIXTURE_NAMES[sourceName]),
+  );
+}
+
+function fixtureObject(version, sourceName) {
+  return JSON.parse(fixtureBuffer(version, sourceName).toString("utf8"));
+}
+
+function assertStatusError(callback, expectedState) {
+  assert.throws(callback, (error) => {
+    assert.ok(error instanceof StatusError);
+    assert.equal(error.readState, expectedState);
+    return true;
+  });
+}
+
+function assertExactOutputContract(document) {
+  assert.deepEqual(
+    Object.keys(document),
+    ["schema", "generated_at", "snapshot_state", "sources"],
+  );
+  assert.equal(document.schema, OUTPUT_SCHEMA);
+  assert.match(
+    document.generated_at,
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+  );
+  assert.ok(["complete", "partial", "unavailable"].includes(document.snapshot_state));
+  assert.deepEqual(Object.keys(document.sources), SOURCE_ORDER);
+
+  for (const sourceName of SOURCE_ORDER) {
+    const source = document.sources[sourceName];
+    assert.deepEqual(
+      Object.keys(source),
+      ["read_state", "updated_at", "summary", "fingerprint"],
+    );
+    assert.ok([
+      "available",
+      "missing",
+      "invalid",
+      "unsupported_schema",
+      "unsafe",
+      "too_large",
+      "changed_during_read",
+    ].includes(source.read_state));
+
+    if (source.read_state === "available") {
+      assert.match(
+        source.updated_at,
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      assert.deepEqual(Object.keys(source.summary), SUMMARY_KEYS[sourceName]);
+      assert.match(source.fingerprint, /^hmac-sha256:[0-9a-f]{64}$/);
+    } else {
+      assert.equal(source.updated_at, null);
+      assert.equal(source.summary, null);
+      assert.equal(source.fingerprint, null);
+    }
+  }
+}
+
+function makeStats(entry, overrides = {}) {
+  const type = overrides.type || entry.type || "file";
+  return {
+    uid: overrides.uid ?? entry.uid ?? 0,
+    gid: overrides.gid ?? entry.gid ?? 0,
+    mode: overrides.mode ?? entry.mode ?? (type === "directory" ? 0o40700 : 0o100600),
+    nlink: overrides.nlink ?? entry.nlink ?? 1,
+    size: overrides.size ?? entry.size ?? (entry.buffer ? entry.buffer.length : 0),
+    dev: overrides.dev ?? entry.dev ?? 7,
+    ino: overrides.ino ?? entry.ino,
+    mtimeMs: overrides.mtimeMs ?? entry.mtimeMs ?? 1000,
+    ctimeMs: overrides.ctimeMs ?? entry.ctimeMs ?? 1000,
+    isDirectory: () => type === "directory",
+    isFile: () => type === "file",
+    isSymbolicLink: () => type === "symlink",
+  };
+}
+
+class FakeFs {
+  constructor(entries) {
+    this.constants = {
+      O_RDONLY: 0,
+      O_NOFOLLOW: 0x20000,
+      O_CLOEXEC: 0x80000,
+    };
+    this.entries = new Map();
+    this.descriptors = new Map();
+    this.nextDescriptor = 20;
+    let nextInode = 100;
+    for (const [filePath, rawEntry] of Object.entries(entries)) {
+      this.entries.set(filePath, {
+        type: "file",
+        ...rawEntry,
+        buffer: rawEntry.buffer ? Buffer.from(rawEntry.buffer) : Buffer.alloc(0),
+        ino: rawEntry.ino ?? nextInode,
+      });
+      nextInode += 1;
+    }
+  }
+
+  error(code) {
+    const error = new Error(code);
+    error.code = code;
+    return error;
+  }
+
+  lstatSync(filePath) {
+    const entry = this.entries.get(filePath);
+    if (!entry) {
+      throw this.error("ENOENT");
+    }
+    if (entry.activePathRace) {
+      entry.activePathRace = false;
+      return makeStats(entry, { ino: entry.ino + 100000 });
+    }
+    return makeStats(entry);
+  }
+
+  openSync(filePath, flags) {
+    const entry = this.entries.get(filePath);
+    if (!entry) {
+      throw this.error("ENOENT");
+    }
+    if (entry.type === "symlink") {
+      throw this.error("ELOOP");
+    }
+    if (entry.type !== "file") {
+      throw this.error("EISDIR");
+    }
+    assert.ok((flags & this.constants.O_NOFOLLOW) !== 0);
+    const descriptor = this.nextDescriptor;
+    this.nextDescriptor += 1;
+    const race = entry.alwaysRace || (entry.raceReadsRemaining || 0) > 0;
+    if (entry.raceReadsRemaining > 0) {
+      entry.raceReadsRemaining -= 1;
+    }
+    const pathRace = entry.alwaysPathRace ||
+      (entry.pathRaceReadsRemaining || 0) > 0;
+    if (entry.pathRaceReadsRemaining > 0) {
+      entry.pathRaceReadsRemaining -= 1;
+    }
+    entry.activePathRace = pathRace;
+    this.descriptors.set(descriptor, { entry, statCalls: 0, race });
+    return descriptor;
+  }
+
+  fstatSync(descriptor) {
+    const opened = this.descriptors.get(descriptor);
+    if (!opened) {
+      throw this.error("EBADF");
+    }
+    opened.statCalls += 1;
+    const mtimeMs = opened.race && opened.statCalls > 1
+      ? (opened.entry.mtimeMs ?? 1000) + 1
+      : opened.entry.mtimeMs;
+    return makeStats(opened.entry, {
+      ino: opened.entry.fdIno ?? opened.entry.ino,
+      mtimeMs,
+    });
+  }
+
+  readSync(descriptor, target, offset, length, position) {
+    const opened = this.descriptors.get(descriptor);
+    if (!opened) {
+      throw this.error("EBADF");
+    }
+    const available = Math.max(0, opened.entry.buffer.length - position);
+    const copied = Math.min(length, available);
+    opened.entry.buffer.copy(target, offset, position, position + copied);
+    return copied;
+  }
+
+  closeSync(descriptor) {
+    this.descriptors.delete(descriptor);
+  }
+}
+
+function trustedEntries(version = "v1") {
+  const entries = {
+    "/var": {
+      type: "directory",
+      buffer: Buffer.alloc(0),
+      mode: 0o40755,
+    },
+    "/var/lib": {
+      type: "directory",
+      buffer: Buffer.alloc(0),
+      mode: 0o40755,
+    },
+    "/var/lib/digitalogic": {
+      type: "directory",
+      buffer: Buffer.alloc(0),
+      mode: 0o40755,
+    },
+    [PRIVATE_ROOT]: {
+      type: "directory",
+      buffer: Buffer.alloc(0),
+      mode: 0o40700,
+    },
+    "/etc": {
+      type: "directory",
+      buffer: Buffer.alloc(0),
+      mode: 0o40755,
+    },
+    "/etc/digitalogic": {
+      type: "directory",
+      buffer: Buffer.alloc(0),
+      mode: 0o40755,
+    },
+    [HMAC_KEY_PATH]: {
+      buffer: KEY_A,
+      mode: 0o100600,
+    },
+  };
+  for (const sourceName of SOURCE_ORDER) {
+    entries[SOURCE_CONFIG[sourceName].path] = {
+      buffer: fixtureBuffer(version, sourceName),
+      mode: 0o100600,
+    };
+  }
+  return entries;
+}
+
+for (const version of ["v1", "v1.1"]) {
+  for (const sourceName of SOURCE_ORDER) {
+    test(`${sourceName} accepts the strict ${version} producer fixture`, () => {
+      const parsed = parseSource(
+        sourceName,
+        fixtureBuffer(version, sourceName),
+        KEY_A,
+        NOW.getTime(),
+      );
+      assert.equal(
+        parsed.updated_at,
+        sourceName === "latest_completed"
+          ? fixtureObject(version, sourceName).completed_at
+          : fixtureObject(version, sourceName).updated_at,
+      );
+      assert.deepEqual(parsed.summary, EXPECTED_SUMMARIES[version][sourceName]);
+      assert.match(parsed.fingerprint, /^hmac-sha256:[0-9a-f]{64}$/);
+    });
+  }
+}
+
+test("private fixture fields never appear in any declassified source", () => {
+  for (const version of ["v1", "v1.1"]) {
+    for (const sourceName of SOURCE_ORDER) {
+      const parsed = parseSource(
+        sourceName,
+        fixtureBuffer(version, sourceName),
+        KEY_A,
+        NOW.getTime(),
+      );
+      const output = JSON.stringify(parsed);
+      assert.doesNotMatch(output, /PRIVATE-|https:\/\/|docs\.google\.com/i);
+    }
+  }
+});
+
+test("fingerprints are stable across record order and timestamp-only rewrites", () => {
+  const original = fixtureObject("v1", "owner_approvals");
+  const reordered = structuredClone(original);
+  reordered.approvals.reverse();
+  reordered.updated_at = "2026-07-26T09:59:00.000Z";
+
+  const first = parseSource(
+    "owner_approvals",
+    Buffer.from(JSON.stringify(original)),
+    KEY_A,
+    NOW.getTime(),
+  );
+  const second = parseSource(
+    "owner_approvals",
+    Buffer.from(JSON.stringify(reordered)),
+    KEY_A,
+    NOW.getTime(),
+  );
+
+  assert.equal(first.fingerprint, second.fingerprint);
+  assert.notEqual(first.updated_at, second.updated_at);
+});
+
+test("fingerprints change when a meaningful record or HMAC key changes", () => {
+  const original = fixtureObject("v1", "pending_decisions");
+  const changed = structuredClone(original);
+  changed.decisions[0].fingerprint = "different-opaque-record";
+
+  const baseline = parseSource(
+    "pending_decisions",
+    Buffer.from(JSON.stringify(original)),
+    KEY_A,
+    NOW.getTime(),
+  ).fingerprint;
+  const recordChanged = parseSource(
+    "pending_decisions",
+    Buffer.from(JSON.stringify(changed)),
+    KEY_A,
+    NOW.getTime(),
+  ).fingerprint;
+  const keyChanged = parseSource(
+    "pending_decisions",
+    Buffer.from(JSON.stringify(original)),
+    KEY_B,
+    NOW.getTime(),
+  ).fingerprint;
+
+  assert.notEqual(baseline, recordChanged);
+  assert.notEqual(baseline, keyChanged);
+});
+
+test("latest fingerprint tracks audit identity but ignores raw-only changes", () => {
+  const original = fixtureObject("v1.1", "latest_completed");
+  const rawChanged = structuredClone(original);
+  rawChanged.raw_private_payload = "PRIVATE-RAW-ONLY-CHANGE";
+  const auditChanged = structuredClone(original);
+  auditChanged.audit_id = "different-latest-audit";
+
+  const baseline = parseSource(
+    "latest_completed",
+    Buffer.from(JSON.stringify(original)),
+    KEY_A,
+    NOW.getTime(),
+  ).fingerprint;
+  const rawOnly = parseSource(
+    "latest_completed",
+    Buffer.from(JSON.stringify(rawChanged)),
+    KEY_A,
+    NOW.getTime(),
+  ).fingerprint;
+  const differentAudit = parseSource(
+    "latest_completed",
+    Buffer.from(JSON.stringify(auditChanged)),
+    KEY_A,
+    NOW.getTime(),
+  ).fingerprint;
+
+  assert.equal(baseline, rawOnly);
+  assert.notEqual(baseline, differentAudit);
+});
+
+test("latest producer statuses map only to controlled output run states", () => {
+  const expected = {
+    completed: "completed",
+    completed_with_findings: "attention",
+    attention: "attention",
+    blocked: "blocked",
+    failed: "failed",
+    unknown: "unknown",
+  };
+  for (const [producerStatus, outputStatus] of Object.entries(expected)) {
+    const source = fixtureObject("v1.1", "latest_completed");
+    source.status = producerStatus;
+    const parsed = parseSource(
+      "latest_completed",
+      Buffer.from(JSON.stringify(source)),
+      KEY_A,
+      NOW.getTime(),
+    );
+    assert.equal(parsed.summary.run_state, outputStatus);
+  }
+
+  const invalid = fixtureObject("v1.1", "latest_completed");
+  invalid.status = "PRIVATE-UNCONTROLLED-STATUS";
+  assertStatusError(
+    () => parseSource(
+      "latest_completed",
+      Buffer.from(JSON.stringify(invalid)),
+      KEY_A,
+      NOW.getTime(),
+    ),
+    "invalid",
+  );
+});
+
+test("unknown producer versions fail as unsupported_schema", () => {
+  const source = fixtureObject("v1", "latest_completed");
+  source.schema_version = "2.0";
+  assertStatusError(
+    () => parseSource(
+      "latest_completed",
+      Buffer.from(JSON.stringify(source)),
+      KEY_A,
+      NOW.getTime(),
+    ),
+    "unsupported_schema",
+  );
+});
+
+test("malformed JSON and malformed UTF-8 fail as invalid", () => {
+  assertStatusError(() => decodeJson(Buffer.from("{")), "invalid");
+  assertStatusError(() => decodeJson(Buffer.from([0xc3, 0x28])), "invalid");
+});
+
+test("invalid producer enum, timestamp, and aggregate overflow fail closed", () => {
+  const approval = fixtureObject("v1", "owner_approvals");
+  approval.approvals[0].status = "raw-private-status";
+  assertStatusError(
+    () => parseSource(
+      "owner_approvals",
+      Buffer.from(JSON.stringify(approval)),
+      KEY_A,
+      NOW.getTime(),
+    ),
+    "invalid",
+  );
+
+  const latest = fixtureObject("v1", "latest_completed");
+  latest.completed_at = "2030-01-01T00:00:00.000Z";
+  assertStatusError(
+    () => parseSource(
+      "latest_completed",
+      Buffer.from(JSON.stringify(latest)),
+      KEY_A,
+      NOW.getTime(),
+    ),
+    "invalid",
+  );
+
+  const scan = fixtureObject("v1", "google_docs_scan_state");
+  scan.documents = [
+    {
+      fingerprint: "overflow-a",
+      revision_fingerprint: "revision-a",
+      changed: false,
+      tabs_seen: Number.MAX_SAFE_INTEGER,
+      error: false,
+    },
+    {
+      fingerprint: "overflow-b",
+      revision_fingerprint: "revision-b",
+      changed: false,
+      tabs_seen: 1,
+      error: false,
+    },
+  ];
+  assertStatusError(
+    () => parseSource(
+      "google_docs_scan_state",
+      Buffer.from(JSON.stringify(scan)),
+      KEY_A,
+      NOW.getTime(),
+    ),
+    "invalid",
+  );
+});
+
+test("trusted file reading requires no-follow, exact ownership, mode, type, and link count", () => {
+  const target = "/private/state.json";
+  const cases = [
+    [{ type: "symlink", buffer: Buffer.from("{}") }, "unsafe"],
+    [{ type: "directory", buffer: Buffer.alloc(0) }, "unsafe"],
+    [{ buffer: Buffer.from("{}"), uid: 33 }, "unsafe"],
+    [{ buffer: Buffer.from("{}"), gid: 33 }, "unsafe"],
+    [{ buffer: Buffer.from("{}"), mode: 0o100640 }, "unsafe"],
+    [{ buffer: Buffer.from("{}"), mode: 0o104600 }, "unsafe"],
+    [{ buffer: Buffer.from("{}"), nlink: 2 }, "unsafe"],
+    [{ buffer: Buffer.alloc(10), size: 10 }, "too_large"],
+  ];
+
+  for (const [entry, state] of cases) {
+    const fakeFs = new FakeFs({ [target]: entry });
+    assertStatusError(
+      () => readTrustedFile(target, { maxBytes: 5 }, fakeFs),
+      state,
+    );
+  }
+});
+
+test("trusted file reading retries one race and rejects a repeated race", () => {
+  const target = "/private/state.json";
+  const expected = Buffer.from('{"ok":true}');
+  const once = new FakeFs({
+    [target]: {
+      buffer: expected,
+      raceReadsRemaining: 1,
+    },
+  });
+  assert.deepEqual(
+    readTrustedFile(target, { maxBytes: 100 }, once),
+    expected,
+  );
+
+  const repeated = new FakeFs({
+    [target]: {
+      buffer: expected,
+      alwaysRace: true,
+    },
+  });
+  assertStatusError(
+    () => readTrustedFile(target, { maxBytes: 100 }, repeated),
+    "changed_during_read",
+  );
+});
+
+test("trusted file reading rechecks the path after read and detects atomic replacement", () => {
+  const target = "/private/state.json";
+  const expected = Buffer.from('{"ok":true}');
+  const once = new FakeFs({
+    [target]: {
+      buffer: expected,
+      pathRaceReadsRemaining: 1,
+    },
+  });
+  assert.deepEqual(
+    readTrustedFile(target, { maxBytes: 100 }, once),
+    expected,
+  );
+
+  const repeated = new FakeFs({
+    [target]: {
+      buffer: expected,
+      alwaysPathRace: true,
+    },
+  });
+  assertStatusError(
+    () => readTrustedFile(target, { maxBytes: 100 }, repeated),
+    "changed_during_read",
+  );
+});
+
+test("exact-length HMAC key validation rejects short and oversized files", () => {
+  const short = new FakeFs({
+    [HMAC_KEY_PATH]: { buffer: Buffer.alloc(31) },
+  });
+  assertStatusError(
+    () => readTrustedFile(
+      HMAC_KEY_PATH,
+      { maxBytes: 32, exactBytes: 32 },
+      short,
+    ),
+    "unsafe",
+  );
+
+  const long = new FakeFs({
+    [HMAC_KEY_PATH]: { buffer: Buffer.alloc(33) },
+  });
+  assertStatusError(
+    () => readTrustedFile(
+      HMAC_KEY_PATH,
+      { maxBytes: 32, exactBytes: 32 },
+      long,
+    ),
+    "too_large",
+  );
+});
+
+test("complete, partial, and unavailable snapshots use the exact contract", () => {
+  const completeFs = new FakeFs(trustedEntries("v1"));
+  const complete = collectStatus({ fsImpl: completeFs, now: NOW });
+  assertExactOutputContract(complete);
+  assert.equal(complete.snapshot_state, "complete");
+  for (const sourceName of SOURCE_ORDER) {
+    assert.equal(complete.sources[sourceName].read_state, "available");
+  }
+  assert.ok(JSON.stringify(complete).length < 8192);
+
+  const partialEntries = trustedEntries("v1");
+  delete partialEntries[SOURCE_CONFIG.pending_decisions.path];
+  partialEntries[SOURCE_CONFIG.owner_approvals.path] = {
+    buffer: Buffer.from(JSON.stringify({
+      ...fixtureObject("v1", "owner_approvals"),
+      schema_version: "2.0",
+    })),
+  };
+  const partial = collectStatus({
+    fsImpl: new FakeFs(partialEntries),
+    now: NOW,
+  });
+  assertExactOutputContract(partial);
+  assert.equal(partial.snapshot_state, "partial");
+  assert.equal(partial.sources.pending_decisions.read_state, "missing");
+  assert.equal(
+    partial.sources.owner_approvals.read_state,
+    "unsupported_schema",
+  );
+  assert.equal(partial.sources.pending_decisions.summary, null);
+
+  const unavailableEntries = trustedEntries("v1");
+  for (const sourceName of SOURCE_ORDER) {
+    delete unavailableEntries[SOURCE_CONFIG[sourceName].path];
+  }
+  const unavailable = collectStatus({
+    fsImpl: new FakeFs(unavailableEntries),
+    now: NOW,
+  });
+  assertExactOutputContract(unavailable);
+  assert.equal(unavailable.snapshot_state, "unavailable");
+  for (const sourceName of SOURCE_ORDER) {
+    assert.equal(unavailable.sources[sourceName].read_state, "missing");
+  }
+});
+
+test("unsafe private root or HMAC key makes every source safely unavailable", () => {
+  const unsafeRootEntries = trustedEntries("v1");
+  unsafeRootEntries[PRIVATE_ROOT].mode = 0o40750;
+  const unsafeRoot = collectStatus({
+    fsImpl: new FakeFs(unsafeRootEntries),
+    now: NOW,
+  });
+  assertExactOutputContract(unsafeRoot);
+  assert.equal(unsafeRoot.snapshot_state, "unavailable");
+  for (const sourceName of SOURCE_ORDER) {
+    assert.equal(unsafeRoot.sources[sourceName].read_state, "unsafe");
+  }
+
+  const missingKeyEntries = trustedEntries("v1");
+  delete missingKeyEntries[HMAC_KEY_PATH];
+  const missingKey = collectStatus({
+    fsImpl: new FakeFs(missingKeyEntries),
+    now: NOW,
+  });
+  assertExactOutputContract(missingKey);
+  for (const sourceName of SOURCE_ORDER) {
+    assert.equal(missingKey.sources[sourceName].read_state, "unsafe");
+  }
+});
+
+test("writable or symlinked fixed parent directories fail closed", () => {
+  const writableParentEntries = trustedEntries("v1");
+  writableParentEntries["/var/lib/digitalogic"].mode = 0o40775;
+  const writableParent = collectStatus({
+    fsImpl: new FakeFs(writableParentEntries),
+    now: NOW,
+  });
+  assertExactOutputContract(writableParent);
+  for (const sourceName of SOURCE_ORDER) {
+    assert.equal(writableParent.sources[sourceName].read_state, "unsafe");
+  }
+
+  const symlinkedKeyParentEntries = trustedEntries("v1");
+  symlinkedKeyParentEntries["/etc/digitalogic"].type = "symlink";
+  const symlinkedKeyParent = collectStatus({
+    fsImpl: new FakeFs(symlinkedKeyParentEntries),
+    now: NOW,
+  });
+  assertExactOutputContract(symlinkedKeyParent);
+  for (const sourceName of SOURCE_ORDER) {
+    assert.equal(symlinkedKeyParent.sources[sourceName].read_state, "unsafe");
+  }
+});
+
+test("a repeatedly changing source is isolated as changed_during_read", () => {
+  const entries = trustedEntries("v1");
+  entries[SOURCE_CONFIG.google_docs_migration_ledger.path].alwaysRace = true;
+  const document = collectStatus({
+    fsImpl: new FakeFs(entries),
+    now: NOW,
+  });
+  assertExactOutputContract(document);
+  assert.equal(document.snapshot_state, "partial");
+  assert.equal(
+    document.sources.google_docs_migration_ledger.read_state,
+    "changed_during_read",
+  );
+  assert.equal(document.sources.google_docs_migration_ledger.summary, null);
+});
+
+test("unexpected executable arguments return only a fixed safe contract", () => {
+  const child = spawnSync(
+    process.execPath,
+    [HELPER_PATH, "PRIVATE-UNEXPECTED-ARGUMENT"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PRIVATE_ROUTING_SECRET: "PRIVATE-ENVIRONMENT-SECRET",
+      },
+    },
+  );
+  assert.equal(child.status, 64);
+  assert.equal(child.stderr, "");
+  assert.equal(child.stdout.trim().split(/\r?\n/).length, 1);
+  const document = JSON.parse(child.stdout);
+  assertExactOutputContract(document);
+  assert.equal(document.snapshot_state, "unavailable");
+  assert.doesNotMatch(
+    child.stdout,
+    /PRIVATE-UNEXPECTED|PRIVATE-ENVIRONMENT|ROUTING/i,
+  );
+});
+
+test("helper source has no environment, stdin, child-process, network, or write surface", () => {
+  const source = fs.readFileSync(HELPER_PATH, "utf8");
+  assert.doesNotMatch(source, /process\.env|process\.stdin/);
+  assert.doesNotMatch(
+    source,
+    /node:(?:child_process|http|https|net|tls|dgram)|\b(?:writeFile|appendFile|createWriteStream|exec|spawn)\w*\s*\(/,
+  );
+  const imports = [...source.matchAll(/require\("([^"]+)"\)/g)].map(
+    match => match[1],
+  );
+  assert.deepEqual(imports, ["node:fs", "node:crypto", "node:util"]);
+});
+
+test("sudoers review template pins the direct executable and no-argument form", () => {
+  const sudoers = fs.readFileSync(
+    path.join(
+      __dirname,
+      "..",
+      "sudoers.d",
+      "digitalogic-seo-monitor-status",
+    ),
+    "utf8",
+  );
+  assert.match(
+    sudoers,
+    /sha256:__HELPER_SHA256__ \/usr\/local\/libexec\/digitalogic-seo-monitor-status ""/,
+  );
+  assert.match(sudoers, /NOPASSWD:NOEXEC:NOSETENV/);
+  assert.match(sudoers, /env_delete\+="NODE_OPTIONS NODE_PATH"/);
+  assert.doesNotMatch(sudoers, /\/usr\/bin\/node\s+\*/);
+  assert.match(sudoers, /Do not install until the feature PR is merged and approved/);
+});
+
+test("README keeps pending owner approval and unchanged permission boundaries visible", () => {
+  const readme = fs.readFileSync(path.join(__dirname, "..", "README.md"), "utf8");
+  assert.match(readme, /pending owner approval/i);
+  assert.match(readme, /Do not install or deploy/i);
+  assert.match(readme, /directory mode `0700`/);
+  assert.match(readme, /file mode `0600`/);
+  assert.match(readme, /every local process running as `www-data`/);
+});

--- a/tests/WpCliSeoMonitorStatusTest.php
+++ b/tests/WpCliSeoMonitorStatusTest.php
@@ -1,0 +1,449 @@
+<?php
+/**
+ * Sanitized SEO monitor WP-CLI transport tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verify capability, process, and schema boundaries.
+ */
+final class WpCliSeoMonitorStatusTest extends TestCase {
+
+	private const GENERIC_ERROR   = 'SEO monitor status is unavailable.';
+	private const SECRET_SENTINEL = 'https://private.example/?token=do-not-print';
+
+	/**
+	 * Reset command output and capability fixtures.
+	 */
+	protected function setUp(): void {
+		$GLOBALS['digitalogic_test_capabilities'] = array();
+		WP_CLI::$errors                           = array();
+		WP_CLI::$logs                             = array();
+		WP_CLI::$warnings                         = array();
+	}
+
+	/**
+	 * The exact command is registered.
+	 */
+	public function test_exact_command_is_registered(): void {
+		$this->assertArrayHasKey( 'digitalogic seo-monitor status', WP_CLI::$commands );
+	}
+
+	/**
+	 * Capability denial happens before argument handling or bridge execution.
+	 */
+	public function test_capability_is_required_before_argument_validation(): void {
+		$runner_calls = 0;
+		$command      = new Digitalogic_SEO_Monitor_Status_CLI(
+			static function () use ( &$runner_calls ) {
+				++$runner_calls;
+				return self::successful_result( self::valid_payload() );
+			}
+		);
+
+		$command->status( array( 'unexpected' ), array( 'format' => 'json' ) );
+
+		$this->assertSame( 0, $runner_calls );
+		$this->assertSame( array( 'Run this command with --user=<administrator>.' ), WP_CLI::$errors );
+		$this->assertSame( array(), WP_CLI::$logs );
+	}
+
+	/**
+	 * No command-specific positional or named arguments are accepted.
+	 */
+	public function test_authorized_command_rejects_all_command_specific_arguments(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+		$runner_calls = 0;
+		$command      = new Digitalogic_SEO_Monitor_Status_CLI(
+			static function () use ( &$runner_calls ) {
+				++$runner_calls;
+				return self::successful_result( self::valid_payload() );
+			}
+		);
+
+		$command->status( array( 'unexpected' ), array() );
+		$command->status( array(), array( 'format' => 'json' ) );
+
+		$this->assertSame( 0, $runner_calls );
+		$this->assertSame(
+			array(
+				'This command does not accept command-specific arguments.',
+				'This command does not accept command-specific arguments.',
+			),
+			WP_CLI::$errors
+		);
+		$this->assertSame( array(), WP_CLI::$logs );
+	}
+
+	/**
+	 * The authorized command supplies only the reviewed process contract.
+	 */
+	public function test_authorized_command_uses_exact_bridge_contract(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+		$captured = array();
+		$payload  = self::valid_payload();
+		$command  = new Digitalogic_SEO_Monitor_Status_CLI(
+			static function ( $argv, $environment, $timeout, $max_bytes ) use ( &$captured, $payload ) {
+				$captured = array(
+					'argv'        => $argv,
+					'environment' => $environment,
+					'timeout'     => $timeout,
+					'max_bytes'   => $max_bytes,
+				);
+				return self::successful_result( $payload );
+			}
+		);
+
+		$command->status( array(), array() );
+
+		$this->assertSame(
+			array(
+				'/usr/bin/sudo',
+				'-n',
+				'--',
+				'/usr/local/libexec/digitalogic-seo-monitor-status',
+			),
+			$captured['argv']
+		);
+		$this->assertSame(
+			array(
+				'PATH'   => '/usr/sbin:/usr/bin:/sbin:/bin',
+				'LANG'   => 'C',
+				'LC_ALL' => 'C',
+			),
+			$captured['environment']
+		);
+		$this->assertSame( 5.0, $captured['timeout'] );
+		$this->assertSame( 32768, $captured['max_bytes'] );
+		$this->assertSame( array(), WP_CLI::$errors );
+		$this->assertCount( 1, WP_CLI::$logs );
+		$this->assertSame( $payload, json_decode( WP_CLI::$logs[0], true ) );
+	}
+
+	/**
+	 * Nonavailable source envelopes are accepted only with null summaries and fingerprints.
+	 */
+	public function test_partial_snapshot_contract_is_reconstructed(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+		$payload                               = self::valid_payload();
+		$payload['snapshot_state']             = 'partial';
+		$payload['sources']['owner_approvals'] = array(
+			'read_state'  => 'unsafe',
+			'updated_at'  => null,
+			'summary'     => null,
+			'fingerprint' => null,
+		);
+		$command                               = new Digitalogic_SEO_Monitor_Status_CLI(
+			static function () use ( $payload ) {
+				return self::successful_result( $payload );
+			}
+		);
+
+		$command->status( array(), array() );
+
+		$this->assertSame( array(), WP_CLI::$errors );
+		$this->assertSame( $payload, json_decode( WP_CLI::$logs[0], true ) );
+	}
+
+	/**
+	 * Transport failures never echo raw process output.
+	 */
+	public function test_transport_failures_are_generic_and_secret_safe(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+		$valid_json = wp_json_encode( self::valid_payload(), JSON_UNESCAPED_SLASHES ) . "\n";
+		$cases      = array(
+			'nonzero'   => array(
+				'exit_code' => 1,
+				'stdout'    => self::SECRET_SENTINEL,
+				'stderr'    => '',
+				'timed_out' => false,
+				'overflow'  => false,
+			),
+			'stderr'    => array(
+				'exit_code' => 0,
+				'stdout'    => $valid_json,
+				'stderr'    => self::SECRET_SENTINEL,
+				'timed_out' => false,
+				'overflow'  => false,
+			),
+			'timed_out' => array(
+				'exit_code' => null,
+				'stdout'    => self::SECRET_SENTINEL,
+				'stderr'    => '',
+				'timed_out' => true,
+				'overflow'  => false,
+			),
+			'overflow'  => array(
+				'exit_code' => null,
+				'stdout'    => str_repeat( 'x', 32768 ),
+				'stderr'    => '',
+				'timed_out' => false,
+				'overflow'  => true,
+			),
+			'oversize'  => array(
+				'exit_code' => 0,
+				'stdout'    => str_repeat( 'x', 32769 ),
+				'stderr'    => '',
+				'timed_out' => false,
+				'overflow'  => false,
+			),
+		);
+
+		foreach ( $cases as $name => $result ) {
+			WP_CLI::$errors = array();
+			WP_CLI::$logs   = array();
+			$command        = new Digitalogic_SEO_Monitor_Status_CLI(
+				static function () use ( $result ) {
+					return $result;
+				}
+			);
+
+			$command->status( array(), array() );
+
+			$this->assertSame( array( self::GENERIC_ERROR ), WP_CLI::$errors, $name );
+			$this->assertSame( array(), WP_CLI::$logs, $name );
+			$this->assertStringNotContainsString(
+				self::SECRET_SENTINEL,
+				implode( "\n", array_merge( WP_CLI::$errors, WP_CLI::$logs ) ),
+				$name
+			);
+		}
+	}
+
+	/**
+	 * Malformed documents and unknown fields fail closed without raw echo.
+	 */
+	public function test_malformed_and_unknown_key_payloads_fail_closed(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+		$with_unknown               = self::valid_payload();
+		$with_unknown['source_url'] = self::SECRET_SENTINEL;
+		$nested_unknown             = self::valid_payload();
+		$nested_unknown['sources']['owner_approvals']['summary']['collaborator'] = self::SECRET_SENTINEL;
+		$cases = array(
+			'malformed'      => '{"schema":',
+			'multiple_lines' => wp_json_encode( self::valid_payload() ) . "\n" . self::SECRET_SENTINEL,
+			'unknown_top'    => wp_json_encode( $with_unknown, JSON_UNESCAPED_SLASHES ),
+			'unknown_nested' => wp_json_encode( $nested_unknown, JSON_UNESCAPED_SLASHES ),
+		);
+
+		foreach ( $cases as $name => $stdout ) {
+			WP_CLI::$errors = array();
+			WP_CLI::$logs   = array();
+			$command        = new Digitalogic_SEO_Monitor_Status_CLI(
+				static function () use ( $stdout ) {
+					return array(
+						'exit_code' => 0,
+						'stdout'    => $stdout . "\n",
+						'stderr'    => '',
+						'timed_out' => false,
+						'overflow'  => false,
+					);
+				}
+			);
+
+			$command->status( array(), array() );
+
+			$this->assertSame( array( self::GENERIC_ERROR ), WP_CLI::$errors, $name );
+			$this->assertSame( array(), WP_CLI::$logs, $name );
+			$this->assertStringNotContainsString(
+				self::SECRET_SENTINEL,
+				implode( "\n", array_merge( WP_CLI::$errors, WP_CLI::$logs ) ),
+				$name
+			);
+		}
+	}
+
+	/**
+	 * Every controlled enum, type, and exact-shape constraint is enforced.
+	 */
+	public function test_schema_drift_is_rejected(): void {
+		$GLOBALS['digitalogic_test_capabilities']['manage_options'] = true;
+		$mutations = array(
+			'wrong_schema'                => static function ( &$payload ) {
+				$payload['schema'] = 'digitalogic.seo-monitor.status/v2';
+			},
+			'invalid_timestamp'           => static function ( &$payload ) {
+				$payload['generated_at'] = '2026-02-31T25:61:61.999Z';
+			},
+			'snapshot_mismatch'           => static function ( &$payload ) {
+				$payload['snapshot_state'] = 'partial';
+			},
+			'missing_source'              => static function ( &$payload ) {
+				unset( $payload['sources']['pending_decisions'] );
+			},
+			'extra_envelope_key'          => static function ( &$payload ) {
+				$payload['sources']['owner_approvals']['path'] = '/private';
+			},
+			'invalid_read_state'          => static function ( &$payload ) {
+				$payload['sources']['owner_approvals']['read_state'] = 'readable';
+			},
+			'bad_fingerprint'             => static function ( &$payload ) {
+				$payload['sources']['owner_approvals']['fingerprint'] = 'sha256:' . str_repeat( 'a', 64 );
+			},
+			'negative_count'              => static function ( &$payload ) {
+				$payload['sources']['owner_approvals']['summary']['pending'] = -1;
+			},
+			'float_count'                 => static function ( &$payload ) {
+				$payload['sources']['pending_decisions']['summary']['total'] = 1.5;
+			},
+			'unsafe_integer'              => static function ( &$payload ) {
+				$payload['sources']['pending_decisions']['summary']['total'] = 9007199254740992;
+			},
+			'invalid_boolean'             => static function ( &$payload ) {
+				$payload['sources']['google_docs_scan_state']['summary']['inventory_complete'] = 1;
+			},
+			'invalid_run_state'           => static function ( &$payload ) {
+				$payload['sources']['latest_completed']['summary']['run_state'] = 'running';
+			},
+			'available_missing_timestamp' => static function ( &$payload ) {
+				$payload['sources']['owner_approvals']['updated_at'] = null;
+			},
+			'owner_total_mismatch'        => static function ( &$payload ) {
+				$payload['sources']['owner_approvals']['summary']['total'] = 6;
+			},
+			'pending_total_mismatch'      => static function ( &$payload ) {
+				$payload['sources']['pending_decisions']['summary']['total'] = 5;
+			},
+			'ledger_total_mismatch'       => static function ( &$payload ) {
+				$payload['sources']['google_docs_migration_ledger']['summary']['total'] = 10;
+			},
+			'changed_exceeds_seen'        => static function ( &$payload ) {
+				$payload['sources']['google_docs_scan_state']['summary']['documents_changed'] = 11;
+			},
+			'errors_exceed_seen'          => static function ( &$payload ) {
+				$payload['sources']['google_docs_scan_state']['summary']['errors'] = 11;
+			},
+			'nonavailable_has_data'       => static function ( &$payload ) {
+				$payload['snapshot_state'] = 'partial';
+				$payload['sources']['owner_approvals']['read_state'] = 'missing';
+				$payload['sources']['owner_approvals']['fingerprint'] = null;
+			},
+			'nonavailable_has_updated_at' => static function ( &$payload ) {
+				$payload['snapshot_state'] = 'partial';
+				$payload['sources']['owner_approvals']['read_state'] = 'missing';
+				$payload['sources']['owner_approvals']['summary'] = null;
+				$payload['sources']['owner_approvals']['fingerprint'] = null;
+			},
+		);
+
+		foreach ( $mutations as $name => $mutate ) {
+			$payload = self::valid_payload();
+			$mutate( $payload );
+			WP_CLI::$errors = array();
+			WP_CLI::$logs   = array();
+			$command        = new Digitalogic_SEO_Monitor_Status_CLI(
+				static function () use ( $payload ) {
+					return self::successful_result( $payload );
+				}
+			);
+
+			$command->status( array(), array() );
+
+			$this->assertSame( array( self::GENERIC_ERROR ), WP_CLI::$errors, $name );
+			$this->assertSame( array(), WP_CLI::$logs, $name );
+		}
+	}
+
+	/**
+	 * Build one successful process result.
+	 *
+	 * @param array $payload Sanitized payload.
+	 * @return array
+	 */
+	private static function successful_result( $payload ) {
+		return array(
+			'exit_code' => 0,
+			'stdout'    => wp_json_encode( $payload, JSON_UNESCAPED_SLASHES ) . "\n",
+			'stderr'    => '',
+			'timed_out' => false,
+			'overflow'  => false,
+		);
+	}
+
+	/**
+	 * Build one complete valid v1 payload.
+	 *
+	 * @return array
+	 */
+	private static function valid_payload() {
+		$fingerprint = 'hmac-sha256:' . str_repeat( 'a', 64 );
+		$updated_at  = '2026-07-26T06:30:00.000Z';
+
+		return array(
+			'schema'         => 'digitalogic.seo-monitor.status/v1',
+			'generated_at'   => '2026-07-26T06:31:00.123Z',
+			'snapshot_state' => 'complete',
+			'sources'        => array(
+				'latest_completed'             => array(
+					'read_state'  => 'available',
+					'updated_at'  => $updated_at,
+					'summary'     => array(
+						'run_state'            => 'attention',
+						'critical_findings'    => 1,
+						'significant_findings' => 2,
+						'tracked_findings'     => 3,
+						'owner_decisions'      => 4,
+					),
+					'fingerprint' => $fingerprint,
+				),
+				'owner_approvals'              => array(
+					'read_state'  => 'available',
+					'updated_at'  => $updated_at,
+					'summary'     => array(
+						'total'    => 5,
+						'pending'  => 2,
+						'approved' => 2,
+						'rejected' => 1,
+						'expired'  => 0,
+					),
+					'fingerprint' => $fingerprint,
+				),
+				'pending_decisions'            => array(
+					'read_state'  => 'available',
+					'updated_at'  => $updated_at,
+					'summary'     => array(
+						'total'       => 4,
+						'critical'    => 1,
+						'significant' => 1,
+						'tracked'     => 1,
+						'other'       => 1,
+					),
+					'fingerprint' => $fingerprint,
+				),
+				'google_docs_scan_state'       => array(
+					'read_state'  => 'available',
+					'updated_at'  => $updated_at,
+					'summary'     => array(
+						'inventory_complete' => false,
+						'access_blocked'     => true,
+						'cursor_pending'     => false,
+						'documents_seen'     => 10,
+						'documents_changed'  => 3,
+						'tabs_seen'          => 12,
+						'errors'             => 1,
+					),
+					'fingerprint' => $fingerprint,
+				),
+				'google_docs_migration_ledger' => array(
+					'read_state'  => 'available',
+					'updated_at'  => $updated_at,
+					'summary'     => array(
+						'total'               => 9,
+						'discovered'          => 1,
+						'not_product_content' => 1,
+						'needs_mapping'       => 1,
+						'staged_conflict'     => 1,
+						'applied_verified'    => 1,
+						'failed_retryable'    => 1,
+						'blocked'             => 1,
+						'other'               => 2,
+					),
+					'fingerprint' => $fingerprint,
+				),
+			),
+		);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2382,3 +2382,4 @@ require_once dirname(__DIR__) . '/includes/websocket/class-websocket-server.php'
 require_once dirname(__DIR__) . '/includes/admin/class-digitalogic-product-supplier-links-admin.php';
 require_once dirname(__DIR__) . '/includes/cli/class-cli-commands.php';
 require_once dirname(__DIR__) . '/includes/cli/class-digitalogic-product-supplier-links-cli.php';
+require_once dirname(__DIR__) . '/includes/cli/class-digitalogic-seo-monitor-status-cli.php';


### PR DESCRIPTION
## Status

**Pending owner approval.** Keep this status visible until explicit owner
sign-off or an `@codex` correction. Merge or issue closure alone is not owner
approval.

Refs #152

## What changed

- Added `wp digitalogic seo-monitor status`, gated by `manage_options` before
  argument validation or bridge execution.
- Added a fixed, zero-argument root declassifier for the five reviewed private
  state files.
- Preserved the root-owned `0700` directory and `0600` file boundary.
- Added strict producer adapters for observed `schema_version` 1.0 and 1.1
  layouts.
- Added bounded output containing only controlled state, counters, sanitized
  timestamps, and domain-separated HMAC-SHA-256 fingerprints.
- Added a digest-pinned no-argument sudoers review template with environment
  hardening.
- Added PHP-side exact schema reconstruction so bridge stdout and stderr are
  never relayed directly.

## Security boundary

The helper is treated as a least-information declassifier because WordPress
capability identity cannot cross the sudo boundary. Its output is safe even if
another local `www-data` process invokes the reviewed helper directly.

The helper has no caller-controlled argument, path, filename, environment,
stdin, shell, child-process, network, or write surface. It rejects unsafe
ownership, modes, special mode bits, symlinks, hardlinks, oversized files,
malformed UTF-8 or JSON, unsupported schemas, and repeated read races.

Raw state, content, evidence, recommendations, URLs, paths, document
identifiers or titles, collaborator data, credentials, private links, and
notification destinations or routing are never emitted.

## Validation

- `npm --prefix ops/seo-monitor run check`
- `npm --prefix ops/seo-monitor test` — 30/30
- Focused PHPUnit — 8 tests, 83 assertions
- Full PHPUnit — 342 tests, 2,151 assertions; one existing warning and five
  existing skips
- Targeted WordPress PHPCS — clean
- Repository PHPCS baseline — passed
- PHP syntax checks — passed
- `git diff --check` — passed
- Independent combined security audit — no blocking findings
- GitHub CI — Code Quality Check, PHP 8.3 Test, Security Check, and Build
  Plugin Package all passed

CI also renders the sudoers review template with a syntactically valid digest
and checks it with `visudo -cf`.

## Deployment boundary

Nothing from this branch has been installed or deployed. The helper, HMAC key,
sudoers rule, and plugin artifact must remain uninstalled until the PR is
merged and the owner explicitly approves deployment from the reviewed merged
commit. Real-digest `visudo`, sudo argument-denial probes, live sanitized output
verification, and unchanged `0700/0600` readback are intentionally post-merge,
owner-approved steps.
