### PR TITLE
Release Digitalogic 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.3] - 2026-07-26
+
+### Fixed
+- Kept guarded Excel pricing synchronization scoped to the exact configured
+  source and dataset while treating a valid newer local source revision as
+  non-blocking, fully Persian warning metadata without weakening state,
+  idempotency, preview-digest, or explicit apply-confirmation controls.
+
 ## [1.7.2] - 2026-07-26
 
 ### Fixed

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.7.2
+ * Version: 1.7.3
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.7.2' );
+define( 'DIGITALOGIC_VERSION', '1.7.3' );
 define( 'DIGITALOGIC_PBX_SCHEMA_VERSION', '3' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');
 define('DIGITALOGIC_PLUGIN_DIR', plugin_dir_path(__FILE__));


### PR DESCRIPTION
## Summary
- bump the plugin header and runtime constant to 1.7.3
- publish the merged Excel source-revision drift fix under a dated changelog section
- retain an empty Unreleased section

## Impact
The guarded Excel pricing-sync API remains bound to the configured source ID and dataset while a valid newer local source revision is surfaced as a non-blocking Persian warning. The release preserves state revision, idempotency, preview-digest, and explicit apply-confirmation controls.

## Verification
- PR #168: all PHP 8.3, security, quality, and deterministic package checks passed
- focused ExcelPricingSyncTest: 10 tests / 114 assertions
- full PHPUnit: 378 tests / 2,443 assertions (one existing warning, five skips)
- local PHP syntax and release-note/changelog validation passed
- merged source file hash matches the current production hotfix

Refs #166