### PR TITLE
Fix Excel pricing sync across source revision drift

### DIFF
--- a/docs/EXCEL-PRICING-SYNC.md
+++ b/docs/EXCEL-PRICING-SYNC.md
@@ -12,9 +12,13 @@ The companion calls three POST-only routes:
 
 These routes accept only the existing `X-Patris-Product-Sync-Secret`. The
 secret must have a non-empty exact `{id, dataset}` source scope, and every
-request must repeat the exact current `{id, dataset, revision}` from the
-materialized `patris.product-sync` source. There is no WordPress-session,
-WooCommerce-key, or administrator-capability fallback on this machine surface.
+request must repeat that exact `{id, dataset}` plus a syntactically valid
+`sha256:` revision from the local canonical source. The revision remains bound
+to preview, idempotency, settings metadata, and audit records. A local revision
+that differs from the materialized WordPress product-sync revision is visible
+as a non-blocking Persian warning; it is not an authentication failure. There
+is no WordPress-session, WooCommerce-key, or administrator-capability fallback
+on this machine surface.
 
 ## Ownership
 
@@ -62,6 +66,26 @@ The state data has this stable top-level shape:
   "schema": "digitalogic.excel-pricing-sync-state/v1",
   "state_revision": "sha256:GLOBAL_SETTINGS_REVISION",
   "generated_at": "2026-07-26T12:00:00+00:00",
