### PR TITLE
Cap Excel live-pricing pages at 250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   context, and privacy-preserving n8n and RouterOS deployment assets.
 
 ### Fixed
+- Capped Excel live-pricing and shared catalog responses at 250 rows while
+  retaining bounded 100-row WooCommerce query windows and deterministic
+  pagination across the complete catalog.
 - Prevented canonical product-sync and reconciliation from initiating
   per-product outbound update/stock webhooks while WooCommerce rows are being
   drained, while preserving the existing bounded post-commit sync observer and

--- a/docs/EXCEL-PRICING-SYNC.md
+++ b/docs/EXCEL-PRICING-SYNC.md
@@ -39,7 +39,7 @@ The request schema is `digitalogic.excel-pricing-sync-request/v1`.
 `schema_version` is `1`, `operation` matches the route name, and `source`
 contains exactly `id`, `dataset`, and a `sha256:` revision.
 
-State accepts optional `page` and `limit`; the maximum page size is 100.
+State accepts optional `page` and `limit`; the maximum page size is 250.
 Catalog locale is always Persian. `fa` and `fa_IR` are accepted as request
 locale values.
 
@@ -54,7 +54,7 @@ locale values.
     "revision": "sha256:CURRENT_SOURCE_REVISION"
   },
   "page": 1,
