### PR TITLE
Release Digitalogic WP 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-07-26
+
+### Fixed
+- Restored exact managed product-category Code lookup and permanent historic
+  slug redirects on WooCommerce installations that inject menu-order term
+  metadata, using explicit term-meta clauses and deterministic term-ID order.
+
 ## [1.7.0] - 2026-07-26
 
 ### Added

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.7.0
+ * Version: 1.7.1
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.7.0' );
+define( 'DIGITALOGIC_VERSION', '1.7.1' );
 define( 'DIGITALOGIC_PBX_SCHEMA_VERSION', '3' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));


### PR DESCRIPTION
﻿## Release
Digitalogic WooCommerce Extension **1.7.1**

## Included
- merged PR #162 exact managed-category term lookup repair
- deterministic WooCommerce-compatible term ordering
- production-tested neutral category migration contract and revisioned Google Sheets category sync

## Verification
- PHP syntax: pass
- Composer validate/audit: pass, no advisories
- PHPUnit: 374 tests, 2,379 assertions, one existing warning, five skipped
- PR #162 CI/package build: all four jobs green
- production dry query with the final lookup shape: 36 managed terms; Code 121 resolves to term 497

After merge, the release workflow must produce both installable ZIP names and `SHA256SUMS`. The exact release artifact will then be deployed with backup and verified by 301/200 public URL probes.

Relates to #150.
