### PR TITLE
Include exact Product Code in batch pricing assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Added the exact Product Code to every successful batch pricing-assignment
+  projection so strict Patris consumers can validate nested assignment identity
+  without an SKU or alternate-identity fallback.
+
 ## [1.7.1] - 2026-07-26
 
 ### Fixed

--- a/docs/PATRIS-PRODUCT-SYNC.md
+++ b/docs/PATRIS-PRODUCT-SYNC.md
@@ -100,4 +100,8 @@ The batch response is exactly:
  default_percentage_markup, results}
 ```
 
-An assignment contains only optional `shipping_method_id`, optional `profit_percent`, required `profit_percent_source`, and required `pricing_warnings`.
+An assignment contains the required exact `code` (identical to its enclosing
+successful result Code), optional `shipping_method_id`, optional
+`profit_percent`, required `profit_percent_source`, and required
+`pricing_warnings`. The nested Code is the normalized Product Code resolved by
+the existing exact Code path; it never falls back to WooCommerce SKU.

--- a/includes/class-shipping-method-service.php
+++ b/includes/class-shipping-method-service.php
@@ -1380,6 +1380,7 @@ final class Digitalogic_Shipping_Method_Service {
 		$markup     = $this->build_exact_markup_contract( $resolved['product_id'], $default_markup );
 
 		$projection = array(
+			'code'                  => $requested_code,
 			'profit_percent_source' => null === $markup['source'] ? 'unavailable' : (string) $markup['source'],
 			'pricing_warnings'      => $markup['warning'] ? array( $markup['warning'] ) : array(),
 		);

--- a/tests/ShippingMethodServiceTest.php
+++ b/tests/ShippingMethodServiceTest.php
@@ -120,13 +120,57 @@ final class ShippingMethodServiceTest extends TestCase {
         );
         $assignment = $batch['results'][0]['assignment'];
         $this->assertSame(
-            array('profit_percent_source', 'pricing_warnings', 'shipping_method_id'),
+            array('code', 'profit_percent_source', 'pricing_warnings', 'shipping_method_id'),
             array_keys($assignment)
         );
+        $this->assertSame($batch['results'][0]['code'], $assignment['code']);
+        $this->assertSame('CODE-501', $assignment['code']);
         $this->assertSame('air_express', $assignment['shipping_method_id']);
         $this->assertArrayNotHasKey('profit_percent', $assignment);
         $this->assertStringNotContainsString('null', json_encode($batch));
     }
+
+	public function test_batch_assignment_code_is_exact_ordered_and_never_falls_back_to_sku(): void {
+		$GLOBALS['digitalogic_test_posts'][503] = array(
+			'post_type'   => 'product',
+			'post_status' => 'publish',
+			'meta'        => array(
+				'_digitalogic_patris_product_code' => 'EXACT-503',
+				'_digitalogic_shipping_method_id'  => 'air_express',
+				'_sku'                             => 'SKU-503',
+			),
+		);
+		$GLOBALS['digitalogic_test_posts'][504] = array(
+			'post_type'   => 'product',
+			'post_status' => 'publish',
+			'meta'        => array(
+				'_digitalogic_patris_product_code' => 'EXACT-504',
+				'_digitalogic_shipping_method_id'  => 'sea_freight',
+			),
+		);
+
+		$batch = $this->service->get_product_assignments_by_codes(
+			array( ' EXACT-504 ', 'EXACT-503', 'SKU-503' )
+		);
+
+		$this->assertSame( 3, $batch['requested_count'] );
+		$this->assertSame( 2, $batch['resolved_count'] );
+		$this->assertSame( 1, $batch['error_count'] );
+		$this->assertSame( array( 'EXACT-504', 'EXACT-503', 'SKU-503' ), array_column( $batch['results'], 'code' ) );
+
+		foreach ( array_slice( $batch['results'], 0, 2 ) as $result ) {
+			$this->assertSame( 'ok', $result['status'] );
+			$this->assertSame( $result['code'], $result['assignment']['code'] );
+			$this->assertSame(
+				array( 'code', 'profit_percent_source', 'pricing_warnings', 'shipping_method_id' ),
+				array_keys( $result['assignment'] )
+			);
+		}
+
+		$this->assertSame( 'error', $batch['results'][2]['status'] );
+		$this->assertSame( 'digitalogic_product_code_not_found', $batch['results'][2]['error']['code'] );
+		$this->assertArrayNotHasKey( 'assignment', $batch['results'][2] );
+	}
 
 	public function test_shipping_compare_and_assign_is_transactional_and_conflict_safe(): void {
 		$GLOBALS['digitalogic_test_posts'][502] = array(


### PR DESCRIPTION
Refs #164. The issue intentionally remains open for explicit owner approval.

## Summary

- adds the normalized exact Product Code to every successful `results[].assignment` projection
- guarantees `assignment.code === result.code` without adding SKU or alternate identity fallback
- preserves the existing sparse assignment shape and leaves typed error rows unchanged
- documents the strict nested identity requirement and records the compatibility fix in the changelog

## Root cause

The v1.7.1 batch endpoint returned the normalized identity only at `results[].code`. Patris validates each successful assignment as a self-contained strict projection, so the missing nested `assignment.code` caused all successful rows to be rejected as `pricing_assignment_batch_contract_invalid`.

## Verification

- `php -l includes/class-shipping-method-service.php`: pass
- `php -l tests/ShippingMethodServiceTest.php`: pass
- focused PHPUnit: 14 tests, 128 assertions, pass
- full PHPUnit: 375 tests, 2,394 assertions, pass (5 environment skips, 1 pre-existing warning)
- PHPCS debt gate: 40,712 errors / 3,012 warnings, within 43,221 / 3,016 baseline
- `composer validate --strict --no-check-publish`: pass
- `composer audit --locked`: no known advisories in the locked set; Packagist refresh timed out and Composer used its local cache
- `git diff --check`: pass

## Scope

No production deployment, release, catalog/content, or UI changes are included.