### PR TITLE
Harden RouterOS event-mesh subject privacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-product outbound update/stock webhooks while WooCommerce rows are being
   drained, while preserving the existing bounded post-commit sync observer and
   restoring ordinary product webhooks after success or failure.
+- Pseudonymized RouterOS presence subjects before network transmission and
+  omitted raw lease MAC, IP, and hostname values from the generated hook.
 
 ## [1.7.4] - 2026-07-27
 

--- a/ops/event-mesh/README.md
+++ b/ops/event-mesh/README.md
@@ -2,19 +2,26 @@
 
 This directory is the secret-free source for the n8n subworkflow and RouterOS DHCP lease hook.
 
-The parent `Office - Automation Events` workflow should call the rendered subworkflow directly from the raw webhook item, before its audit normalizer redacts caller fields. The supplied deterministic patch disables n8n success, error, and progress execution-data retention for that raw-input workflow and removes routine RouterOS presence items from its existing audit/alert branch, so device and caller identities are not retained in n8n execution history or dispatched as routine notifications. The subworkflow records only mapped RouterOS DHCP/Wi-Fi evidence and acts only on Asterisk calls already marked `incoming_confirmed` by `DialBegin` direction evidence.
+The parent `Office - Automation Events` workflow should call the rendered subworkflow directly from the raw webhook item, before its audit normalizer redacts caller fields. The supplied deterministic patch waits for the child so failures reach the parent's existing error workflow, disables n8n success, error, progress, and manual execution-data retention for that raw-input workflow, and removes routine RouterOS presence items from its existing audit/alert branch. Device and caller identities are therefore not retained as completed n8n executions or dispatched as routine notifications. The subworkflow records only mapped RouterOS DHCP/Wi-Fi evidence and acts only on Asterisk calls already marked `incoming_confirmed` by `DialBegin` direction evidence.
 
 Runtime-only values:
 
-- n8n workflow and credential IDs/names;
+- n8n workflow and credential IDs/names, including the explicit parent-workflow caller allowlist;
 - the explicit workstation notification audience;
 - the private Office Automation webhook URL;
 - RouterOS credentials and device identities;
-- the n8n event key.
+- the n8n event key;
+- the RouterOS subject pepper used to pseudonymize a device before it leaves the router.
 
 Do not put those values in Git, issue/PR text, logs, or rendered artifacts retained outside protected server storage.
 
-RouterOS lease events are intentionally sent for all DHCP transitions. The Digitalogic node hashes the device identity and WordPress accepts only identities in its private operator mapping. Unmapped devices return a quiet `unmapped_router_subject` skip.
+RouterOS lease events are intentionally sent for all DHCP transitions. Before transmission, the router combines its private pepper with the lease MAC, transforms that value with SHA-512, and omits the raw MAC, IP, and hostname. The Digitalogic node hashes that opaque subject again and WordPress accepts only identities in its private operator mapping. Unmapped devices return a quiet `unmapped_router_subject` skip.
+
+The generated hook requires a RouterOS 7 release that supports
+`:convert transform=sha512`. Confirm that command in a bounded router canary
+before installing the hook. Build the private WordPress subject mapping from
+the same pepper and the router's canonical lease-MAC text outside the
+repository; neither input belongs in source, workflow exports, or logs.
 
 Presence remains evidence-based:
 

--- a/ops/event-mesh/n8n/digitalogic-event-mesh.template.json
+++ b/ops/event-mesh/n8n/digitalogic-event-mesh.template.json
@@ -190,9 +190,12 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "saveManualExecutions": true,
+    "saveManualExecutions": false,
     "saveDataSuccessExecution": "none",
     "saveDataErrorExecution": "none",
+    "saveExecutionProgress": false,
+    "callerPolicy": "workflowsFromAList",
+    "callerIds": "__EVENT_MESH_CALLER_IDS__",
     "executionTimeout": 60
   },
   "staticData": null,