-  "limit": 100,
+  "limit": 250,
   "locale": "fa"
 }
 ```

--- a/docs/GOOGLE-SHEETS.md
+++ b/docs/GOOGLE-SHEETS.md
@@ -91,12 +91,13 @@ To use it:
 6. Reload the spreadsheet. Use **Digitalogic Sync -> Sync now** for a manual
    refresh, or **Enable scheduled sync** for the configured interval.
 
-The script fetches at most 100 rows per request, follows server pagination,
+The bundled script fetches 100 rows per request, follows server pagination,
 unions dynamic warehouse columns, and calculates an idempotent catalog
-revision. An unchanged revision avoids rewriting the tabs. Each managed tab
-uses a hidden machine-key row, a localized visible header row, filters, frozen
-headers and first column, text formatting for identifiers, number formatting,
-row banding, and status highlighting.
+revision. The catalog endpoint accepts up to 250 rows per response for clients
+that need fewer round trips. An unchanged revision avoids rewriting the tabs.
+Each managed tab uses a hidden machine-key row, a localized visible header row,
+filters, frozen headers and first column, text formatting for identifiers,
+number formatting, row banding, and status highlighting.
 
 The `Products` and `Categories` tabs are integration-managed. Put notes or
 manual formulas on a different tab so a synchronization cannot replace them.
@@ -120,7 +121,7 @@ Supported query values:
 - `dataset`: `products` or `categories`;
 - `locale`: `en`, `fa`, or `bilingual`;
 - `page`: one-based positive integer;
-- `limit`: `1` through `100`.
+- `limit`: `1` through `250`.
 
 Every response identifies its `dataset`, supplies `columns` and sparse `rows`,
 and reports `page_revision` plus `pagination.total`, `pagination.pages`, and

--- a/includes/class-digitalogic-google-sheets-catalog.php
+++ b/includes/class-digitalogic-google-sheets-catalog.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class Digitalogic_Google_Sheets_Catalog {
 
-	public const MAX_PAGE_SIZE            = 500;
+	public const MAX_PAGE_SIZE            = 250;
 	private const PRODUCT_QUERY_PAGE_SIZE = 100;
 
 	/**

--- a/tests/ExcelPricingSyncTest.php
+++ b/tests/ExcelPricingSyncTest.php
@@ -143,7 +143,7 @@ final class ExcelPricingSyncTest extends TestCase {
 			'state',
 			array(
 				'page'   => 1,
-				'limit'  => 500,
+				'limit'  => 250,
 				'locale' => 'fa',
 			)
 		);
@@ -180,7 +180,7 @@ final class ExcelPricingSyncTest extends TestCase {
 		$this->assertSame( '30', $state['default_markup']['profit_percent'] );
 		$this->assertSame( 'products', $state['catalog']['dataset'] );
 		$this->assertSame( 'fa', $state['catalog']['locale'] );
-		$this->assertSame( 500, $state['catalog']['pagination']['limit'] );
+		$this->assertSame( 250, $state['catalog']['pagination']['limit'] );
 		$this->assertNotEmpty( $state['catalog']['columns'] );
 		$this->assertMatchesRegularExpression( '/[^\x00-\x7F]/', $state['catalog']['columns'][0]['header'] );
 	}

--- a/tests/ExcelPricingSyncTest.php
+++ b/tests/ExcelPricingSyncTest.php
@@ -143,7 +143,7 @@ final class ExcelPricingSyncTest extends TestCase {
 			'state',
 			array(
 				'page'   => 1,
-				'limit'  => 250,
+				'limit'  => 500,
 				'locale' => 'fa',
 			)
 		);

--- a/tests/GoogleSheetsCatalogTest.php
+++ b/tests/GoogleSheetsCatalogTest.php
@@ -46,17 +46,21 @@ final class GoogleSheetsCatalogTest extends TestCase {
 		$this->catalog = Digitalogic_Google_Sheets_Catalog::instance();
 	}
 
-	/** A 250-row catalog page is assembled through bounded 100-row DB queries. */
+	/** Oversized requests are capped at 250 rows assembled through 100-row DB queries. */
 	public function test_large_catalog_page_uses_bounded_internal_query_windows() {
-		$this->seed_catalog_products( 1, 150 );
+		$this->seed_catalog_products( 1, 260 );
 		$GLOBALS['digitalogic_test_wp_query_results'] = array(
 			array(
 				'posts'       => range( 1, 100 ),
-				'found_posts' => 150,
+				'found_posts' => 260,
 			),
 			array(
-				'posts'       => range( 101, 150 ),
-				'found_posts' => 150,
+				'posts'       => range( 101, 200 ),
+				'found_posts' => 260,
+			),
+			array(
+				'posts'       => range( 201, 260 ),
+				'found_posts' => 260,
 			),
 		);
 
@@ -65,21 +69,22 @@ final class GoogleSheetsCatalogTest extends TestCase {
 				'dataset' => 'products',
 				'locale'  => 'fa',
 				'page'    => 1,
-				'limit'   => 250,
+				'limit'   => 500,
 			)
 		);
 
 		$this->assertFalse( is_wp_error( $result ) );
-		$this->assertCount( 150, $result['rows'] );
+		$this->assertCount( 250, $result['rows'] );
+		$this->assertSame( 'woo:1', $result['rows'][0]['sync_key'] );
+		$this->assertSame( 'woo:250', $result['rows'][249]['sync_key'] );
+		$this->assertSame( 250, count( array_unique( array_column( $result['rows'], 'sync_key' ) ) ) );
 		$this->assertSame( 250, $result['pagination']['limit'] );
-		$this->assertSame( 150, $result['pagination']['total'] );
-		$this->assertSame( 1, $result['pagination']['pages'] );
-		$this->assertFalse( $result['pagination']['has_more'] );
-		$this->assertCount( 2, $GLOBALS['digitalogic_test_wp_query_args'] );
-		$this->assertSame( 100, $GLOBALS['digitalogic_test_wp_query_args'][0]['posts_per_page'] );
-		$this->assertSame( 1, $GLOBALS['digitalogic_test_wp_query_args'][0]['paged'] );
-		$this->assertSame( 100, $GLOBALS['digitalogic_test_wp_query_args'][1]['posts_per_page'] );
-		$this->assertSame( 2, $GLOBALS['digitalogic_test_wp_query_args'][1]['paged'] );
+		$this->assertSame( 260, $result['pagination']['total'] );
+		$this->assertSame( 2, $result['pagination']['pages'] );
+		$this->assertTrue( $result['pagination']['has_more'] );
+		$this->assertCount( 3, $GLOBALS['digitalogic_test_wp_query_args'] );
+		$this->assertSame( array( 100, 100, 100 ), array_column( $GLOBALS['digitalogic_test_wp_query_args'], 'posts_per_page' ) );
+		$this->assertSame( array( 1, 2, 3 ), array_column( $GLOBALS['digitalogic_test_wp_query_args'], 'paged' ) );
 	}
 
 	/** A non-aligned external page preserves exact row boundaries across query windows. */
@@ -176,10 +181,12 @@ final class GoogleSheetsCatalogTest extends TestCase {
 		$row = $result['rows'][0];
 		$this->assertSame( '000123', $row['sync_key'] );
 		$this->assertSame( '000123', $row['patris_code'] );
-		$code_column = array_values(array_filter(
-			$result['columns'],
-			static fn($candidate) => 'patris_code' === $candidate['key']
-		))[0];
+		$code_column = array_values(
+			array_filter(
+				$result['columns'],
+				static fn( $candidate ) => 'patris_code' === $candidate['key']
+			)
+		)[0];
 		$this->assertSame( 'Product Code', $code_column['label_en'] );
 		$this->assertSame( 'کد کالا', $code_column['label_fa'] );
 		$this->assertSame( 2400000, $row['effective_price'] );

--- a/tests/GoogleSheetsCatalogTest.php
+++ b/tests/GoogleSheetsCatalogTest.php
@@ -46,7 +46,7 @@ final class GoogleSheetsCatalogTest extends TestCase {
 		$this->catalog = Digitalogic_Google_Sheets_Catalog::instance();
 	}
 
-	/** A 500-row catalog page is assembled through bounded 100-row DB queries. */
+	/** A 250-row catalog page is assembled through bounded 100-row DB queries. */
 	public function test_large_catalog_page_uses_bounded_internal_query_windows() {
 		$this->seed_catalog_products( 1, 150 );
 		$GLOBALS['digitalogic_test_wp_query_results'] = array(
@@ -65,13 +65,13 @@ final class GoogleSheetsCatalogTest extends TestCase {
 				'dataset' => 'products',
 				'locale'  => 'fa',
 				'page'    => 1,
-				'limit'   => 500,
+				'limit'   => 250,
 			)
 		);
 
 		$this->assertFalse( is_wp_error( $result ) );
 		$this->assertCount( 150, $result['rows'] );
-		$this->assertSame( 500, $result['pagination']['limit'] );
+		$this->assertSame( 250, $result['pagination']['limit'] );
 		$this->assertSame( 150, $result['pagination']['total'] );
 		$this->assertSame( 1, $result['pagination']['pages'] );
 		$this->assertFalse( $result['pagination']['has_more'] );


### PR DESCRIPTION
## Summary - corrects the merged #174 catalog bound from 500 rows to 250 rows per Excel state response - preserves bounded 100-row database query windows, so the shared product manager limit remains unchanged - lets the Persian Excel workbook fetch the current 967-row WooCommerce catalog in four bounded state pages - keeps the Excel state adapter and Google Sheets catalog on one shared page-size constant - retains the exact non-aligned pagination, ordering, uniqueness, and query-window coverage added in #174 - aligns the Excel and Google Sheets documentation with the supported 250-row response cap  ## Why The 500-row response reduced HTTP round trips but left too little latency margin for a reliable Excel sync. A 250-row response keeps the payload bounded while still reducing the original ten-page flow to four pages.  Refs #166 Follow-up to #174 Refs atomicdeploy/patris-export#215  ## Validation - focused Excel/Google Sheets tests: 21 tests, 195 assertions - full PHPUnit suite: 391 tests, 2522 assertions; existing 1 warning and 5 skips - full Node suite: 75 tests passed - cap coverage proves an oversized 500-row request returns 250 unique ordered rows through three bounded 100-row database query windows, with correct pagination metadata - PHP syntax checks for all changed PHP files - WordPress PHPCS on the changed source and test files - `git diff --check`  ## Owner approval state Keep issue #166 and atomicdeploy/patris-export#215 open and pending explicit owner approval; merging this implementation must not be treated as owner sign-off.