### PR TITLE
Normalize bare 989 caller IDs

### DIFF
--- a/ops/pbx/DEPLOYMENT.md
+++ b/ops/pbx/DEPLOYMENT.md
@@ -77,12 +77,13 @@ Both the `s` and `_X.` routes must contain only their existing inbound `NoOp`, t
 Remove the former `digitalogic-call-verification-menu`, public digit 2, pending
 lookup, and conditional shortcut from those public priorities completely.
 
-Inside the existing `[prefix-tci-callerid]` subroutine, normalize `00989…` first
-and `0989…` second, replacing either prefix with `09`. Then strip `021` from a
-same-city Tehran landline. Only after those transformations may the existing
-internal callback access prefix `9` be added. For example, `02166754123` becomes
-`966754123`; the outbound `_9X.` route removes the access digit and sends
-`66754123`. Non-Tehran landline prefixes remain intact.
+Inside the existing `[prefix-tci-callerid]` subroutine, normalize `00989…` first,
+`0989…` second, and bare `989…` third, replacing each prefix with `09`. Then strip
+`021` from a same-city Tehran landline. Only after those transformations may the
+existing internal callback access prefix `9` be added. For example,
+`989123456789` becomes `909123456789`, and `02166754123` becomes `966754123`;
+the outbound `_9X.` route removes the access digit. Non-Tehran landline prefixes
+remain intact.
 
 Do not add a public fallback digit. The private `verify` context is intentionally
 unrouted until a separate Digitalogic IVR is designed and approved.
@@ -107,8 +108,9 @@ Use real PSTN ANI and redacted evidence:
   the verification HTTP endpoint and AGI and rings extension 101 immediately.
 - Asterisk shows the paired TCI and `PJSIP/101` channels, with no verification
   audio, early `Answer()`, prompt, or DTMF collection.
-- `0989123456789` and `00989123456789` both normalize to `09123456789` before
-  the internal callback access prefix is added; an existing `09…` ANI is unchanged.
+- `989123456789`, `0989123456789`, and `00989123456789` all normalize to
+  `09123456789` before the internal callback access prefix is added; an existing
+  `09…` ANI is unchanged.
 - `02166754123` becomes extension caller ID `966754123`; one-touch redial sends
   the same-city subscriber number `66754123` without the `021` prefix.
 - Both s and _X inbound paths behave identically.

--- a/ops/pbx/README.md
+++ b/ops/pbx/README.md
@@ -6,9 +6,9 @@ the current production DID bypasses every verification helper and rings extensio
 101 directly. The helper and its BGM-mixed prompts remain installed but dormant
 for the next, separately approved IVR pass. No public verification digit exists.
 Before the existing internal callback prefix is added, inbound caller IDs beginning
-with `0989` or `00989` are canonicalized to the Iranian local `09` form. Tehran
-landlines also lose the same-city `021` prefix, so extension redial uses a number
-the TCI trunk accepts.
+with `989`, `0989`, or `00989` are canonicalized to the Iranian local `09` form.
+Tehran landlines also lose the same-city `021` prefix, so extension redial uses a
+number the TCI trunk accepts.
 
 The dormant wrapper forwards one reviewed mode to the helper:
 

--- a/ops/pbx/asterisk/digitalogic-pending-shortcut.conf
+++ b/ops/pbx/asterisk/digitalogic-pending-shortcut.conf
@@ -10,15 +10,16 @@
 ; IVR pass can enable verification deliberately without recovering old code. They
 ; MUST NOT be merged into the current [from-tci] priorities.
 ;
-; In the existing [prefix-tci-callerid] context, normalize the two TCI variants
+; In the existing [prefix-tci-callerid] context, normalize the TCI variants
 ; immediately before adding the internal callback access prefix:
 ;
 ;   same => n,ExecIf($["${CALLERID(num):0:5}"="00989"]?Set(CALLERID(num)=09${CALLERID(num):5}))
 ;   same => n,ExecIf($["${CALLERID(num):0:4}"="0989"]?Set(CALLERID(num)=09${CALLERID(num):4}))