--- a/ops/event-mesh/n8n/route-event.code.js
+++ b/ops/event-mesh/n8n/route-event.code.js
@@ -18,7 +18,7 @@ const correlationId = first(body.linkedid, body.uniqueid, body.correlation_id, $
 
 if (
   (eventType.includes('dhcp') || eventType.includes('wifi') || eventType.includes('registration'))
-  && first(body.mac, body.mac_address, body['mac-address'])
+  && first(body.subject, body.subject_hash)
 ) {
   const present = ['bound', 'up', 'online', 'joined', 'connected', 'registered', '1', 'true'].includes(status);
   const away = ['unbound', 'down', 'offline', 'left', 'disconnected', 'deregistered', '0', 'false'].includes(status);
@@ -27,14 +27,9 @@ if (
       route: 'presence',
       source: eventType.includes('wifi') || eventType.includes('registration') ? 'routeros_wifi' : 'routeros_dhcp',
       state: present ? (eventType.includes('dhcp') ? 'bound' : 'joined') : (away ? (eventType.includes('dhcp') ? 'unbound' : 'left') : 'unknown'),
-      router_subject: first(body.mac, body.mac_address, body['mac-address']),
+      router_subject: first(body.subject, body.subject_hash),
       observed_at: observedAt,
-      metadata: {
-        hostname: first(body.hostname, body.host_name),
-        router: first(body.router, body.router_name),
-        ssid: first(body.ssid, body.interface),
-        signal: first(body.signal, body.signal_strength, body['signal-strength']),
-      },
+      metadata: { source: 'routeros' },
     },
   }];
 }

--- a/ops/event-mesh/routeros/dhcp-lease-script.rsc
+++ b/ops/event-mesh/routeros/dhcp-lease-script.rsc
@@ -1,7 +1,9 @@
 # Render this secret-free template outside the repository.
-# The webhook path is private routing configuration and must not be committed.
+# The webhook path and subject pepper are private routing configuration and must not be committed.
 :local endpoint "__OFFICE_AUTOMATION_WEBHOOK_URL__"
+:local subjectPepper "__ROUTEROS_SUBJECT_PEPPER__"
 :local state "unbound"
 :if ($leaseBound = "1") do={ :set state "bound" }
-:local payload ("{\"event_type\":\"routeros_dhcp_lease\",\"status\":\"" . $state . "\",\"mac\":\"" . $leaseActMAC . "\",\"ip\":\"" . $leaseActIP . "\",\"source\":\"routeros\"}")
+:local subject [:convert transform=sha512 to=hex ($subjectPepper . $leaseActMAC)]
+:local payload ("{\"event_type\":\"routeros_dhcp_lease\",\"status\":\"" . $state . "\",\"subject\":\"" . $subject . "\",\"source\":\"routeros\"}")
 /tool fetch url=$endpoint http-method=post http-header-field="Content-Type: application/json" http-data=$payload output=none keep-result=no

--- a/ops/event-mesh/scripts/patch-office-workflow.cjs
+++ b/ops/event-mesh/scripts/patch-office-workflow.cjs
@@ -71,7 +71,7 @@ function patch(workflow, options) {
       convertFieldsToString: true,
     },
     mode: "once",
