### PR TITLE
Reduce Excel live-pricing sync round trips

### DIFF
--- a/includes/class-digitalogic-excel-pricing-sync.php
+++ b/includes/class-digitalogic-excel-pricing-sync.php
@@ -29,7 +29,7 @@ final class Digitalogic_Excel_Pricing_Sync {
 	private const PREVIEW_TTL_SECONDS       = 600;
 	private const APPLY_IDEMPOTENCY_SECONDS = 86400;
 	private const MAX_AUDIT_ENTRIES         = 50;
-	private const MAX_PAGE_SIZE             = 100;
+	private const MAX_PAGE_SIZE             = 500;
 	private const MAX_RATE                  = 1000000000;
 	private const MAX_PROFIT_PERCENT        = '1000';
 	private const MAX_PROFIT_SCALE          = 12;

--- a/includes/class-digitalogic-excel-pricing-sync.php
+++ b/includes/class-digitalogic-excel-pricing-sync.php
@@ -29,7 +29,6 @@ final class Digitalogic_Excel_Pricing_Sync {
 	private const PREVIEW_TTL_SECONDS       = 600;
 	private const APPLY_IDEMPOTENCY_SECONDS = 86400;
 	private const MAX_AUDIT_ENTRIES         = 50;
-	private const MAX_PAGE_SIZE             = 500;
 	private const MAX_RATE                  = 1000000000;
 	private const MAX_PROFIT_PERCENT        = '1000';
 	private const MAX_PROFIT_SCALE          = 12;
@@ -140,9 +139,9 @@ final class Digitalogic_Excel_Pricing_Sync {
 		}
 
 		$page  = isset( $payload['page'] ) ? absint( $payload['page'] ) : 1;
-		$limit = isset( $payload['limit'] ) ? absint( $payload['limit'] ) : self::MAX_PAGE_SIZE;
+		$limit = isset( $payload['limit'] ) ? absint( $payload['limit'] ) : Digitalogic_Google_Sheets_Catalog::MAX_PAGE_SIZE;
 		$page  = max( 1, $page );
-		$limit = max( 1, min( self::MAX_PAGE_SIZE, $limit ) );
+		$limit = max( 1, min( Digitalogic_Google_Sheets_Catalog::MAX_PAGE_SIZE, $limit ) );
 
 		$catalog = Digitalogic_Google_Sheets_Catalog::instance()->get_page(
 			array(

--- a/includes/class-digitalogic-google-sheets-catalog.php
+++ b/includes/class-digitalogic-google-sheets-catalog.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class Digitalogic_Google_Sheets_Catalog {
 
-	public const MAX_PAGE_SIZE = 100;
+	public const MAX_PAGE_SIZE            = 500;
+	private const PRODUCT_QUERY_PAGE_SIZE = 100;
 
 	/**
 	 * Shared instance.
@@ -290,29 +291,59 @@ final class Digitalogic_Google_Sheets_Catalog {
 	 * @return array|WP_Error
 	 */
 	private function get_products_page( $args ) {
-		$result     = Digitalogic_Product_Manager::instance()->query_products(
-			array(
-				'page'  => $args['page'],
-				'limit' => $args['limit'],
-				'sorts' => array(
-					array(
-						'field'     => 'id',
-						'direction' => 'asc',
+		$offset            = ( $args['page'] - 1 ) * $args['limit'];
+		$query_page        = (int) floor( $offset / self::PRODUCT_QUERY_PAGE_SIZE ) + 1;
+		$first_page_offset = $offset % self::PRODUCT_QUERY_PAGE_SIZE;
+		$products          = array();
+		$total             = 0;
+		$query_pages       = 0;
+		$product_count     = 0;
+
+		while ( $product_count < $args['limit'] ) {
+			$result = Digitalogic_Product_Manager::instance()->query_products(
+				array(
+					'page'  => $query_page,
+					'limit' => self::PRODUCT_QUERY_PAGE_SIZE,
+					'sorts' => array(
+						array(
+							'field'     => 'id',
+							'direction' => 'asc',
+						),
 					),
-				),
-			)
-		);
-		$projection = $this->transform_products( $result['products'] ?? array() );
+				)
+			);
+			if ( 0 === $query_pages ) {
+				$total       = absint( $result['recordsFiltered'] ?? 0 );
+				$query_pages = absint( $result['pages'] ?? 0 );
+			}
+
+			$page_products = array_values( (array) ( $result['products'] ?? array() ) );
+			if ( $first_page_offset > 0 ) {
+				$page_products     = array_slice( $page_products, $first_page_offset );
+				$first_page_offset = 0;
+			}
+			$remaining     = $args['limit'] - count( $products );
+			$products      = array_merge( $products, array_slice( $page_products, 0, $remaining ) );
+			$product_count = count( $products );
+
+			if ( ! $page_products || $query_page >= $query_pages ) {
+				break;
+			}
+			++$query_page;
+		}
+
+		$projection = $this->transform_products( $products );
 		if ( is_wp_error( $projection ) ) {
 			return $projection;
 		}
+		$pages = $args['limit'] > 0 ? (int) ceil( $total / $args['limit'] ) : 0;
 
 		return $this->response_envelope(
 			$args,
 			$projection['columns'],
 			$projection['rows'],
-			absint( $result['recordsFiltered'] ?? 0 ),
-			absint( $result['pages'] ?? 0 )
+			$total,
+			$pages
 		);
 	}
 

--- a/tests/ExcelPricingSyncTest.php
+++ b/tests/ExcelPricingSyncTest.php
@@ -143,7 +143,7 @@ final class ExcelPricingSyncTest extends TestCase {
 			'state',
 			array(
 				'page'   => 1,
-				'limit'  => 25,
+				'limit'  => 500,
 				'locale' => 'fa',
 			)
 		);
@@ -180,7 +180,7 @@ final class ExcelPricingSyncTest extends TestCase {
 		$this->assertSame( '30', $state['default_markup']['profit_percent'] );
 		$this->assertSame( 'products', $state['catalog']['dataset'] );
 		$this->assertSame( 'fa', $state['catalog']['locale'] );
-		$this->assertSame( 25, $state['catalog']['pagination']['limit'] );
+		$this->assertSame( 500, $state['catalog']['pagination']['limit'] );
 		$this->assertNotEmpty( $state['catalog']['columns'] );
 		$this->assertMatchesRegularExpression( '/[^\x00-\x7F]/', $state['catalog']['columns'][0]['header'] );
 	}

--- a/tests/GoogleSheetsCatalogTest.php
+++ b/tests/GoogleSheetsCatalogTest.php
@@ -37,6 +37,8 @@ final class GoogleSheetsCatalogTest extends TestCase {
 		$GLOBALS['digitalogic_test_meta_update_failures'] = array();
 		$GLOBALS['digitalogic_test_meta_delete_failures'] = array();
 		$GLOBALS['digitalogic_test_transaction_failures'] = array();
+		$GLOBALS['digitalogic_test_wp_query_results']     = array();
+		$GLOBALS['digitalogic_test_wp_query_args']        = array();
 		$GLOBALS['digitalogic_test_wc_currency']          = 'IRT';
 		$GLOBALS['wpdb']                                  = new Digitalogic_Test_WPDB();
 		$this->reset_singleton( Digitalogic_Shipping_Method_Service::class );
@@ -46,14 +48,7 @@ final class GoogleSheetsCatalogTest extends TestCase {
 
 	/** A 500-row catalog page is assembled through bounded 100-row DB queries. */
 	public function test_large_catalog_page_uses_bounded_internal_query_windows() {
-		for ( $product_id = 1; $product_id <= 150; ++$product_id ) {
-			$GLOBALS['digitalogic_test_posts'][ $product_id ] = array(
-				'post_type'   => 'product',
-				'post_status' => 'publish',
-				'post_title'  => 'Catalog product ' . $product_id,
-				'meta'        => array(),
-			);
-		}
+		$this->seed_catalog_products( 1, 150 );
 		$GLOBALS['digitalogic_test_wp_query_results'] = array(
 			array(
 				'posts'       => range( 1, 100 ),
@@ -64,7 +59,6 @@ final class GoogleSheetsCatalogTest extends TestCase {
 				'found_posts' => 150,
 			),
 		);
-		$GLOBALS['digitalogic_test_wp_query_args']    = array();
 
 		$result = $this->catalog->get_page(
 			array(
@@ -86,6 +80,48 @@ final class GoogleSheetsCatalogTest extends TestCase {
 		$this->assertSame( 1, $GLOBALS['digitalogic_test_wp_query_args'][0]['paged'] );
 		$this->assertSame( 100, $GLOBALS['digitalogic_test_wp_query_args'][1]['posts_per_page'] );
 		$this->assertSame( 2, $GLOBALS['digitalogic_test_wp_query_args'][1]['paged'] );
+	}
+
+	/** A non-aligned external page preserves exact row boundaries across query windows. */
+	public function test_non_aligned_catalog_page_does_not_skip_or_duplicate_products() {
+		$this->seed_catalog_products( 101, 260 );
+		$GLOBALS['digitalogic_test_wp_query_results'] = array(
+			array(
+				'posts'       => range( 101, 200 ),
+				'found_posts' => 260,
+			),
+			array(
+				'posts'       => range( 201, 260 ),
+				'found_posts' => 260,
+			),
+		);
+
+		$result = $this->catalog->get_page(
+			array(
+				'dataset' => 'products',
+				'locale'  => 'fa',
+				'page'    => 2,
+				'limit'   => 125,
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertCount( 125, $result['rows'] );
+		$this->assertSame( 'woo:126', $result['rows'][0]['sync_key'] );
+		$this->assertSame( 'woo:250', $result['rows'][124]['sync_key'] );
+		$this->assertSame( 125, count( array_unique( array_column( $result['rows'], 'sync_key' ) ) ) );
+		$this->assertSame(
+			array(
+				'page'     => 2,
+				'limit'    => 125,
+				'total'    => 260,
+				'pages'    => 3,
+				'has_more' => true,
+			),
+			$result['pagination']
+		);
+		$this->assertSame( array( 2, 3 ), array_column( $GLOBALS['digitalogic_test_wp_query_args'], 'paged' ) );
+		$this->assertSame( array( 100, 100 ), array_column( $GLOBALS['digitalogic_test_wp_query_args'], 'posts_per_page' ) );
 	}
 
 	/** Verify the real canonical presenters and dynamic warehouse projection. */
@@ -386,6 +422,23 @@ final class GoogleSheetsCatalogTest extends TestCase {
 		$this->assertFalse( $response->get_data()['success'] );
 		$this->assertSame( 'digitalogic_sheets_dataset_invalid', $response->get_data()['code'] );
 		$this->assertArrayNotHasKey( 'credentials', $response->get_data() );
+	}
+
+	/**
+	 * Seed deterministic product fixtures for catalog pagination tests.
+	 *
+	 * @param int $first_id First product ID.
+	 * @param int $last_id Last product ID.
+	 */
+	private function seed_catalog_products( $first_id, $last_id ) {
+		for ( $product_id = $first_id; $product_id <= $last_id; ++$product_id ) {
+			$GLOBALS['digitalogic_test_posts'][ $product_id ] = array(
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Catalog product ' . $product_id,
+				'meta'        => array(),
+			);
+		}
 	}
 
 	/**

--- a/tests/GoogleSheetsCatalogTest.php
+++ b/tests/GoogleSheetsCatalogTest.php
@@ -44,6 +44,50 @@ final class GoogleSheetsCatalogTest extends TestCase {
 		$this->catalog = Digitalogic_Google_Sheets_Catalog::instance();
 	}
 
+	/** A 500-row catalog page is assembled through bounded 100-row DB queries. */
+	public function test_large_catalog_page_uses_bounded_internal_query_windows() {
+		for ( $product_id = 1; $product_id <= 150; ++$product_id ) {
+			$GLOBALS['digitalogic_test_posts'][ $product_id ] = array(
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Catalog product ' . $product_id,
+				'meta'        => array(),
+			);
+		}
+		$GLOBALS['digitalogic_test_wp_query_results'] = array(
+			array(
+				'posts'       => range( 1, 100 ),
+				'found_posts' => 150,
+			),
+			array(
+				'posts'       => range( 101, 150 ),
+				'found_posts' => 150,
+			),
+		);
+		$GLOBALS['digitalogic_test_wp_query_args']    = array();
+
+		$result = $this->catalog->get_page(
+			array(
+				'dataset' => 'products',
+				'locale'  => 'fa',
+				'page'    => 1,
+				'limit'   => 500,
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertCount( 150, $result['rows'] );
+		$this->assertSame( 500, $result['pagination']['limit'] );
+		$this->assertSame( 150, $result['pagination']['total'] );
+		$this->assertSame( 1, $result['pagination']['pages'] );
+		$this->assertFalse( $result['pagination']['has_more'] );
+		$this->assertCount( 2, $GLOBALS['digitalogic_test_wp_query_args'] );
+		$this->assertSame( 100, $GLOBALS['digitalogic_test_wp_query_args'][0]['posts_per_page'] );
+		$this->assertSame( 1, $GLOBALS['digitalogic_test_wp_query_args'][0]['paged'] );
+		$this->assertSame( 100, $GLOBALS['digitalogic_test_wp_query_args'][1]['posts_per_page'] );
+		$this->assertSame( 2, $GLOBALS['digitalogic_test_wp_query_args'][1]['paged'] );
+	}
+
 	/** Verify the real canonical presenters and dynamic warehouse projection. */
 	public function test_product_projection_uses_code_shipping_pricing_and_dynamic_warehouse_columns() {
 		$GLOBALS['digitalogic_test_posts'][41] = array(


### PR DESCRIPTION
## Summary
- raises the bounded Google Sheets/Excel catalog page size from 100 to 500
- assembles each large page through bounded 100-row database query windows, preserving the default limit for other product transports
- lets the Persian Excel workbook fetch the current 967-row WooCommerce catalog in two HTTP round trips instead of ten
- uses the catalog page bound as the single source of truth for the Excel state adapter
- covers non-aligned external pages so products cannot be skipped or duplicated at internal query-window boundaries

Refs #166
Refs atomicdeploy/patris-export#215

## Validation
- focused Excel/Google Sheets tests: 21 tests, 194 assertions
- full PHPUnit suite: 382 tests, 2491 assertions; existing 1 warning and 5 skips
- PHP syntax checks for all changed PHP files
- exact first-page and non-aligned second-page pagination, order, uniqueness, and bounded-query assertions
- `git diff --check`
- GitHub CI performs the repository PHPCS debt baseline, PHP 8.3, security, and package gates

## Owner approval state
Implementation is merge-ready; keep issues #166 and atomicdeploy/patris-export#215 open and pending explicit owner approval.