+;   same => n,ExecIf($["${CALLERID(num):0:3}"="989"]?Set(CALLERID(num)=09${CALLERID(num):3}))
 ;   same => n,ExecIf($["${CALLERID(num):0:3}"="021"]?Set(CALLERID(num)=${CALLERID(num):3}))
 ;   same => n,ExecIf($["${CALLERID(num)}"!=""]?Set(CALLERID(num)=9${CALLERID(num)}))
 ;
-; This maps 0989XXXXXXXXX and 00989XXXXXXXXX to the same canonical
+; This maps 989XXXXXXXXX, 0989XXXXXXXXX, and 00989XXXXXXXXX to the same canonical
 ; 09XXXXXXXXX number. A same-city Tehran landline loses its 021 trunk prefix
 ; before the existing callback access prefix is added; other caller IDs pass
 ; through unchanged.

--- a/ops/pbx/test/pbx-assets.test.js
+++ b/ops/pbx/test/pbx-assets.test.js
@@ -27,17 +27,21 @@ test('TCI caller IDs normalize and strip local 021 before callback prefixing', (
 	const dialplan = read('asterisk/digitalogic-pending-shortcut.conf');
 	const from00989 = '${CALLERID(num):0:5}"="00989';
 	const from0989 = '${CALLERID(num):0:4}"="0989';
+	const from989 = '${CALLERID(num):0:3}"="989';
 	const local021 = '${CALLERID(num):0:3}"="021';
 	const callbackPrefix = 'Set(CALLERID(num)=9${CALLERID(num)})';
 	assert.notEqual(dialplan.indexOf(from00989), -1);
 	assert.notEqual(dialplan.indexOf(from0989), -1);
+	assert.notEqual(dialplan.indexOf(from989), -1);
 	assert.notEqual(dialplan.indexOf(local021), -1);
 	assert.notEqual(dialplan.indexOf(callbackPrefix), -1);
 	assert.ok(dialplan.indexOf(from00989) < dialplan.indexOf(from0989));
-	assert.ok(dialplan.indexOf(from0989) < dialplan.indexOf(local021));
+	assert.ok(dialplan.indexOf(from0989) < dialplan.indexOf(from989));
+	assert.ok(dialplan.indexOf(from989) < dialplan.indexOf(local021));
 	assert.ok(dialplan.indexOf(local021) < dialplan.indexOf(callbackPrefix));
 	assert.match(dialplan, /00989[^\n]+CALLERID\(num\)=09\$\{CALLERID\(num\):5\}/);
 	assert.match(dialplan, /0989[^\n]+CALLERID\(num\)=09\$\{CALLERID\(num\):4\}/);
+	assert.match(dialplan, /989[^\n]+CALLERID\(num\)=09\$\{CALLERID\(num\):3\}/);
 
 	const callbackNumber = (number) => {
 		if (number.startsWith('00989')) {
@@ -46,6 +50,9 @@ test('TCI caller IDs normalize and strip local 021 before callback prefixing', (
 		if (number.startsWith('0989')) {
 			number = `09${number.slice(4)}`;
 		}
+		if (number.startsWith('989')) {
+			number = `09${number.slice(3)}`;
+		}
 		if (number.startsWith('021')) {
 			number = number.slice(3);
 		}
@@ -53,6 +60,7 @@ test('TCI caller IDs normalize and strip local 021 before callback prefixing', (
 	};
 	assert.equal(callbackNumber('0989123456789'), '909123456789');
 	assert.equal(callbackNumber('00989123456789'), '909123456789');
+	assert.equal(callbackNumber('989123456789'), '909123456789');
 	assert.equal(callbackNumber('09123456789'), '909123456789');
 	assert.equal(callbackNumber('02166754123'), '966754123');
 	assert.equal(callbackNumber('02612345678'), '902612345678');


### PR DESCRIPTION
## What changed

- normalize bare 989... TCI caller IDs to local 