-    options: { waitForSubWorkflow: false },
+    options: { waitForSubWorkflow: true },
   };
   if (!dispatchNode) {
     dispatchNode = {
@@ -99,6 +99,7 @@ function patch(workflow, options) {
   next.settings.saveDataSuccessExecution = "none";
   next.settings.saveDataErrorExecution = "none";
   next.settings.saveExecutionProgress = false;
+  next.settings.saveManualExecutions = false;
   return next;
 }
 

--- a/ops/event-mesh/scripts/render-n8n-workflow.cjs
+++ b/ops/event-mesh/scripts/render-n8n-workflow.cjs
@@ -12,6 +12,22 @@ function required(env, key) {
   return value;
 }
 
+function callerIds(env) {
+  const ids = required(env, "EVENT_MESH_CALLER_IDS")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (
+    ids.length < 1
+    || ids.length > 10
+    || ids.some((value) => !/^[A-Za-z0-9_-]{1,100}$/.test(value))
+    || new Set(ids).size !== ids.length
+  ) {
+    throw new Error("EVENT_MESH_CALLER_IDS must contain 1-10 unique n8n workflow IDs.");
+  }
+  return ids.join(",");
+}
+
 function render(env = process.env) {
   const audience = JSON.parse(required(env, "EVENT_MESH_CALLER_AUDIENCE_JSON"));
   if (!audience || typeof audience !== "object" || Array.isArray(audience)) {
@@ -23,6 +39,7 @@ function render(env = process.env) {
     __DIGITALOGIC_CREDENTIAL_ID__: required(env, "EVENT_MESH_CREDENTIAL_ID"),
     __DIGITALOGIC_CREDENTIAL_NAME__: required(env, "EVENT_MESH_CREDENTIAL_NAME"),
     __CALLER_NOTIFICATION_AUDIENCE_JSON__: JSON.stringify(audience),
+    __EVENT_MESH_CALLER_IDS__: callerIds(env),
   };
   let source = fs.readFileSync(templatePath, "utf8");
   const code = {
@@ -56,4 +73,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { render };
+module.exports = { callerIds, render };

--- a/ops/event-mesh/scripts/render-routeros-script.cjs
+++ b/ops/event-mesh/scripts/render-routeros-script.cjs
@@ -9,7 +9,7 @@ function required(env, key) {
   return value;
 }
 
-function render(endpoint) {
+function render(endpoint, subjectPepper) {
   const source = String(endpoint);
   if (/["\r\n]/.test(source)) {
     throw new Error("The Office Automation webhook URL contains control characters.");
@@ -18,14 +18,27 @@ function render(endpoint) {
   if (url.protocol !== "https:") {
     throw new Error("The Office Automation webhook must be an HTTPS URL without control characters.");
   }
+  const pepper = String(subjectPepper || "").trim();
+  if (!/^[A-Za-z0-9_-]{32,128}$/.test(pepper)) {
+    throw new Error("The RouterOS subject pepper must be a 32-128 character base64url value.");
+  }
   const template = fs.readFileSync(path.join(__dirname, "..", "routeros", "dhcp-lease-script.rsc"), "utf8");
-  return template.replace("__OFFICE_AUTOMATION_WEBHOOK_URL__", url.toString());
+  return template
+    .replace("__OFFICE_AUTOMATION_WEBHOOK_URL__", url.toString())
+    .replace("__ROUTEROS_SUBJECT_PEPPER__", pepper);
 }
 
 function main() {
   const output = path.resolve(required(process.env, "ROUTEROS_SCRIPT_OUTPUT"));
   fs.mkdirSync(path.dirname(output), { recursive: true, mode: 0o700 });
-  fs.writeFileSync(output, render(required(process.env, "EVENT_MESH_OFFICE_WEBHOOK_URL")), { mode: 0o600 });
+  fs.writeFileSync(
+    output,
+    render(
+      required(process.env, "EVENT_MESH_OFFICE_WEBHOOK_URL"),
+      required(process.env, "EVENT_MESH_ROUTER_SUBJECT_PEPPER"),
+    ),
+    { mode: 0o600 },
+  );
   process.stdout.write(`${output}\n`);
 }
 

--- a/ops/event-mesh/test/workflow.test.cjs
+++ b/ops/event-mesh/test/workflow.test.cjs
@@ -6,7 +6,7 @@ const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { render } = require("../scripts/render-n8n-workflow.cjs");
+const { callerIds, render } = require("../scripts/render-n8n-workflow.cjs");
 const { patch, FILTER_NAME, DISPATCH_NAME } = require("../scripts/patch-office-workflow.cjs");
 const { render: renderRouterOs } = require("../scripts/render-routeros-script.cjs");
 
@@ -16,11 +16,30 @@ test("renders an inactive, credential-referenced event workflow", () => {
     EVENT_MESH_CREDENTIAL_ID: "synthetic-credential",
     EVENT_MESH_CREDENTIAL_NAME: "Synthetic Digitalogic Credential",
     EVENT_MESH_CALLER_AUDIENCE_JSON: '{"devices":["synthetic-workstation"]}',
+    EVENT_MESH_CALLER_IDS: "synthetic-office-workflow",
   });
   assert.equal(workflow.active, false);
   assert.equal(workflow.nodes.some((node) => node.type === "n8n-nodes-digitalogic.digitalogic"), true);
   assert.equal(JSON.stringify(workflow).includes("__"), false);
   assert.equal(JSON.stringify(workflow).includes("synthetic-workstation"), true);
+  assert.equal(workflow.settings.saveManualExecutions, false);
+  assert.equal(workflow.settings.saveDataSuccessExecution, "none");
+  assert.equal(workflow.settings.saveDataErrorExecution, "none");
+  assert.equal(workflow.settings.saveExecutionProgress, false);
+  assert.equal(workflow.settings.callerPolicy, "workflowsFromAList");
+  assert.equal(workflow.settings.callerIds, "synthetic-office-workflow");
+});
+
+test("validates the explicit parent-workflow caller allowlist", () => {
+  assert.equal(
+    callerIds({ EVENT_MESH_CALLER_IDS: "synthetic-office-primary,synthetic-office-backup" }),
+    "synthetic-office-primary,synthetic-office-backup",
+  );
+  assert.throws(
+    () => callerIds({ EVENT_MESH_CALLER_IDS: "synthetic-office,synthetic-office" }),
+    /unique n8n workflow IDs/,
+  );
+  assert.throws(() => callerIds({ EVENT_MESH_CALLER_IDS: "invalid workflow id" }), /unique n8n workflow IDs/);
 });
 
 test("tracked assets contain no concrete webhook path or credential secret", () => {
@@ -33,6 +52,9 @@ test("tracked assets contain no concrete webhook path or credential secret", () 
     assert.doesNotMatch(content, /https?:\/\/[^\s"']+\/webhook\/[A-Za-z0-9_-]+/i);
     assert.doesNotMatch(content, /(?:api[_-]?key|password|secret)\s*[:=]\s*["'][^_"'][^"']+/i);
   }
+  const routerRoute = fs.readFileSync(path.join(root, "n8n", "route-event.code.js"), "utf8");
+  assert.match(routerRoute, /body\.subject/);
+  assert.doesNotMatch(routerRoute, /body\.(?:mac|mac_address)|body\['mac-address'\]/);
 });
 
 test("patches the Office workflow without losing its existing raw-event branch", () => {
@@ -65,6 +87,11 @@ test("patches the Office workflow without losing its existing raw-event branch",
   assert.equal(twice.settings.saveDataSuccessExecution, "none");
   assert.equal(twice.settings.saveDataErrorExecution, "none");
   assert.equal(twice.settings.saveExecutionProgress, false);
+  assert.equal(twice.settings.saveManualExecutions, false);
+  assert.equal(
+    twice.nodes.find((node) => node.name === DISPATCH_NAME).parameters.options.waitForSubWorkflow,
+    true,
+  );
 });
 
 test("preserves the single-workflow export envelope during CLI patching", () => {
@@ -114,8 +141,24 @@ test("preserves the single-workflow export envelope during CLI patching", () => 
 });
 
 test("renders only an HTTPS RouterOS webhook target", () => {
-  const rendered = renderRouterOs("https://automation.example.test/webhook/private-path");
+  const rendered = renderRouterOs(
+    "https://automation.example.test/webhook/private-path",
+    "synthetic_router_subject_pepper_1234567890",
+  );
   assert.match(rendered, /https:\/\/automation\.example\.test\/webhook\/private-path/);
-  assert.throws(() => renderRouterOs("http://automation.example.test/webhook/path"), /HTTPS/);
-  assert.throws(() => renderRouterOs("https://example.test/\"\n/tool fetch"), /control/);
+  assert.match(rendered, /transform=sha512 to=hex/);
+  assert.match(rendered, /synthetic_router_subject_pepper_1234567890/);
+  assert.doesNotMatch(rendered, /leaseActIP/);
+  assert.doesNotMatch(rendered, /\\"mac\\"/);
+  assert.doesNotMatch(rendered, /\\"ip\\"/);
+  assert.doesNotMatch(rendered, /\\"hostname\\"/);
+  assert.throws(
+    () => renderRouterOs("http://automation.example.test/webhook/path", "synthetic_router_subject_pepper_1234567890"),
+    /HTTPS/,
+  );
+  assert.throws(
+    () => renderRouterOs("https://example.test/\"\n/tool fetch", "synthetic_router_subject_pepper_1234567890"),
+    /control/,
+  );
+  assert.throws(() => renderRouterOs("https://example.test/webhook/path", "short"), /pepper/);
 });

--- a/ops/n8n-nodes-digitalogic/test/digitalogic-node.test.js
+++ b/ops/n8n-nodes-digitalogic/test/digitalogic-node.test.js
@@ -38,13 +38,13 @@ test("classifies customer-originated CDR rows as inbound", () => {
   fs.writeFileSync(
     fixturePath,
     [
-      '"","09123456789","02166754124","","","","","","","2026-07-27 10:00:00","2026-07-27 10:00:02","2026-07-27 10:01:00","60","58","ANSWERED","","call-1"',
-      '"","02166754124","09123456789","","","","","","","2026-07-27 09:00:00","","2026-07-27 09:00:10","10","0","NO ANSWER","","call-2"',
+      '"","02100000000","02111111111","","","","","","","2026-07-27 10:00:00","2026-07-27 10:00:02","2026-07-27 10:01:00","60","58","ANSWERED","","call-1"',
+      '"","02111111111","02100000000","","","","","","","2026-07-27 09:00:00","","2026-07-27 09:00:10","10","0","NO ANSWER","","call-2"',
     ].join("\n"),
     "utf8",
   );
   try {
-    const history = readCdrHistory("09123456789", fixturePath);
+    const history = readCdrHistory("02100000000", fixturePath);
     assert.equal(history.calls[0].direction, "inbound");
     assert.equal(history.calls[1].direction, "outbound");
   } finally {


### PR DESCRIPTION
Follow-up to #172 and #177. This PR intentionally does not close #172; owner approval remains pending.

## Summary

- pseudonymize RouterOS lease subjects with a private pepper before network transmission
- omit raw lease MAC, IP, hostname, and optional router metadata from the generated event path
- require a validated runtime allowlist of exact parent n8n workflow IDs
- disable workflow execution-data retention for the raw event path and wait for the child workflow to complete
- document the RouterOS 7 SHA-512 canary and private mapping boundary

## Validation

- event-mesh operations syntax and tests — 6/6 pass
- Digitalogic n8n node tests — 4/4 pass
- no concrete private mobile or subject-pepper value detected in the changed source
- `git diff --check`
- RouterOS `:convert transform=sha512` syntax verified against the current official RouterOS scripting manual

## Deployment boundary

Source only. No n8n, RouterOS, or production WordPress deployment is performed by this PR. Runtime workflow IDs, private subject material, device mappings, routing, and credentials remain outside source and require a backed-up canary/live-readback deployment pass.

## Review state

This implementation remains `review: pending-owner-approval` until the owner explicitly approves it or comments `@codex`.