### PR TITLE
Release Digitalogic 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-07-26
+
 ### Fixed
 - Added the exact Product Code to every successful batch pricing-assignment
   projection so strict Patris consumers can validate nested assignment identity

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.7.1
+ * Version: 1.7.2
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.7.1' );
+define( 'DIGITALOGIC_VERSION', '1.7.2' );
 define( 'DIGITALOGIC_PBX_SCHEMA_VERSION', '3' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));


### PR DESCRIPTION
## Summary
- bump the plugin header and runtime constant to 1.7.2
- publish the exact batch pricing-assignment Product Code fix under the dated 1.7.2 changelog section
- retain an empty Unreleased section for subsequent work

## Impact
The source, tag, generated release notes, and installable package now identify the same 1.7.2 version. Strict Patris consumers receive the previously merged nested `assignment.code` compatibility fix in a durable source-built release.

## Verification
- PHP lint: 124 source files
- PHPUnit: 375 tests, 2394 assertions (1 existing warning, 5 skipped)
- Node/UI/Apps Script: 74 tests
- PBX operations: 25 tests
- Office automation: 19 tests
- SEO monitor: 30 tests
- PHPCS baseline: 40,712 errors / 3,012 warnings, both below baseline
- public-tree policy: passed
- release-note version/changelog validation: passed

Refs #164