### PR TITLE
Restore exact legacy product-category redirects

### DIFF
--- a/includes/class-digitalogic-product-category-slugs.php
+++ b/includes/class-digitalogic-product-category-slugs.php
@@ -116,9 +116,10 @@ final class Digitalogic_Product_Category_Slugs {
 			array(
 				'taxonomy'   => 'product_cat',
 				'hide_empty' => false,
-				'meta_key'   => self::CATEGORY_CODE_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value' => $category_code, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_query' => self::exact_meta_query( self::CATEGORY_CODE_META, $category_code ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'number'     => 2,
+				'orderby'    => 'term_id',
+				'order'      => 'ASC',
 			)
 		);
 
@@ -145,8 +146,9 @@ final class Digitalogic_Product_Category_Slugs {
 			array(
 				'taxonomy'   => 'product_cat',
 				'hide_empty' => false,
-				'meta_key'   => self::CATEGORY_MANAGED_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_value' => '1', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_query' => self::exact_meta_query( self::CATEGORY_MANAGED_META, '1' ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'orderby'    => 'term_id',
+				'order'      => 'ASC',
 			)
 		);
 		if ( is_wp_error( $managed_terms ) ) {
@@ -235,5 +237,26 @@ final class Digitalogic_Product_Category_Slugs {
 		sort( $slugs, SORT_STRING );
 
 		return $slugs;
+	}
+
+	/**
+	 * Build one explicit equality clause for a term-meta query.
+	 *
+	 * WordPress accepts top-level meta_key/meta_value arguments for many query
+	 * classes, but the live term-query stack does not preserve that shorthand.
+	 * An explicit clause remains portable and keeps both lookups fail-closed.
+	 *
+	 * @param string $key Term meta key.
+	 * @param string $value Exact term meta value.
+	 * @return array
+	 */
+	private static function exact_meta_query( $key, $value ) {
+		return array(
+			array(
+				'key'     => (string) $key,
+				'value'   => (string) $value,
+				'compare' => '=',
+			),
+		);
 	}
 }

--- a/tests/ProductCategorySlugsTest.php
+++ b/tests/ProductCategorySlugsTest.php
@@ -17,6 +17,7 @@ final class ProductCategorySlugsTest extends TestCase {
 		parent::setUp();
 		$GLOBALS['digitalogic_test_terms']                 = array();
 		$GLOBALS['digitalogic_test_term_meta']             = array();
+		$GLOBALS['digitalogic_test_term_queries']          = array();
 		$GLOBALS['digitalogic_test_posts']                 = array();
 		$GLOBALS['digitalogic_test_wc_products']           = array();
 		$GLOBALS['digitalogic_test_wc_product_query_args'] = array();
@@ -31,6 +32,19 @@ final class ProductCategorySlugsTest extends TestCase {
 		$this->add_term( 11, 'duplicate-category', '113007', true );
 
 		$this->assertFalse( Digitalogic_Product_Category_Slugs::instance()->find_by_category_code( '113007' ) );
+		$this->assertSame(
+			array(
+				array(
+					'key'     => Digitalogic_Product_Category_Slugs::CATEGORY_CODE_META,
+					'value'   => '113007',
+					'compare' => '=',
+				),
+			),
+			$GLOBALS['digitalogic_test_term_queries'][0]['meta_query']
+		);
+		$this->assertArrayNotHasKey( 'meta_key', $GLOBALS['digitalogic_test_term_queries'][0] );
+		$this->assertSame( 'term_id', $GLOBALS['digitalogic_test_term_queries'][0]['orderby'] );
+		$this->assertSame( 'ASC', $GLOBALS['digitalogic_test_term_queries'][0]['order'] );
 	}
 
 	/** Redirects require an exact recorded slug and a managed neutral owner. */
@@ -54,6 +68,13 @@ final class ProductCategorySlugsTest extends TestCase {
 
 		$this->add_term( 21, 'product-category-113008', '113008', false );
 		$this->assertSame( '', $service->resolve_legacy_category_redirect( 'patris-113008' ) );
+		$this->assertSame(
+			Digitalogic_Product_Category_Slugs::CATEGORY_MANAGED_META,
+			$GLOBALS['digitalogic_test_term_queries'][0]['meta_query'][0]['key']
+		);
+		$this->assertArrayNotHasKey( 'meta_key', $GLOBALS['digitalogic_test_term_queries'][0] );
+		$this->assertSame( 'term_id', $GLOBALS['digitalogic_test_term_queries'][0]['orderby'] );
+		$this->assertSame( 'ASC', $GLOBALS['digitalogic_test_term_queries'][0]['order'] );
 	}
 
 	/** Homepage source category selection follows category-code metadata. */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,6 +40,7 @@ $GLOBALS['digitalogic_test_next_post_id'] = 1;
 $GLOBALS['digitalogic_test_post_meta_cache'] = array();
 $GLOBALS['digitalogic_test_terms'] = array();
 $GLOBALS['digitalogic_test_term_meta'] = array();
+$GLOBALS['digitalogic_test_term_queries'] = array();
 $GLOBALS['digitalogic_test_next_term_id'] = 1;
 $GLOBALS['digitalogic_test_update_failures'] = array();
 $GLOBALS['digitalogic_test_meta_update_failures'] = array();
@@ -2033,6 +2034,7 @@ function get_term_by( $field, $value, $taxonomy = '', $output = 'OBJECT', $filte
 }
 
 function get_terms($args = array()) {
+	$GLOBALS['digitalogic_test_term_queries'][] = $args;
 	$terms = array();
 	foreach (($GLOBALS['digitalogic_test_terms'] ?? array()) as $term_id => $term) {
 		$term = is_object($term) ? $term : (object) $term;
@@ -2049,6 +2051,34 @@ function get_terms($args = array()) {
 			$resolved_id = (int) ($term->term_id ?? $term_id);
 			$meta = $GLOBALS['digitalogic_test_term_meta'][$resolved_id][$args['meta_key']] ?? '';
 			if ((string) $meta !== (string) ($args['meta_value'] ?? '')) {
+				continue;
+			}
+		} elseif ( ! empty( $args['meta_query'] ) ) {
+			$resolved_id = (int) ($term->term_id ?? $term_id);
+			$query       = $args['meta_query'];
+			$relation    = isset( $query['relation'] ) ? strtoupper( (string) $query['relation'] ) : 'AND';
+			unset( $query['relation'] );
+			$matches = array();
+			foreach ( $query as $clause ) {
+				if ( ! is_array( $clause ) || ! isset( $clause['key'] ) ) {
+					continue;
+				}
+				$exists = array_key_exists(
+					$clause['key'],
+					$GLOBALS['digitalogic_test_term_meta'][ $resolved_id ] ?? array()
+				);
+				$compare = strtoupper( (string) ( $clause['compare'] ?? '=' ) );
+				if ( 'EXISTS' === $compare ) {
+					$matches[] = $exists;
+					continue;
+				}
+				$value     = $exists
+					? $GLOBALS['digitalogic_test_term_meta'][ $resolved_id ][ $clause['key'] ]
+					: null;
+				$matches[] = $exists && (string) $value === (string) ( $clause['value'] ?? '' );
+			}
+			$matched = 'OR' === $relation ? in_array( true, $matches, true ) : ! in_array( false, $matches, true );
+			if ( ! $matched ) {
 				continue;
 			}
 		}


### PR DESCRIPTION
﻿## Summary
- replace the live-incompatible top-level `meta_key`/`meta_value` term-query shorthand with one shared explicit equality `meta_query`
- restore exact category-code lookup and legacy-slug redirect ownership without widening matching
- extend the term-query test double and assert the production query shape so the regression cannot silently return

## Production evidence
After the approved 30-term neutral-slug migration, direct live readback showed:
- direct term meta for term 497: code `121`, managed `1`, legacy `patris-121`
- top-level term-meta query: 0 matches
- equivalent explicit `meta_query`: 1 exact match
- neutral URL: HTTP 200
- historic URL: HTTP 404 before this fix (expected 301)

## Verification
- PHP syntax checks: pass
- Composer validation/audit: pass, no advisories
- PHPUnit: 374 tests, 2,375 assertions, 1 existing warning, 5 skipped
- focused ProductCategorySlugs + StorefrontCatalog: 13 tests, 44 assertions
- WordPress PHPCS on production class and focused test: pass
- `git diff --check`: pass

Relates to #150. The issue remains open until the packaged production build proves exact old URL -> 301 -> neutral URL and the owner completes final approval.
