### PR TITLE
Fix WP-CLI exact product-code reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `patris-*` slugs to stable `product-category-<code>` URLs, retained exact
   permanent redirects, preserved adopted/manual slugs, and made homepage source
   category selection resolve through the authoritative category-code metadata.
+- Separated the exact source-neutral Product Code from WooCommerce SKU in
+  `wp digitalogic products list`, preserving both fields without an identity
+  fallback.
 - Consolidated the login identity normalizer, preserved password selections through visibility toggles, localized username-step controls, added keyboard-complete language selection, and removed the duplicate checkbox glyph across RTL/LTR light/dark login states.
 - Enforced explicit notification channel allow-lists in both n8n routing and the notifier, kept endpoint/category preferences after the channel gate, and counted PHP-FPM slow requests by canonical request headers instead of stack lines.
 - Styled the reserved `Changes` and `Audit` support rows as professional workflow panels while preserving staged values, append-only audit data, legacy layouts, and frozen table headers.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -14,6 +14,19 @@ Product commands accept exactly one selector:
 SKUs are never converted to integers, so values such as `001230` remain exact.
 Duplicate SKUs fail with an ambiguity error rather than selecting one record.
 
+## List products
+
+```bash
+wp digitalogic products list --limit=20 --format=table
+wp digitalogic products list --limit=-1 --format=json
+```
+
+The source-neutral `Product Code` field is the exact
+`_digitalogic_patris_product_code` integration identifier. `SKU` is the
+separate WooCommerce SKU. Both remain exact strings, including leading zeroes.
+When only SKU exists, `Product Code` stays empty: product-sync reconciliation
+never falls back to SKU.
+
 ## Read one product
 
 ```bash

--- a/includes/cli/class-cli-commands.php
+++ b/includes/cli/class-cli-commands.php
@@ -105,6 +105,9 @@ class Digitalogic_CLI_Commands {
     
     /**
      * List products
+     *
+     * Product Code is the exact integration identifier. WooCommerce SKU is
+     * reported separately and is never used as a Product Code fallback.
      * 
      * ## OPTIONS
      * 
@@ -148,15 +151,16 @@ class Digitalogic_CLI_Commands {
         $items = array();
         foreach ($products as $product) {
             $items[] = array(
-                'ID' => $product['id'],
-                'Name' => $product['name'],
-                'Product Code' => $product['sku'],
-                'Price' => $product['price'],
-                'Stock' => $product['stock_quantity']
+                'ID'           => $product['id'],
+                'Name'         => $product['name'],
+                'Product Code' => (string) ($product['patris_product_code'] ?? ''),
+                'SKU'          => (string) ($product['sku'] ?? ''),
+                'Price'        => $product['price'],
+                'Stock'        => $product['stock_quantity']
             );
         }
         
-        WP_CLI\Utils\format_items($format, $items, array('ID', 'Name', 'Product Code', 'Price', 'Stock'));
+        WP_CLI\Utils\format_items($format, $items, array('ID', 'Name', 'Product Code', 'SKU', 'Price', 'Stock'));
     }
 
 	/**

--- a/tests/WpCliPatrisReportTest.php
+++ b/tests/WpCliPatrisReportTest.php
@@ -30,12 +30,74 @@ namespace {
 			$GLOBALS['digitalogic_test_option_cache']     = array();
 			$GLOBALS['digitalogic_test_posts']            = array();
 			$GLOBALS['digitalogic_test_cli_format_items'] = array();
+			$GLOBALS['digitalogic_test_wp_query_args']    = array();
+			$GLOBALS['digitalogic_test_wp_query_results'] = array();
+			$GLOBALS['digitalogic_test_primed_post_ids']  = array();
+			$GLOBALS['digitalogic_test_wc_products']      = array();
+			$GLOBALS['digitalogic_test_wc_lookup_rows']   = array();
 			$GLOBALS['wpdb']                              = new Digitalogic_Test_WPDB();
 			WP_CLI::$errors                               = array();
 			WP_CLI::$logs                                 = array();
 
+			$this->reset_singleton( Digitalogic_Product_Manager::class );
 			$this->reset_singleton( Digitalogic_Product_Sync_Receiver::class );
 			$this->reset_singleton( Digitalogic_Report_Engine::class );
+		}
+
+		/** Product list keeps the exact integration Code separate from SKU. */
+		public function test_product_list_outputs_exact_product_code_and_separate_sku(): void {
+			$GLOBALS['digitalogic_test_posts']            = array(
+				1601 => array(
+					'post_type'    => 'product',
+					'post_status'  => 'publish',
+					'post_title'   => 'Exact Code Product',
+					'product_type' => 'simple',
+					'meta'         => array(
+						'_sku'                             => 'SKU-001',
+						'_digitalogic_patris_product_code' => '000123',
+						'_price'                           => '125000',
+						'_regular_price'                   => '125000',
+						'_stock'                           => '4',
+						'_manage_stock'                    => 'yes',
+						'_stock_status'                    => 'instock',
+					),
+				),
+				1602 => array(
+					'post_type'    => 'product',
+					'post_status'  => 'publish',
+					'post_title'   => 'SKU-only Product',
+					'product_type' => 'simple',
+					'meta'         => array(
+						'_sku'           => 'SKU-ONLY',
+						'_price'         => '',
+						'_regular_price' => '',
+						'_stock_status'  => 'instock',
+					),
+				),
+			);
+			$GLOBALS['digitalogic_test_wp_query_results'] = array(
+				array(
+					'posts'       => array( 1601, 1602 ),
+					'found_posts' => 2,
+				),
+			);
+
+			( new Digitalogic_CLI_Commands() )->products_list(
+				array(),
+				array(
+					'limit'  => 20,
+					'format' => 'json',
+				)
+			);
+
+			$this->assertSame( array(), WP_CLI::$errors );
+			$this->assertCount( 1, $GLOBALS['digitalogic_test_cli_format_items'] );
+			$formatted = $GLOBALS['digitalogic_test_cli_format_items'][0];
+			$this->assertSame( array( 'ID', 'Name', 'Product Code', 'SKU', 'Price', 'Stock' ), $formatted['fields'] );
+			$this->assertSame( '000123', $formatted['items'][0]['Product Code'] );
+			$this->assertSame( 'SKU-001', $formatted['items'][0]['SKU'] );
+			$this->assertSame( '', $formatted['items'][1]['Product Code'] );
+			$this->assertSame( 'SKU-ONLY', $formatted['items'][1]['SKU'] );
 		}
 
 		/** Table output contains the selected price-list row fields. */


### PR DESCRIPTION
Closes #160.

## Summary
- make `wp digitalogic products list` report the exact `_digitalogic_patris_product_code` as `Product Code`
- add WooCommerce `SKU` as a separate output field with no identity fallback
- document exact-string and leading-zero behavior
- cover exact-code, SKU, and SKU-only rows with a regression test

## Verification
- `php -l includes/cli/class-cli-commands.php`
- `php -l tests/WpCliPatrisReportTest.php`
- focused PHPUnit: 2 tests, 14 assertions
- full PHPUnit: 368 tests, 2347 assertions, 1 existing warning, 5 skipped
- `git diff --check`

## Review status
Implementation is ready for repository review. Owner approval remains explicit and separate from merge/closure.