### PR TITLE
Prevent canonical product-sync webhook fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Prevented canonical product-sync and reconciliation from initiating
+  per-product outbound update/stock webhooks while WooCommerce rows are being
+  drained, while preserving the existing bounded post-commit sync observer and
+  restoring ordinary product webhooks after success or failure.
+
 ## [1.7.4] - 2026-07-27
 
 ### Fixed

--- a/includes/api/class-webhooks.php
+++ b/includes/api/class-webhooks.php
@@ -33,6 +33,13 @@ class Digitalogic_Webhooks {
      * @var array<int,array<int,array<string,mixed>>>
      */
     private $pending_product_changes = array();
+
+    /**
+     * Re-entrant guard for canonical bulk writes that publish one summary event.
+     *
+     * @var int
+     */
+    private $product_change_webhook_suppression_depth = 0;
     
     public static function instance() {
         if (is_null(self::$instance)) {
@@ -222,6 +229,10 @@ class Digitalogic_Webhooks {
      * @param WC_Product $product Product being saved.
      */
     public function capture_product_changes($product) {
+        if ($this->product_change_webhooks_suppressed()) {
+            return;
+        }
+
         if (!is_object($product) || !method_exists($product, 'get_id') || !method_exists($product, 'get_changes')) {
             return;
         }
@@ -259,6 +270,11 @@ class Digitalogic_Webhooks {
      * Product updated webhook
      */
     public function product_updated($product_id) {
+        if ($this->product_change_webhooks_suppressed()) {
+            unset($this->pending_product_changes[(int) $product_id]);
+            return;
+        }
+
         $manager = Digitalogic_Product_Manager::instance();
         $product = $manager->get_product($product_id);
         
@@ -275,6 +291,10 @@ class Digitalogic_Webhooks {
      * Product created webhook
      */
     public function product_created($product_id) {
+        if ($this->product_change_webhooks_suppressed()) {
+            return;
+        }
+
         $manager = Digitalogic_Product_Manager::instance();
         $product = $manager->get_product($product_id);
         
@@ -304,6 +324,10 @@ class Digitalogic_Webhooks {
      * Product stock webhook.
      */
     public function product_stock_changed($product) {
+        if ($this->product_change_webhooks_suppressed()) {
+            return;
+        }
+
         if (!is_object($product) || !method_exists($product, 'get_id')) {
             return;
         }
@@ -393,6 +417,41 @@ class Digitalogic_Webhooks {
         }
 
         return true;
+    }
+
+    /**
+     * Run canonical WooCommerce writes without initiating per-row HTTP.
+     *
+     * The receiver emits the existing bounded product-sync summary after this
+     * scope closes. The depth counter keeps nested/retry paths safe, and the
+     * finally block restores ordinary product webhooks after any exception.
+     *
+     * @param callable $operation Guarded bulk operation.
+     * @return mixed
+     */
+    public function without_product_change_webhooks($operation) {
+        if (!is_callable($operation)) {
+            throw new InvalidArgumentException('A callable product-change operation is required.');
+        }
+
+        $this->product_change_webhook_suppression_depth++;
+        try {
+            return call_user_func($operation);
+        } finally {
+            $this->product_change_webhook_suppression_depth = max(
+                0,
+                $this->product_change_webhook_suppression_depth - 1
+            );
+        }
+    }
+
+    /**
+     * Whether canonical bulk writes currently own product-change delivery.
+     *
+     * @return bool
+     */
+    private function product_change_webhooks_suppressed() {
+        return $this->product_change_webhook_suppression_depth > 0;
     }
 
     /**

--- a/includes/class-product-sync-receiver.php
+++ b/includes/class-product-sync-receiver.php
@@ -1608,6 +1608,30 @@ class Digitalogic_Product_Sync_Receiver {
      * @return array
      */
     private function drain_delivery_products(&$source_state, $include_pending, $include_deferred) {
+        return Digitalogic_Webhooks::instance()->without_product_change_webhooks(
+            function () use (&$source_state, $include_pending, $include_deferred) {
+                return $this->drain_delivery_products_without_product_change_webhooks(
+                    $source_state,
+                    $include_pending,
+                    $include_deferred
+                );
+            }
+        );
+    }
+
+    /**
+     * Drain the durable delivery sets inside the receiver's webhook guard.
+     *
+     * @param array $source_state Source state, updated in place.
+     * @param bool  $include_pending Retry transient work.
+     * @param bool  $include_deferred Retry terminal reconciliation work.
+     * @return array
+     */
+    private function drain_delivery_products_without_product_change_webhooks(
+        &$source_state,
+        $include_pending,
+        $include_deferred
+    ) {
         $result = array(
             'attempted' => 0,
             'updated' => 0,

--- a/tests/ProductSyncWebhookTest.php
+++ b/tests/ProductSyncWebhookTest.php
@@ -14,8 +14,24 @@ final class ProductSyncWebhookTest extends TestCase {
         $GLOBALS['digitalogic_test_routes'] = array();
         $GLOBALS['digitalogic_test_remote_posts'] = array();
         $GLOBALS['digitalogic_test_remote_post_results'] = array();
+        // phpcs:disable -- Bulk product-sync regression globals follow the established test fixture style.
+        $GLOBALS['digitalogic_test_option_cache'] = array();
+        $GLOBALS['digitalogic_test_posts'] = array();
+        $GLOBALS['digitalogic_test_post_meta_cache'] = array();
+        $GLOBALS['digitalogic_test_update_failures'] = array();
+        $GLOBALS['digitalogic_test_transaction_failures'] = array();
+        $GLOBALS['digitalogic_test_cache_deletes'] = array();
+        $GLOBALS['digitalogic_test_wc_products'] = array();
+        $GLOBALS['digitalogic_test_wc_product_saves'] = array();
+        $GLOBALS['digitalogic_test_wc_save_failures'] = array();
+        $GLOBALS['digitalogic_test_wc_after_save'] = null;
+        $GLOBALS['digitalogic_test_wc_currency'] = 'IRT';
+        $GLOBALS['wpdb'] = new Digitalogic_Test_WPDB();
         $this->resetSingleton(Digitalogic_Webhooks::class);
         $this->resetSingleton(Digitalogic_Shipping_Method_Service::class);
+        $this->resetSingleton(Digitalogic_Product_Sync_Receiver::class);
+        $this->resetSingleton(Digitalogic_Product_Manager::class);
+        // phpcs:enable
     }
 
     public function test_observer_emits_bounded_current_contract_summary(): void {
@@ -44,6 +60,135 @@ final class ProductSyncWebhookTest extends TestCase {
         );
         $this->assertSame('patris.product-sync', $payload['data']['schema']);
     }
+
+    // phpcs:disable -- Bulk product-sync regression fixtures follow the established PHPUnit style.
+    public function test_receiver_suppresses_per_row_http_and_restores_ordinary_product_webhooks(): void {
+        $products = array();
+        foreach (array(701, 702, 703) as $product_id) {
+            $product_code = 'SYNC-' . $product_id;
+            $GLOBALS['digitalogic_test_posts'][$product_id] = array(
+                'post_type' => 'product',
+                'post_status' => 'publish',
+                'meta' => array('_digitalogic_patris_product_code' => $product_code),
+            );
+            $product = array(
+                'product_code' => $product_code,
+                'total_stock' => $product_id - 694,
+                'warnings' => array(),
+            );
+            $product['record_hash'] = $this->recordHash($product);
+            $products[] = $product;
+        }
+
+        $webhooks = Digitalogic_Webhooks::instance();
+        $emit_product_hooks = null;
+        $emit_product_hooks = static function ($saved_product) use (&$emit_product_hooks) {
+            $GLOBALS['digitalogic_test_wc_after_save'] = $emit_product_hooks;
+            do_action('woocommerce_before_product_object_save', $saved_product);
+            do_action('woocommerce_update_product', $saved_product->get_id());
+            do_action('woocommerce_product_set_stock', $saved_product);
+        };
+        $GLOBALS['digitalogic_test_wc_after_save'] = $emit_product_hooks;
+
+        $result = Digitalogic_Product_Sync_Receiver::instance()->receive(
+            $this->snapshot($products)
+        );
+
+        $this->assertNotInstanceOf(WP_Error::class, $result);
+        $this->assertSame(3, $result['woocommerce']['updated']);
+        $this->assertCount(3, $GLOBALS['digitalogic_test_wc_product_saves']);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+        $summary = json_decode(
+            $GLOBALS['digitalogic_test_remote_posts'][0]['args']['body'],
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame('patris.product_sync.applied', $summary['event']);
+
+        $webhooks->product_updated(701);
+
+        $this->assertCount(2, $GLOBALS['digitalogic_test_remote_posts']);
+        $ordinary = json_decode(
+            $GLOBALS['digitalogic_test_remote_posts'][1]['args']['body'],
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertSame('product.updated', $ordinary['event']);
+    }
+
+    public function test_product_webhook_guard_restores_delivery_after_exception(): void {
+        $GLOBALS['digitalogic_test_posts'][701] = array(
+            'post_type' => 'product',
+            'post_status' => 'publish',
+            'meta' => array('_digitalogic_patris_product_code' => 'SYNC-701'),
+        );
+        $webhooks = Digitalogic_Webhooks::instance();
+
+        try {
+            $webhooks->without_product_change_webhooks(static function () use ($webhooks) {
+                $webhooks->product_updated(701);
+                throw new RuntimeException('Injected bulk failure.');
+            });
+            $this->fail('The injected bulk failure should escape the guard.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Injected bulk failure.', $exception->getMessage());
+        }
+
+        $this->assertCount(0, $GLOBALS['digitalogic_test_remote_posts']);
+        $webhooks->product_updated(701);
+        $this->assertCount(1, $GLOBALS['digitalogic_test_remote_posts']);
+    }
+
+    private function snapshot($products): array {
+        $material = array_map(
+            static fn($product) => $product['product_code'] . '=' . $product['record_hash'],
+            $products
+        );
+        sort($material, SORT_STRING);
+        $source = array(
+            'id' => 'tests',
+            'dataset' => 'ALLANBAR',
+            'revision' => 'sha256:' . hash('sha256', implode("\n", $material)),
+        );
+        $identity = array(
+            'schema' => 'patris.product-sync',
+            'event_type' => 'snapshot',
+            'source' => $source,
+            'generated_at' => '2026-07-27T00:00:00Z',
+            'products' => $material,
+            'categories' => array(),
+            'excluded_codes' => array(),
+            'quarantined_codes' => array(),
+        );
+
+        return array(
+            'schema' => 'patris.product-sync',
+            'event_type' => 'snapshot',
+            'event_id' => 'sha256:' . hash(
+                'sha256',
+                json_encode($identity, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+            ),
+            'source' => $source,
+            'generated_at' => '2026-07-27T00:00:00Z',
+            'products' => $products,
+            'categories' => array(),
+            'excluded_codes' => array(),
+            'quarantined_codes' => array(),
+            'warnings' => array(),
+        );
+    }
+
+    private function recordHash($record): string {
+        ksort($record, SORT_STRING);
+
+        return 'sha256:' . hash(
+            'sha256',
+            json_encode($record, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        );
+    }
+    // phpcs:enable
 
     private function resetSingleton($class): void {
         $property = new ReflectionProperty($class, 'instance');


### PR DESCRIPTION
## Summary

- guard canonical receiver and reconciliation drains with a re-entrant
  product-change webhook suppression scope
- suppress only the per-row Digitalogic `product.updated`, `product.created`,
  and stock webhook fan-out while WooCommerce products are being written
- preserve the existing bounded `patris.product_sync.applied` observer after
  the committed receiver result
- restore ordinary product webhook behavior in a `finally` block, including
  after an exception

## Root cause

A 939-row authenticated request to
`POST /wp-json/digitalogic/patris/product-sync` held the receiver lock for more
than five minutes and gateway-returned HTTP 504. The live PHP-FPM slowlog showed
the worker inside:

`drain_delivery_products -> apply_product_feed -> WC_Product::save -> product_updated -> trigger_webhook -> wp_remote_post`

The canonical event remained durably recoverable (819 applied, 120 deferred,
zero pending after supported reconciliation). The defect was synchronous
per-row outbound HTTP initiation inside the guarded bulk write, not canonical
state loss.

## Verification

- PHP syntax checks passed for all touched PHP files
- focused webhook regression: 3 tests, 15 assertions
- full PHPUnit suite on current source: 384 tests, 2,501 assertions, with the
  existing one warning and five environment-dependent skips
- WordPress PHPCS baseline: 40,748 errors (max 43,221), 3,012 warnings
  (max 3,016)
- `git diff --check` passed

The regression fixture simulates three WooCommerce row saves whose update and
stock hooks would each initiate outbound HTTP. The canonical receive produces
only the single aggregate observer, then a normal product update immediately
delivers again. A separate exception case proves the guard restores delivery.

Tracks #176. The issue intentionally remains open and marked
`review: pending-owner-approval` after merge.

## Release impact

This production timeout fix requires the next patch release after v1.7.4,
coordinated with the other changes already landing on `main`.
