### PR TITLE
Migrate managed category slugs to neutral URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   seven-percent operator warnings without placing credentials in the workbook.
 
 ### Fixed
+- Migrated integration-managed WooCommerce product categories from public
+  `patris-*` slugs to stable `product-category-<code>` URLs, retained exact
+  permanent redirects, preserved adopted/manual slugs, and made homepage source
+  category selection resolve through the authoritative category-code metadata.
 - Consolidated the login identity normalizer, preserved password selections through visibility toggles, localized username-step controls, added keyboard-complete language selection, and removed the duplicate checkbox glyph across RTL/LTR light/dark login states.
 - Enforced explicit notification channel allow-lists in both n8n routing and the notifier, kept endpoint/category preferences after the channel gate, and counted PHP-FPM slow requests by canonical request headers instead of stack lines.
 - Styled the reserved `Changes` and `Audit` support rows as professional workflow panels while preserving staged values, append-only audit data, legacy layouts, and frozen table headers.

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -124,6 +124,7 @@ final class Digitalogic {
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-import-export.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-unit-converter.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-product-identifier-resolver.php';
+        require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-category-slugs.php';
         require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-supplier-links.php';
 		require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-metadata-inspector.php';
 		require_once DIGITALOGIC_PLUGIN_DIR . 'includes/class-digitalogic-product-write-lock.php';
@@ -234,6 +235,7 @@ final class Digitalogic {
         Digitalogic_Comment_Guard::instance();
         Digitalogic_Product_Resources::instance();
         Digitalogic_Storefront_Catalog::instance();
+        Digitalogic_Product_Category_Slugs::instance();
         Digitalogic_Homepage_Showcase::instance();
         Digitalogic_Storefront_Product_Table::instance();
         Digitalogic_Storefront_Order_Forms::instance();

--- a/docs/PATRIS-CATALOG-MATERIALIZER.md
+++ b/docs/PATRIS-CATALOG-MATERIALIZER.md
@@ -34,6 +34,11 @@ Freight arrives as the inseparable `shipping_price_per_kg` and
   never removed.
 - Existing category names and parents are preserved unless `rename` is
   explicitly true for that reviewed source category.
+- New integration-managed product categories use stable, source-neutral public
+  slugs in the form `product-category-<category-code>`. On an apply run, only
+  terms marked with `_digitalogic_patris_category_managed=1` are migrated from
+  historic `patris-*` slugs. The old exact paths are retained as permanent
+  redirects; adopted/manual term slugs are never changed by this migration.
 - A variable product cannot own a leaf Patris Code. The materializer can create
   a reviewed child under an existing variable parent, but it never invents a
   new variable family.

--- a/includes/class-digitalogic-product-category-slugs.php
+++ b/includes/class-digitalogic-product-category-slugs.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Source-neutral public slugs for integration-managed product categories.
+ *
+ * @package Digitalogic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Owns managed category slug generation, lookup, migration redirects.
+ */
+final class Digitalogic_Product_Category_Slugs {
+
+	public const CATEGORY_CODE_META     = '_digitalogic_patris_category_code';
+	public const CATEGORY_MANAGED_META  = '_digitalogic_patris_category_managed';
+	public const LEGACY_SLUGS_META      = '_digitalogic_product_category_legacy_slugs';
+	public const NEUTRAL_PREFIX         = 'product-category-';
+	public const LEGACY_PREFIX          = 'patris-';
+	public const LEGACY_REDIRECT_STATUS = 301;
+
+	/**
+	 * Singleton service.
+	 *
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Return the singleton service.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register the public compatibility redirect.
+	 */
+	private function __construct() {
+		add_action( 'template_redirect', array( $this, 'maybe_redirect_legacy_category' ), 1 );
+	}
+
+	/**
+	 * Build the stable public slug for a source category Code.
+	 *
+	 * @param string $category_code Exact source category Code.
+	 * @return string
+	 */
+	public static function neutral_slug( $category_code ) {
+		$suffix = sanitize_title( trim( (string) $category_code ) );
+
+		return '' === $suffix ? '' : self::NEUTRAL_PREFIX . $suffix;
+	}
+
+	/**
+	 * Build the historic public slug for a source category Code.
+	 *
+	 * @param string $category_code Exact source category Code.
+	 * @return string
+	 */
+	public static function legacy_slug( $category_code ) {
+		$suffix = sanitize_title( trim( (string) $category_code ) );
+
+		return '' === $suffix ? '' : self::LEGACY_PREFIX . $suffix;
+	}
+
+	/**
+	 * Record one exact historic slug before a managed term is migrated.
+	 *
+	 * @param int    $term_id Exact term ID.
+	 * @param string $legacy_slug Historic public slug.
+	 * @return bool
+	 */
+	public function remember_legacy_slug( $term_id, $legacy_slug ) {
+		$legacy_slug = sanitize_title( (string) $legacy_slug );
+		if ( ! str_starts_with( $legacy_slug, self::LEGACY_PREFIX ) ) {
+			return false;
+		}
+
+		$stored   = $this->normalize_legacy_slugs( get_term_meta( (int) $term_id, self::LEGACY_SLUGS_META, true ) );
+		$stored[] = $legacy_slug;
+		$stored   = array_values( array_unique( $stored ) );
+		sort( $stored, SORT_STRING );
+		if ( false === update_term_meta( (int) $term_id, self::LEGACY_SLUGS_META, $stored ) ) {
+			return false;
+		}
+
+		return in_array(
+			$legacy_slug,
+			$this->normalize_legacy_slugs( get_term_meta( (int) $term_id, self::LEGACY_SLUGS_META, true ) ),
+			true
+		);
+	}
+
+	/**
+	 * Resolve one unambiguous product category by its authoritative source Code.
+	 *
+	 * @param string $category_code Exact source category Code.
+	 * @return object|false
+	 */
+	public function find_by_category_code( $category_code ) {
+		$category_code = trim( (string) $category_code );
+		if ( '' === $category_code ) {
+			return false;
+		}
+
+		$matches = get_terms(
+			array(
+				'taxonomy'   => 'product_cat',
+				'hide_empty' => false,
+				'meta_key'   => self::CATEGORY_CODE_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $category_code, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'number'     => 2,
+			)
+		);
+
+		return ! is_wp_error( $matches ) && 1 === count( $matches ) ? reset( $matches ) : false;
+	}
+
+	/**
+	 * Return the canonical URL for one historic managed category slug.
+	 *
+	 * This method is public so the resolution can be verified without emitting
+	 * headers or terminating a request.
+	 *
+	 * @param string $requested_path Product-category query path or leaf slug.
+	 * @return string
+	 */
+	public function resolve_legacy_category_redirect( $requested_path ) {
+		$segments = array_values( array_filter( explode( '/', trim( (string) $requested_path, '/' ) ), 'strlen' ) );
+		$slug     = sanitize_title( empty( $segments ) ? '' : end( $segments ) );
+		if ( '' === $slug || ! str_starts_with( $slug, self::LEGACY_PREFIX ) ) {
+			return '';
+		}
+
+		$managed_terms = get_terms(
+			array(
+				'taxonomy'   => 'product_cat',
+				'hide_empty' => false,
+				'meta_key'   => self::CATEGORY_MANAGED_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => '1', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+		if ( is_wp_error( $managed_terms ) ) {
+			return '';
+		}
+
+		$matched = array();
+		foreach ( $managed_terms as $term ) {
+			$term_id       = (int) ( $term->term_id ?? 0 );
+			$category_code = (string) get_term_meta( $term_id, self::CATEGORY_CODE_META, true );
+			$neutral_slug  = self::neutral_slug( $category_code );
+			if ( '' === $category_code || (string) ( $term->slug ?? '' ) !== $neutral_slug ) {
+				continue;
+			}
+
+			$legacy_slugs = $this->legacy_slugs( $term_id, $category_code );
+			if ( in_array( $slug, $legacy_slugs, true ) ) {
+				$matched[] = $term;
+			}
+		}
+
+		if ( 1 !== count( $matched ) ) {
+			return '';
+		}
+
+		$url = get_term_link( reset( $matched ), 'product_cat' );
+
+		return is_wp_error( $url ) ? '' : (string) $url;
+	}
+
+	/**
+	 * Permanently redirect a historic product-category path to its exact owner.
+	 *
+	 * @return void
+	 */
+	public function maybe_redirect_legacy_category() {
+		$requested_path = (string) get_query_var( 'product_cat', '' );
+		$url            = $this->resolve_legacy_category_redirect( $requested_path );
+		if ( '' === $url ) {
+			return;
+		}
+
+		if ( wp_safe_redirect( $url, self::LEGACY_REDIRECT_STATUS, 'Digitalogic' ) ) {
+			exit;
+		}
+	}
+
+	/**
+	 * Read the closed legacy-slug allowlist for one managed term.
+	 *
+	 * @param int    $term_id Exact term ID.
+	 * @param string $category_code Exact source category Code.
+	 * @return array
+	 */
+	private function legacy_slugs( $term_id, $category_code ) {
+		$slugs   = $this->normalize_legacy_slugs( get_term_meta( (int) $term_id, self::LEGACY_SLUGS_META, true ) );
+		$default = self::legacy_slug( $category_code );
+		if ( '' !== $default ) {
+			$slugs[] = $default;
+		}
+		$slugs = array_values( array_unique( $slugs ) );
+		sort( $slugs, SORT_STRING );
+
+		return $slugs;
+	}
+
+	/**
+	 * Normalize a stored historic-slug allowlist.
+	 *
+	 * @param mixed $stored Stored term metadata.
+	 * @return array
+	 */
+	private function normalize_legacy_slugs( $stored ) {
+		$stored = is_array( $stored ) ? $stored : ( '' === $stored ? array() : array( $stored ) );
+		$slugs  = array();
+		foreach ( $stored as $slug ) {
+			if ( ! is_string( $slug ) ) {
+				continue;
+			}
+			$slug = sanitize_title( (string) $slug );
+			if ( str_starts_with( $slug, self::LEGACY_PREFIX ) ) {
+				$slugs[] = $slug;
+			}
+		}
+		$slugs = array_values( array_unique( $slugs ) );
+		sort( $slugs, SORT_STRING );
+
+		return $slugs;
+	}
+}

--- a/includes/class-patris-catalog-materializer.php
+++ b/includes/class-patris-catalog-materializer.php
@@ -18,10 +18,10 @@ final class Digitalogic_Patris_Catalog_Materializer {
 
 	public const MANIFEST_SCHEMA_VERSION = '1.0';
 
-	public const CATEGORY_CODE_META    = '_digitalogic_patris_category_code';
+	public const CATEGORY_CODE_META    = Digitalogic_Product_Category_Slugs::CATEGORY_CODE_META;
 	public const CATEGORY_KEY_META     = '_digitalogic_catalog_category_key';
 	public const CATEGORY_TERM_META    = '_digitalogic_patris_category_term_id';
-	public const CATEGORY_MANAGED_META = '_digitalogic_patris_category_managed';
+	public const CATEGORY_MANAGED_META = Digitalogic_Product_Category_Slugs::CATEGORY_MANAGED_META;
 	public const CATEGORY_ADOPTED_META = '_digitalogic_patris_category_adopted';
 	public const OWNER_SOURCE_META     = '_digitalogic_patris_owner_source_id';
 	public const OWNER_DATASET_META    = '_digitalogic_patris_owner_dataset';
@@ -1155,12 +1155,20 @@ final class Digitalogic_Patris_Catalog_Materializer {
 					'action'  => 'planned_create',
 				);
 			} else {
+				$neutral_slug = Digitalogic_Product_Category_Slugs::neutral_slug( (string) $category['category_code'] );
+				if ( '' === $neutral_slug ) {
+					return $this->error( 'digitalogic_patris_materializer_category_slug_invalid', 'The product category Code cannot produce a stable public slug.' );
+				}
+				$slug_owner = get_term_by( 'slug', $neutral_slug, 'product_cat' );
+				if ( is_object( $slug_owner ) ) {
+					return $this->error( 'digitalogic_patris_materializer_category_slug_conflict', 'The stable product category slug is already owned by another category.' );
+				}
 				$inserted = wp_insert_term(
 					$name,
 					'product_cat',
 					array(
 						'parent' => $parent_id,
-						'slug'   => 'patris-' . sanitize_title( (string) $category['category_code'] ),
+						'slug'   => $neutral_slug,
 					)
 				);
 				if ( is_wp_error( $inserted ) ) {
@@ -1183,20 +1191,41 @@ final class Digitalogic_Patris_Catalog_Materializer {
 			return $this->error( 'digitalogic_patris_materializer_category_unavailable', 'The mapped category is unavailable.' );
 		}
 
-		if ( ( $managed || $rename_reviewed ) && ( (string) $term->name !== $name || (int) $term->parent !== $parent_id ) ) {
+		$neutral_slug = Digitalogic_Product_Category_Slugs::neutral_slug( (string) $category['category_code'] );
+		if ( '' === $neutral_slug ) {
+			return $this->error( 'digitalogic_patris_materializer_category_slug_invalid', 'The product category Code cannot produce a stable public slug.' );
+		}
+		$migrate_slug = $managed && str_starts_with( (string) ( $term->slug ?? '' ), Digitalogic_Product_Category_Slugs::LEGACY_PREFIX );
+		$needs_update = (string) $term->name !== $name || (int) $term->parent !== $parent_id || $migrate_slug;
+		if ( $migrate_slug ) {
+			$slug_owner = get_term_by( 'slug', $neutral_slug, 'product_cat' );
+			if ( is_object( $slug_owner ) && (int) $slug_owner->term_id !== $term_id ) {
+				return $this->error( 'digitalogic_patris_materializer_category_slug_conflict', 'The stable product category slug is already owned by another category.' );
+			}
+
+			if ( ! Digitalogic_Product_Category_Slugs::instance()->remember_legacy_slug( $term_id, (string) $term->slug ) ) {
+				return $this->error( 'digitalogic_patris_materializer_category_legacy_slug_failed', 'The legacy product category redirect could not be recorded.' );
+			}
+		}
+
+		if ( ( $managed || $rename_reviewed ) && $needs_update ) {
+			$update_args = array(
+				'name'   => $name,
+				'parent' => $parent_id,
+			);
+			if ( $migrate_slug ) {
+				$update_args['slug'] = $neutral_slug;
+			}
 			$updated = wp_update_term(
 				$term_id,
 				'product_cat',
-				array(
-					'name'   => $name,
-					'parent' => $parent_id,
-				)
+				$update_args
 			);
 			if ( is_wp_error( $updated ) ) {
 				return $updated;
 			}
 			$action = 'updated';
-		} elseif ( ! $managed && ( (string) $term->name !== $name || (int) $term->parent !== $parent_id ) ) {
+		} elseif ( ! $managed && $needs_update ) {
 			$action = 'preserved_manual';
 		}
 
@@ -1214,6 +1243,9 @@ final class Digitalogic_Patris_Catalog_Materializer {
 		}
 		if ( (string) get_term_meta( $term_id, self::CATEGORY_CODE_META, true ) !== (string) $category['category_code'] ) {
 			return $this->error( 'digitalogic_patris_materializer_category_meta_failed', 'The category Code failed readback verification.' );
+		}
+		if ( ( 'created' === $action || $migrate_slug ) && (string) get_term( $term_id, 'product_cat' )->slug !== $neutral_slug ) {
+			return $this->error( 'digitalogic_patris_materializer_category_slug_failed', 'The stable product category slug failed readback verification.' );
 		}
 
 		return array(

--- a/includes/integrations/class-homepage-showcase.php
+++ b/includes/integrations/class-homepage-showcase.php
@@ -253,7 +253,7 @@ final class Digitalogic_Homepage_Showcase {
 			'displays-modules',
 			'modules-development-board',
 		);
-		$found = array();
+		$found      = array();
 
 		foreach ( $slugs as $slug ) {
 			$products = wc_get_products(
@@ -288,25 +288,32 @@ final class Digitalogic_Homepage_Showcase {
 	 * @return array
 	 */
 	private function get_more_products( $limit, $exclude_ids ) {
-		$slugs = array(
-			'patris-113007',
-			'patris-113003',
-			'patris-113008',
-			'patris-113010',
-			'temperature-and-humidity-sensors',
-			'lcd-and-oled-displays',
-			'regulators',
-			'patris-106001',
+		$categories = array(
+			array( 'category_code' => '113007' ),
+			array( 'category_code' => '113003' ),
+			array( 'category_code' => '113008' ),
+			array( 'category_code' => '113010' ),
+			array( 'slug' => 'temperature-and-humidity-sensors' ),
+			array( 'slug' => 'lcd-and-oled-displays' ),
+			array( 'slug' => 'regulators' ),
+			array( 'category_code' => '106001' ),
 		);
 		$found = array();
 
-		foreach ( $slugs as $slug ) {
+		foreach ( $categories as $category ) {
+			$term = isset( $category['category_code'] )
+				? Digitalogic_Product_Category_Slugs::instance()->find_by_category_code( $category['category_code'] )
+				: get_term_by( 'slug', $category['slug'], 'product_cat' );
+			if ( ! is_object( $term ) || is_wp_error( $term ) || '' === (string) ( $term->slug ?? '' ) ) {
+				continue;
+			}
+
 			$products = wc_get_products(
 				array(
 					'status'       => 'publish',
 					'stock_status' => 'instock',
 					'visibility'   => 'visible',
-					'category'     => array( $slug ),
+					'category'     => array( (string) $term->slug ),
 					'exclude'      => array_merge( array_map( 'absint', $exclude_ids ), array_keys( $found ) ),
 					'limit'        => 24,
 					'orderby'      => 'modified',

--- a/tests/PatrisCatalogMaterializerTest.php
+++ b/tests/PatrisCatalogMaterializerTest.php
@@ -211,6 +211,54 @@ final class PatrisCatalogMaterializerTest extends TestCase {
 		$this->assertGreaterThan( 0, (float) $product->get_weight() );
 		$this->assertCount( 1, $product->get_category_ids() );
 		$this->assertSame( (string) $product->get_category_ids()[0], $product->get_meta( 'rank_math_primary_product_cat', true ) );
+		foreach ( array( '101', '101001' ) as $category_code ) {
+			$term = Digitalogic_Product_Category_Slugs::instance()->find_by_category_code( $category_code );
+			$this->assertIsObject( $term );
+			$this->assertSame( 'product-category-' . $category_code, $term->slug );
+		}
+	}
+
+	/** Verify apply migrates managed legacy slugs and records every old path. */
+	public function test_apply_migrates_only_managed_legacy_category_slugs_and_records_redirects(): void {
+		$this->receiveFixture();
+		$manifest = $this->manifest();
+		$this->addTerm( 50, $manifest['categories']['101']['name_fa'], 0, 'product_cat', 'patris-custom-root' );
+		$this->addTerm( 51, $manifest['categories']['101001']['name_fa'], 50, 'product_cat', 'patris-101001' );
+		update_term_meta( 50, Digitalogic_Patris_Catalog_Materializer::CATEGORY_CODE_META, '101' );
+		update_term_meta( 51, Digitalogic_Patris_Catalog_Materializer::CATEGORY_CODE_META, '101001' );
+		update_term_meta( 50, Digitalogic_Patris_Catalog_Materializer::CATEGORY_MANAGED_META, '1' );
+		update_term_meta( 51, Digitalogic_Patris_Catalog_Materializer::CATEGORY_MANAGED_META, '1' );
+
+		$result = Digitalogic_Patris_Catalog_Materializer::instance()->run( $manifest, array( 'apply' => true ) );
+
+		$this->assertSame( 2, $result['categories']['updated'] );
+		$this->assertSame( 'product-category-101', get_term( 50, 'product_cat' )->slug );
+		$this->assertSame( 'product-category-101001', get_term( 51, 'product_cat' )->slug );
+		$this->assertSame(
+			array( 'patris-custom-root' ),
+			get_term_meta( 50, Digitalogic_Product_Category_Slugs::LEGACY_SLUGS_META, true )
+		);
+		$this->assertSame(
+			array( 'patris-101001' ),
+			get_term_meta( 51, Digitalogic_Product_Category_Slugs::LEGACY_SLUGS_META, true )
+		);
+	}
+
+	/** Verify adopted/manual term slugs remain outside automatic migration. */
+	public function test_apply_preserves_an_adopted_manual_legacy_category_slug(): void {
+		$this->receiveFixture();
+		$manifest = $this->manifest();
+		$this->addTerm( 50, $manifest['categories']['101']['name_fa'], 0, 'product_cat', 'patris-manual-root' );
+		$this->addTerm( 51, $manifest['categories']['101001']['name_fa'], 50, 'product_cat', 'patris-manual-leaf' );
+		update_term_meta( 50, Digitalogic_Patris_Catalog_Materializer::CATEGORY_CODE_META, '101' );
+		update_term_meta( 51, Digitalogic_Patris_Catalog_Materializer::CATEGORY_CODE_META, '101001' );
+
+		$result = Digitalogic_Patris_Catalog_Materializer::instance()->run( $manifest, array( 'apply' => true ) );
+
+		$this->assertSame( 2, $result['categories']['already_mapped'] );
+		$this->assertSame( 'patris-manual-root', get_term( 50, 'product_cat' )->slug );
+		$this->assertSame( 'patris-manual-leaf', get_term( 51, 'product_cat' )->slug );
+		$this->assertSame( '', get_term_meta( 50, Digitalogic_Product_Category_Slugs::LEGACY_SLUGS_META, true ) );
 	}
 
 	/** Verify stale freight state cannot bypass publication readiness. */

--- a/tests/ProductCategorySlugsTest.php
+++ b/tests/ProductCategorySlugsTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Source-neutral managed product-category slug tests.
+ *
+ * @package Digitalogic
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies lookup, redirect, and homepage compatibility.
+ */
+final class ProductCategorySlugsTest extends TestCase {
+
+	/** Reset every shared registry used by the category service. */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['digitalogic_test_terms']                 = array();
+		$GLOBALS['digitalogic_test_term_meta']             = array();
+		$GLOBALS['digitalogic_test_posts']                 = array();
+		$GLOBALS['digitalogic_test_wc_products']           = array();
+		$GLOBALS['digitalogic_test_wc_product_query_args'] = array();
+		$GLOBALS['digitalogic_test_action_callbacks']      = array();
+		$this->reset_singleton( Digitalogic_Product_Category_Slugs::class );
+		$this->reset_singleton( Digitalogic_Homepage_Showcase::class );
+	}
+
+	/** Ambiguous category-code ownership must fail closed. */
+	public function test_source_category_lookup_fails_closed_when_the_code_is_ambiguous(): void {
+		$this->add_term( 10, 'product-category-113007', '113007', true );
+		$this->add_term( 11, 'duplicate-category', '113007', true );
+
+		$this->assertFalse( Digitalogic_Product_Category_Slugs::instance()->find_by_category_code( '113007' ) );
+	}
+
+	/** Redirects require an exact recorded slug and a managed neutral owner. */
+	public function test_legacy_redirect_resolves_only_an_exact_managed_neutral_term(): void {
+		$this->add_term( 20, 'product-category-113007', '113007', true );
+		update_term_meta(
+			20,
+			Digitalogic_Product_Category_Slugs::LEGACY_SLUGS_META,
+			array( 'patris-custom-113007' )
+		);
+		$service = Digitalogic_Product_Category_Slugs::instance();
+
+		$this->assertSame(
+			'https://digitalogic.test/product-category/product-category-113007',
+			$service->resolve_legacy_category_redirect( 'parent/patris-113007' )
+		);
+		$this->assertSame(
+			'https://digitalogic.test/product-category/product-category-113007',
+			$service->resolve_legacy_category_redirect( 'patris-custom-113007' )
+		);
+
+		$this->add_term( 21, 'product-category-113008', '113008', false );
+		$this->assertSame( '', $service->resolve_legacy_category_redirect( 'patris-113008' ) );
+	}
+
+	/** Homepage source category selection follows category-code metadata. */
+	public function test_homepage_resolves_source_categories_by_code_meta_after_migration(): void {
+		$this->add_term( 30, 'product-category-113007', '113007', true );
+		$GLOBALS['digitalogic_test_posts'][41] = array(
+			'post_type'    => 'product',
+			'post_status'  => 'publish',
+			'product_type' => 'simple',
+			'post_title'   => 'Neutral category product',
+			'meta'         => array(),
+		);
+
+		$method = ( new ReflectionClass( Digitalogic_Homepage_Showcase::class ) )->getMethod( 'get_more_products' );
+		$result = $method->invoke( Digitalogic_Homepage_Showcase::instance(), 1, array() );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame(
+			array( 'product-category-113007' ),
+			$GLOBALS['digitalogic_test_wc_product_query_args'][0]['category']
+		);
+	}
+
+	/** The public compatibility redirect is registered at initialization. */
+	public function test_service_registers_the_permanent_redirect_hook(): void {
+		Digitalogic_Product_Category_Slugs::instance();
+
+		$this->assertSame( 301, Digitalogic_Product_Category_Slugs::LEGACY_REDIRECT_STATUS );
+		$this->assertTrue( has_action( 'template_redirect' ) );
+		$callback = $GLOBALS['digitalogic_test_action_callbacks']['template_redirect'][0]['callback'];
+		$this->assertSame( 'maybe_redirect_legacy_category', $callback[1] );
+	}
+
+	/**
+	 * Add one exact product category to the test registry.
+	 *
+	 * @param int    $term_id Exact term ID.
+	 * @param string $slug Public slug.
+	 * @param string $category_code Authoritative source category Code.
+	 * @param bool   $managed Whether the integration owns this term.
+	 */
+	private function add_term( int $term_id, string $slug, string $category_code, bool $managed ): void {
+		$GLOBALS['digitalogic_test_terms'][ $term_id ] = array(
+			'term_id'  => $term_id,
+			'name'     => 'Category ' . $category_code,
+			'slug'     => $slug,
+			'parent'   => 0,
+			'taxonomy' => 'product_cat',
+		);
+		update_term_meta( $term_id, Digitalogic_Product_Category_Slugs::CATEGORY_CODE_META, $category_code );
+		if ( $managed ) {
+			update_term_meta( $term_id, Digitalogic_Product_Category_Slugs::CATEGORY_MANAGED_META, '1' );
+		}
+	}
+
+	/**
+	 * Reset one singleton between tests.
+	 *
+	 * @param string $class_name Exact class name.
+	 */
+	private function reset_singleton( string $class_name ): void {
+		$property = ( new ReflectionClass( $class_name ) )->getProperty( 'instance' );
+		$property->setValue( null, null );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2004,6 +2004,34 @@ function get_term($term_id, $taxonomy = '') {
 	return new WP_Error('term_not_found', 'Term not found.');
 }
 
+/**
+ * Find one term by a scalar field in the test registry.
+ *
+ * @param string $field    Field selector.
+ * @param mixed  $value    Expected value.
+ * @param string $taxonomy Optional taxonomy.
+ * @param string $output   Ignored output mode.
+ * @param string $filter   Ignored filter mode.
+ * @return object|false
+ */
+function get_term_by( $field, $value, $taxonomy = '', $output = 'OBJECT', $filter = 'raw' ) {
+	unset( $output, $filter );
+	foreach ( ( $GLOBALS['digitalogic_test_terms'] ?? array() ) as $stored ) {
+		$term = is_object( $stored ) ? $stored : (object) $stored;
+		if ( '' !== $taxonomy && isset( $term->taxonomy ) && (string) $term->taxonomy !== (string) $taxonomy ) {
+			continue;
+		}
+		$candidate = 'id' === $field || 'term_id' === $field
+			? (int) ($term->term_id ?? 0)
+			: (string) ($term->{$field} ?? '');
+		if ( ( 'id' === $field || 'term_id' === $field ? (int) $value : (string) $value ) === $candidate ) {
+			return $term;
+		}
+	}
+
+	return false;
+}
+
 function get_terms($args = array()) {
 	$terms = array();
 	foreach (($GLOBALS['digitalogic_test_terms'] ?? array()) as $term_id => $term) {
@@ -2061,6 +2089,9 @@ function wp_insert_term($term, $taxonomy, $args = array()) {
     if (is_array($existing)) {
         return new WP_Error('term_exists', 'Term already exists.', (int) $existing['term_id']);
     }
+	if ( isset( $args['slug'] ) && get_term_by( 'slug', (string) $args['slug'], $taxonomy ) ) {
+		return new WP_Error( 'term_exists', 'Term slug already exists.' );
+	}
     $next = max(1, (int) ($GLOBALS['digitalogic_test_next_term_id'] ?? 1));
     while (isset($GLOBALS['digitalogic_test_terms'][$next])) {
         $next++;
@@ -2088,6 +2119,13 @@ function wp_update_term($term_id, $taxonomy, $args = array()) {
     if (isset($args['parent'])) {
         $GLOBALS['digitalogic_test_terms'][$term_id]['parent'] = (int) $args['parent'];
     }
+	if ( isset( $args['slug'] ) ) {
+		$slug_owner = get_term_by( 'slug', (string) $args['slug'], $taxonomy );
+		if ( $slug_owner && $term_id !== (int) $slug_owner->term_id ) {
+			return new WP_Error( 'duplicate_term_slug', 'Term slug already exists.' );
+		}
+		$GLOBALS['digitalogic_test_terms'][ $term_id ]['slug'] = (string) $args['slug'];
+	}
     $GLOBALS['digitalogic_test_terms'][$term_id]['taxonomy'] = (string) $taxonomy;
 
     return array('term_id' => $term_id, 'term_taxonomy_id' => $term_id);
@@ -2387,6 +2425,7 @@ require_once dirname(__DIR__) . '/includes/class-digitalogic-woocommerce-currenc
 require_once dirname( __DIR__ ) . '/includes/class-digitalogic-access-control.php';
 require_once dirname( __DIR__ ) . '/includes/panel/class-digitalogic-panel-error-page.php';
 require_once dirname(__DIR__) . '/includes/class-product-identifier-resolver.php';
+require_once dirname(__DIR__) . '/includes/class-digitalogic-product-category-slugs.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-supplier-links.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-product-query.php';
 require_once dirname(__DIR__) . '/includes/class-digitalogic-patris-price-policy.php'; // phpcs:ignore
@@ -2412,6 +2451,7 @@ require_once dirname(__DIR__) . '/includes/panel/class-panel.php';
 require_once dirname(__DIR__) . '/includes/integrations/class-label-overrides.php';
 require_once dirname(__DIR__) . '/includes/integrations/class-product-identity.php';
 require_once dirname(__DIR__) . '/includes/integrations/class-digitalogic-product-resources.php';
+require_once dirname(__DIR__) . '/includes/integrations/class-homepage-showcase.php';
 require_once dirname(__DIR__) . '/includes/websocket/class-websocket-server.php';
 require_once dirname(__DIR__) . '/includes/admin/class-digitalogic-product-supplier-links-admin.php';
 require_once dirname(__DIR__) . '/includes/cli/class-cli-commands.php';


### PR DESCRIPTION
Closes #150.

## What changed

- create integration-managed WooCommerce product categories with stable public
  slugs in the form `product-category-<category-code>`
- migrate only terms carrying the existing managed-category ownership meta when
  their current slug is `patris-*`
- record each exact historic slug before migration and permanently redirect it
  to the exact managed neutral term
- fail closed on ambiguous category-code ownership or neutral-slug collisions
- preserve adopted/manual term slugs and every existing internal source/meta key
- resolve homepage source-category product selections by authoritative category
  Code metadata instead of source-branded slug assumptions
- document the apply-time migration and add focused materializer, redirect, and
  homepage regression coverage
- include the change in the not-yet-tagged Digitalogic 1.7.0 changelog

## Compatibility and safety

The migration remains part of the administrator-authorized catalog materializer
apply path; plugin initialization does not perform taxonomy writes. Redirect
resolution accepts only an exact recorded/default legacy slug whose single
owner is still marked managed and has the expected neutral slug. Manual terms
are untouched.

## Verification

- `phpunit`: 373 tests, 2,364 assertions; one existing warning and five existing
  skips
- Node test suite: 74/74 passed
- PHP syntax: 124/124 repository PHP files passed
- repository WordPress coding-standard baseline: 40,697 errors (max 43,221),
  3,016 warnings (max 3,016)
- focused new service and tests: zero PHPCS violations
- `git diff --check`: passed