+  "source": {
+    "id": "configured-source-id",
+    "dataset": "configured-dataset",
+    "submitted_revision": "sha256:LOCAL_SOURCE_REVISION",
+    "current_revision": "sha256:WORDPRESS_SOURCE_REVISION",
+    "revision_matches_current": false
+  },
+  "warnings": [
+    {
+      "code": "source_revision_out_of_sync",
+      "severity": "warning",
+      "message_fa": "نسخهٔ منبع محلی با آخرین نسخهٔ ثبت‌شده در سایت یکسان نیست؛ همگام‌سازی تنظیمات برای همین شناسه و مجموعه ادامه یافت.",
+      "details": {
+        "source_id": "configured-source-id",
+        "dataset": "configured-dataset",
+        "submitted_revision": "sha256:LOCAL_SOURCE_REVISION",
+        "current_revision": "sha256:WORDPRESS_SOURCE_REVISION"
+      }
+    }
+  ],
   "currency": {
     "dollar_price": 170000,
     "yuan_price": 25300,
@@ -122,7 +146,8 @@ Preview returns a server-bound `preview_digest` with a ten-minute expiry.
 Warnings have stable codes, severity, a Persian operator message in
 `message_fa`, and bounded comparison details. A date older than seven days and
 a currency or profit difference above seven percent are surfaced as critical
-warnings.
+warnings. When source revisions differ, `source_revision_out_of_sync` exposes
+both submitted and current revisions without blocking preview.
 
 ## Apply
 
@@ -168,6 +193,13 @@ Preview and apply response data use:
   "mode": "preview",
   "status": "confirmation_required",
   "state_revision": "sha256:GLOBAL_SETTINGS_REVISION",
+  "source": {
+    "id": "configured-source-id",
+    "dataset": "configured-dataset",
+    "submitted_revision": "sha256:LOCAL_SOURCE_REVISION",
+    "current_revision": "sha256:WORDPRESS_SOURCE_REVISION",
+    "revision_matches_current": false
+  },
   "preview_digest": "sha256:PREVIEW_DIGEST",
   "expires_at": "2026-07-26T12:10:00+00:00",
   "warnings": [],

--- a/includes/class-digitalogic-excel-pricing-sync.php
+++ b/includes/class-digitalogic-excel-pricing-sync.php
@@ -129,9 +129,9 @@ final class Digitalogic_Excel_Pricing_Sync {
 			return $payload;
 		}
 
-		$current_source = $this->validate_current_source( $payload['source'] );
-		if ( is_wp_error( $current_source ) ) {
-			return $current_source;
+		$source_context = $this->validate_current_source( $payload['source'] );
+		if ( is_wp_error( $source_context ) ) {
+			return $source_context;
 		}
 
 		$globals = $this->read_globals();
@@ -156,10 +156,18 @@ final class Digitalogic_Excel_Pricing_Sync {
 			return $catalog;
 		}
 
+		$warnings       = array();
+		$source_warning = $this->source_revision_warning( $source_context );
+		if ( null !== $source_warning ) {
+			$warnings[] = $source_warning;
+		}
+
 		return array(
 			'schema'         => self::STATE_SCHEMA,
 			'state_revision' => $globals['state_revision'],
 			'generated_at'   => $this->now_iso8601(),
+			'source'         => $source_context,
+			'warnings'       => $warnings,
 			'currency'       => $globals['currency'],
 			'default_markup' => $globals['default_markup'],
 			'catalog'        => $catalog,
@@ -315,10 +323,10 @@ final class Digitalogic_Excel_Pricing_Sync {
 					return $replayed;
 				}
 
-				$source = $this->validate_current_source( $payload['source'] );
-				if ( is_wp_error( $source ) ) {
+				$source_context = $this->validate_current_source( $payload['source'] );
+				if ( is_wp_error( $source_context ) ) {
 					$this->release_idempotency( 'apply', $headers['idempotency_key'] );
-					return $source;
+					return $source_context;
 				}
 
 				$current = $this->read_globals();
@@ -357,6 +365,7 @@ final class Digitalogic_Excel_Pricing_Sync {
 
 				$result = $this->apply_locked(
 					$payload['source'],
+					$source_context,
 					$headers['idempotency_key'],
 					$headers['expected_state_revision'],
 					$settings,
@@ -399,9 +408,9 @@ final class Digitalogic_Excel_Pricing_Sync {
 	 * @return array|WP_Error
 	 */
 	private function build_preview( $source, $expected_state_revision, $settings ) {
-		$current_source = $this->validate_current_source( $source );
-		if ( is_wp_error( $current_source ) ) {
-			return $current_source;
+		$source_context = $this->validate_current_source( $source );
+		if ( is_wp_error( $source_context ) ) {
+			return $source_context;
 		}
 
 		$current = $this->read_globals();
@@ -412,7 +421,11 @@ final class Digitalogic_Excel_Pricing_Sync {
 			return $this->revision_conflict( $current['state_revision'] );
 		}
 
-		$warnings = $this->comparison_warnings( $current, $settings );
+		$warnings       = $this->comparison_warnings( $current, $settings );
+		$source_warning = $this->source_revision_warning( $source_context );
+		if ( null !== $source_warning ) {
+			array_unshift( $warnings, $source_warning );
+		}
 		$expires  = time() + self::PREVIEW_TTL_SECONDS;
 		$identity = array(
 			'schema'                  => self::PREVIEW_SCHEMA,
@@ -448,6 +461,7 @@ final class Digitalogic_Excel_Pricing_Sync {
 			'mode'            => 'preview',
 			'status'          => empty( $warnings ) ? 'ready' : 'confirmation_required',
 			'state_revision'  => $current['state_revision'],
+			'source'          => $source_context,
 			'preview_digest'  => $digest,
 			'expires_at'      => gmdate( 'c', $expires ),
 			'warnings'        => $warnings,
@@ -459,6 +473,7 @@ final class Digitalogic_Excel_Pricing_Sync {
 	 * Apply settings under the synchronization lock.
 	 *
 	 * @param array  $source                    Exact current source.
+	 * @param array  $source_context             Submitted/current source revisions.
 	 * @param string $idempotency_key           Apply idempotency key.
 	 * @param string $expected_state_revision   Expected settings revision.
 	 * @param array  $settings                  Canonical settings.
@@ -466,7 +481,7 @@ final class Digitalogic_Excel_Pricing_Sync {
 	 * @param array  $preview                   Stored preview.
 	 * @return array|WP_Error
 	 */
-	private function apply_locked( $source, $idempotency_key, $expected_state_revision, $settings, $preview_digest, $preview ) {
+	private function apply_locked( $source, $source_context, $idempotency_key, $expected_state_revision, $settings, $preview_digest, $preview ) {
 		$current = $this->read_globals();
 		if ( is_wp_error( $current ) ) {
 			return $current;
@@ -477,7 +492,7 @@ final class Digitalogic_Excel_Pricing_Sync {
 
 		if ( $changed ) {
 			$result = $this->run_transaction(
-				function () use ( $source, $idempotency_key, $expected_state_revision, $settings, $preview_digest, $desired ) {
+				function () use ( $source, $source_context, $idempotency_key, $expected_state_revision, $settings, $preview_digest, $desired ) {
 					foreach (
 						array(
 							'dollar_price',
@@ -512,6 +527,7 @@ final class Digitalogic_Excel_Pricing_Sync {
 
 					$audit = $this->append_audit_entry(
 						$source,
+						$source_context,
 						$idempotency_key,
 						$preview_digest,
 						$locked_current,
@@ -550,9 +566,22 @@ final class Digitalogic_Excel_Pricing_Sync {
 			$readback = $current;
 		}
 
-		$warnings   = isset( $preview['warnings'] ) && is_array( $preview['warnings'] )
+		$warnings       = isset( $preview['warnings'] ) && is_array( $preview['warnings'] )
 			? array_values( $preview['warnings'] )
 			: array();
+		$warnings       = array_values(
+			array_filter(
+				$warnings,
+				static function ( $warning ) {
+					return ! is_array( $warning )
+						|| 'source_revision_out_of_sync' !== ( $warning['code'] ?? '' );
+				}
+			)
+		);
+		$source_warning = $this->source_revision_warning( $source_context );
+		if ( null !== $source_warning ) {
+			array_unshift( $warnings, $source_warning );
+		}
 		$warnings[] = $this->warning(
 			'patris_regeneration_required',
 			'تنظیمات سراسری تأیید شد؛ companion باید قیمت‌های مشتق‌شده را بازتولید و ارسال کند.',
@@ -564,6 +593,7 @@ final class Digitalogic_Excel_Pricing_Sync {
 			'mode'            => 'apply',
 			'status'          => $changed ? 'applied' : 'unchanged',
 			'state_revision'  => $readback['state_revision'],
+			'source'          => $source_context,
 			'preview_digest'  => $preview_digest,
 			'expires_at'      => gmdate( 'c', (int) $preview['expires_at'] ),
 			'warnings'        => $warnings,
@@ -765,7 +795,12 @@ final class Digitalogic_Excel_Pricing_Sync {
 	}
 
 	/**
-	 * Require the exact source revision currently materialized in WordPress.
+	 * Require the exact configured source identity materialized in WordPress.
+	 *
+	 * A valid submitted revision remains part of request, preview, idempotency,
+	 * settings, and audit identities. It may be newer than the product-sync
+	 * revision currently stored by WordPress, so revision drift is returned as
+	 * non-blocking response metadata instead of an authorization failure.
 	 *
 	 * @param array $source Requested source.
 	 * @return array|WP_Error
@@ -784,11 +819,11 @@ final class Digitalogic_Excel_Pricing_Sync {
 			|| ! is_string( $current['revision'] )
 			|| ! hash_equals( $current['id'], $source['id'] )
 			|| ! hash_equals( $current['dataset'], $source['dataset'] )
-			|| ! hash_equals( $current['revision'], $source['revision'] )
+			|| ! $this->is_revision( $current['revision'] )
 		) {
 			return $this->error(
-				'digitalogic_excel_sync_source_revision_conflict',
-				'revision منبع محلی با آخرین منبع ثبت‌شده در سایت یکسان نیست.',
+				'digitalogic_excel_sync_source_scope_conflict',
+				'شناسه یا مجموعهٔ منبع محلی با منبع ثبت‌شده در سایت یکسان نیست.',
 				409,
 				array(
 					'current_source' => array(
@@ -800,7 +835,38 @@ final class Digitalogic_Excel_Pricing_Sync {
 			);
 		}
 
-		return $current;
+		return array(
+			'id'                       => $source['id'],
+			'dataset'                  => $source['dataset'],
+			'submitted_revision'       => $source['revision'],
+			'current_revision'         => $current['revision'],
+			'revision_matches_current' => hash_equals( $current['revision'], $source['revision'] ),
+		);
+	}
+
+	/**
+	 * Return a Persian operator warning when the valid submitted revision is
+	 * not yet materialized by the WordPress product-sync receiver.
+	 *
+	 * @param array $source_context Submitted/current source metadata.
+	 * @return array|null
+	 */
+	private function source_revision_warning( $source_context ) {
+		if ( ! empty( $source_context['revision_matches_current'] ) ) {
+			return null;
+		}
+
+		return $this->warning(
+			'source_revision_out_of_sync',
+			'نسخهٔ منبع محلی با آخرین نسخهٔ ثبت‌شده در سایت یکسان نیست؛ همگام‌سازی تنظیمات برای همین شناسه و مجموعه ادامه یافت.',
+			'warning',
+			array(
+				'source_id'          => $source_context['id'],
+				'dataset'            => $source_context['dataset'],
+				'submitted_revision' => $source_context['submitted_revision'],
+				'current_revision'   => $source_context['current_revision'],
+			)
+		);
 	}
 
 	/**
@@ -1298,6 +1364,7 @@ final class Digitalogic_Excel_Pricing_Sync {
 	 * Append a bounded nonsecret audit entry inside the write transaction.
 	 *
 	 * @param array  $source          Exact source.
+	 * @param array  $source_context   Submitted/current source revisions.
 	 * @param string $idempotency_key Apply idempotency key.
 	 * @param string $preview_digest  Preview digest.
 	 * @param array  $before          Previous globals.
@@ -1305,17 +1372,18 @@ final class Digitalogic_Excel_Pricing_Sync {
 	 * @param array  $settings        Applied settings.
 	 * @return true|WP_Error
 	 */
-	private function append_audit_entry( $source, $idempotency_key, $preview_digest, $before, $after, $settings ) {
+	private function append_audit_entry( $source, $source_context, $idempotency_key, $preview_digest, $before, $after, $settings ) {
 		$row       = $this->read_option_db( self::AUDIT_OPTION, true );
 		$entries   = $row['exists'] && is_array( $row['value'] ) ? array_values( $row['value'] ) : array();
 		$entries[] = array(
-			'applied_at'        => current_time( 'mysql', true ),
-			'source'            => $source,
-			'idempotency_key'   => $idempotency_key,
-			'preview_digest'    => $preview_digest,
-			'previous_revision' => $before['state_revision'],
-			'state_revision'    => $after['state_revision'],
-			'settings'          => $settings,
+			'applied_at'              => current_time( 'mysql', true ),
+			'source'                  => $source,
+			'source_revision_context' => $source_context,
+			'idempotency_key'         => $idempotency_key,
+			'preview_digest'          => $preview_digest,
+			'previous_revision'       => $before['state_revision'],
+			'state_revision'          => $after['state_revision'],
+			'settings'                => $settings,
 		);
 		$entries   = array_slice( $entries, -self::MAX_AUDIT_ENTRIES );
 

--- a/tests/ExcelPricingSyncTest.php
+++ b/tests/ExcelPricingSyncTest.php
@@ -152,11 +152,22 @@ final class ExcelPricingSyncTest extends TestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$state = $response->get_data();
 		$this->assertSame(
-			array( 'schema', 'state_revision', 'generated_at', 'currency', 'default_markup', 'catalog' ),
+			array( 'schema', 'state_revision', 'generated_at', 'source', 'warnings', 'currency', 'default_markup', 'catalog' ),
 			array_keys( $state )
 		);
 		$this->assertSame( Digitalogic_Excel_Pricing_Sync::STATE_SCHEMA, $state['schema'] );
 		$this->assertStringStartsWith( 'sha256:', $state['state_revision'] );
+		$this->assertSame(
+			array(
+				'id'                       => $this->source['id'],
+				'dataset'                  => $this->source['dataset'],
+				'submitted_revision'       => $this->source['revision'],
+				'current_revision'         => $this->source['revision'],
+				'revision_matches_current' => true,
+			),
+			$state['source']
+		);
+		$this->assertSame( array(), $state['warnings'] );
 		$this->assertSame(
 			array( 'dollar_price', 'yuan_price', 'effective_date', 'revision', 'age_days', 'stale' ),
 			array_keys( $state['currency'] )
@@ -172,6 +183,157 @@ final class ExcelPricingSyncTest extends TestCase {
 		$this->assertSame( 25, $state['catalog']['pagination']['limit'] );
 		$this->assertNotEmpty( $state['catalog']['columns'] );
 		$this->assertMatchesRegularExpression( '/[^\x00-\x7F]/', $state['catalog']['columns'][0]['header'] );
+	}
+
+	/**
+	 * A newer valid local revision remains visible and non-blocking throughout
+	 * state, preview, apply, settings metadata, and the bounded audit record.
+	 */
+	public function test_source_revision_drift_is_visible_but_non_blocking_for_full_flow(): void {
+		$submitted_source             = $this->source;
+		$submitted_source['revision'] = 'sha256:' . str_repeat( 'b', 64 );
+
+		$state = Digitalogic_Excel_Pricing_Sync::instance()->state(
+			$this->request(
+				'state',
+				array( 'source' => $submitted_source )
+			)
+		);
+		$this->assertFalse( is_wp_error( $state ) );
+		$this->assert_source_revision_drift( $state, $submitted_source );
+
+		$settings = $this->proposed_settings();
+		$preview  = Digitalogic_Excel_Pricing_Sync::instance()->preview(
+			$this->mutation_request(
+				'preview',
+				'excel-preview-drift-0001',
+				$state['state_revision'],
+				$settings,
+				array( 'source' => $submitted_source )
+			)
+		);
+		$this->assertFalse( is_wp_error( $preview ) );
+		$this->assert_source_revision_drift( $preview, $submitted_source );
+
+		$applied = Digitalogic_Excel_Pricing_Sync::instance()->apply(
+			$this->mutation_request(
+				'apply',
+				'excel-apply-drift-000001',
+				$state['state_revision'],
+				$settings,
+				array(
+					'source'         => $submitted_source,
+					'preview_digest' => $preview['preview_digest'],
+					'confirmation'   => 'APPLY',
+				)
+			)
+		);
+		$this->assertFalse( is_wp_error( $applied ) );
+		$this->assertSame( 'applied', $applied['status'] );
+		$this->assert_source_revision_drift( $applied, $submitted_source );
+		$this->assertSame(
+			$submitted_source,
+			$GLOBALS['digitalogic_test_options'][ Digitalogic_Excel_Pricing_Sync::SETTINGS_OPTION ]['source']
+		);
+
+		$audit = $GLOBALS['digitalogic_test_options'][ Digitalogic_Excel_Pricing_Sync::AUDIT_OPTION ];
+		$this->assertCount( 1, $audit );
+		$this->assertSame( $submitted_source, $audit[0]['source'] );
+		$this->assertSame( $applied['source'], $audit[0]['source_revision_context'] );
+	}
+
+	/**
+	 * Revision tolerance must never widen the configured source ID/dataset.
+	 */
+	public function test_wrong_source_id_or_dataset_remains_rejected(): void {
+		$wrong_sources = array(
+			array_merge( $this->source, array( 'id' => 'wrong-source' ) ),
+			array_merge( $this->source, array( 'dataset' => 'wrong-dataset' ) ),
+		);
+
+		foreach ( $wrong_sources as $wrong_source ) {
+			$result = Digitalogic_Excel_Pricing_Sync::instance()->state(
+				$this->request(
+					'state',
+					array( 'source' => $wrong_source )
+				)
+			);
+
+			$this->assertSame( 'digitalogic_excel_sync_source_scope_conflict', $result->get_error_code() );
+			$this->assertSame( 409, $result->get_error_data()['status'] );
+		}
+	}
+
+	/**
+	 * Revision tolerance does not weaken transport, idempotency, or preview
+	 * binding: every submitted revision remains part of those identities.
+	 */
+	public function test_revision_drift_keeps_mutation_guards_strict(): void {
+		$state    = $this->state_data();
+		$settings = $this->proposed_settings();
+		$source_b = array_merge(
+			$this->source,
+			array( 'revision' => 'sha256:' . str_repeat( 'b', 64 ) )
+		);
+		$source_c = array_merge(
+			$this->source,
+			array( 'revision' => 'sha256:' . str_repeat( 'c', 64 ) )
+		);
+
+		$if_match = Digitalogic_Excel_Pricing_Sync::instance()->preview(
+			$this->request(
+				'preview',
+				array(
+					'source'                  => $source_b,
+					'idempotency_key'         => 'excel-preview-guard-0001',
+					'expected_state_revision' => $state['state_revision'],
+					'settings'                => $settings,
+					'product_changes'         => array(),
+				),
+				array(
+					'Idempotency-Key' => 'excel-preview-guard-0001',
+					'If-Match'        => '"sha256:' . str_repeat( 'f', 64 ) . '"',
+				)
+			)
+		);
+		$this->assertSame( 'digitalogic_excel_sync_if_match_mismatch', $if_match->get_error_code() );
+
+		$preview = Digitalogic_Excel_Pricing_Sync::instance()->preview(
+			$this->mutation_request(
+				'preview',
+				'excel-preview-guard-0002',
+				$state['state_revision'],
+				$settings,
+				array( 'source' => $source_b )
+			)
+		);
+		$this->assertFalse( is_wp_error( $preview ) );
+
+		$reused = Digitalogic_Excel_Pricing_Sync::instance()->preview(
+			$this->mutation_request(
+				'preview',
+				'excel-preview-guard-0002',
+				$state['state_revision'],
+				$settings,
+				array( 'source' => $source_c )
+			)
+		);
+		$this->assertSame( 'digitalogic_excel_sync_idempotency_reused', $reused->get_error_code() );
+
+		$mismatched_preview = Digitalogic_Excel_Pricing_Sync::instance()->apply(
+			$this->mutation_request(
+				'apply',
+				'excel-apply-guard-000001',
+				$state['state_revision'],
+				$settings,
+				array(
+					'source'         => $source_c,
+					'preview_digest' => $preview['preview_digest'],
+					'confirmation'   => 'APPLY',
+				)
+			)
+		);
+		$this->assertSame( 'digitalogic_excel_sync_preview_mismatch', $mismatched_preview->get_error_code() );
 	}
 
 	/**
@@ -415,6 +577,36 @@ final class ExcelPricingSyncTest extends TestCase {
 				'If-Match'        => '"' . $revision . '"',
 			)
 		);
+	}
+
+	/**
+	 * Assert additive source metadata and its Persian non-blocking warning.
+	 *
+	 * @param array $response         Successful sync response.
+	 * @param array $submitted_source Submitted source identity.
+	 * @return void
+	 */
+	private function assert_source_revision_drift( $response, $submitted_source ) {
+		$this->assertSame( $submitted_source['id'], $response['source']['id'] );
+		$this->assertSame( $submitted_source['dataset'], $response['source']['dataset'] );
+		$this->assertSame( $submitted_source['revision'], $response['source']['submitted_revision'] );
+		$this->assertSame( $this->source['revision'], $response['source']['current_revision'] );
+		$this->assertFalse( $response['source']['revision_matches_current'] );
+
+		$warnings = array_values(
+			array_filter(
+				$response['warnings'],
+				static function ( $warning ) {
+					return is_array( $warning )
+						&& 'source_revision_out_of_sync' === ( $warning['code'] ?? '' );
+				}
+			)
+		);
+		$this->assertCount( 1, $warnings );
+		$this->assertSame( 'warning', $warnings[0]['severity'] );
+		$this->assertMatchesRegularExpression( '/[^\x00-\x7F]/', $warnings[0]['message_fa'] );
+		$this->assertSame( $submitted_source['revision'], $warnings[0]['details']['submitted_revision'] );
+		$this->assertSame( $this->source['revision'], $warnings[0]['details']['current_revision'] );
 	}
 
 	/**


### PR DESCRIPTION
## What changed

- keep the Excel pricing-sync machine surface scoped to the exact configured Patris source ID and dataset;
- treat a syntactically valid but different product-source revision as non-blocking metadata;
- return submitted/current source revisions and a fully Persian warning when they differ;
- retain strict pricing `state_revision` / `If-Match`, idempotency, preview-digest, and explicit apply confirmation controls;
- preserve both the submitted source and current source-revision context in the bounded audit record.

## Why

The canonical product revision includes live pricing-enrichment and cache diagnostics. A cold, partial, stale, or warm cache can therefore change that revision even though the workbook is still authorized for the same exact source and dataset. The previous equality gate incorrectly blocked credential-free Excel synchronization with HTTP 409.

Product-sync receiver semantics are unchanged. Product writes remain forbidden on this route, and pricing mutations remain protected by their own optimistic-concurrency and confirmation controls.

## Validation

- focused `ExcelPricingSyncTest`: 10 tests, 114 assertions;
- full PHPUnit: 378 tests, 2,443 assertions (one pre-existing warning and five skips);
- PHP syntax checks;
- scoped WordPress PHPCS;
- `git diff --check`;
- production readback: same source/dataset with a different valid revision returned HTTP 200 and the Persian `source_revision_out_of_sync` warning.

Closes no issue automatically. References #166.

Status: pending owner approval.
