### PR TITLE
Release Digitalogic WooCommerce Extension 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-07-27
+
+### Changed
+- Restored monotonic release provenance by superseding the untagged production
+  `1.8.0` build with a source-traceable `1.8.1` release whose current
+  `main` source is the reviewed semantic superset.
+
 ### Added
 - Added an authenticated WordPress/WebSocket workstation event mesh with
   bounded actionable responses, evidence-based presence, WooCommerce caller

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@
 - HMAC signature verification
 - Non-blocking async delivery
 - Secret-free production watchdog, notification routing, n8n workflow, and rollback assets: [`ops/office-automation/README.md`](ops/office-automation/README.md)
+- Optional authenticated workstation event mesh and privacy-safe RouterOS/n8n
+  deployment assets (source distribution only, not the plugin ZIP):
+  [`ops/event-mesh/README.md`](ops/event-mesh/README.md)
 
 ### ☎️ Phone verification and PBX notifications
 - From the Digits OTP sidebar, choose **Verify by calling**, or add an Iranian mobile/landline contact from My Account, then call `021-66754123` from the same number. A live caller-ID challenge collects the 120-second code immediately after «دوست عزیزم»; calls without one continue to the operator.
@@ -85,6 +88,16 @@
 - MySQL 5.7 or higher
 
 ## Installation
+
+Current source-built release: [v1.8.1](https://github.com/atomicdeploy/digitalogic-wp/releases/tag/v1.8.1).
+It supersedes an untagged production-only `1.8.0` build with the reviewed
+semantic superset from `main`, preserving monotonic WordPress versioning while
+restoring immutable source and package provenance.
+Use the stable install ZIP below and verify it against the release
+[`SHA256SUMS`](https://github.com/atomicdeploy/digitalogic-wp/releases/download/v1.8.1/SHA256SUMS)
+manifest. The WordPress package contains production plugin files and
+dependencies; reviewed PBX, n8n, RouterOS, and workstation deployment assets
+remain available in the immutable source tag.
 
 ### Via WordPress Admin
 

--- a/digitalogic.php
+++ b/digitalogic.php
@@ -3,7 +3,7 @@
  * Plugin Name: Digitalogic WooCommerce Extension
  * Plugin URI: https://github.com/atomicdeploy/digitalogic-wp
  * Description: Custom dynamic pricing, stock manager, and POS integration for Digitalogic electronic components shop. Supports bulk operations, import/export, and external API integration.
- * Version: 1.7.4
+ * Version: 1.8.1
  * Author: Digitalogic
  * Author URI: https://digitalogic.ir
  * Text Domain: digitalogic
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define( 'DIGITALOGIC_VERSION', '1.7.4' );
+define( 'DIGITALOGIC_VERSION', '1.8.1' );
 define( 'DIGITALOGIC_PBX_SCHEMA_VERSION', '3' );
 define( 'DIGITALOGIC_EVENT_MESH_SCHEMA_VERSION', '1' );
 define('DIGITALOGIC_MIN_PHP_VERSION', '8.3');

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -52,7 +52,7 @@ mkdir -p -- "$(dirname -- "$output")"
 cat > "$output" <<EOF
 # Digitalogic WooCommerce Extension ${version}
 
-This release is an installable, production-only WordPress plugin package built and verified directly from source commit [\`${source_commit}\`](https://github.com/atomicdeploy/digitalogic-wp/commit/${source_commit}). It provides the Digitalogic product, pricing, currency, inventory, shipping-method, Patris integration, REST, webhook, polling, and administrative panel capabilities documented in the repository.
+This release is an installable, production-only WordPress plugin package built and verified directly from source commit [\`${source_commit}\`](https://github.com/atomicdeploy/digitalogic-wp/commit/${source_commit}). It provides the Digitalogic product, pricing, currency, inventory, shipping-method, Patris integration, Excel and Google Sheets synchronization, REST, webhook, polling, and administrative panel capabilities documented in the repository.
 
 ## Download and install
 
@@ -62,7 +62,7 @@ This release is an installable, production-only WordPress plugin package built a
 
 Both ZIP files have a single \`digitalogic-wp/\` plugin root and include production Composer dependencies. Development dependencies, tests, repository metadata, backup files, and editor artifacts are excluded.
 
-Operational deployment sources such as the PBX assets under \`ops/\` are intentionally excluded from the public WordPress plugin ZIP. They remain versioned in this immutable tag and GitHub's source archives for reviewed, separate deployment.
+Operational deployment sources such as the PBX, n8n, RouterOS, and workstation event-mesh assets under \`ops/\` are intentionally excluded from the public WordPress plugin ZIP. They remain versioned in this immutable tag and GitHub's source archives for reviewed, separate deployment.
 
 ## Verify the download
 


### PR DESCRIPTION
## Summary
- publishes the reviewed current `main` source as Digitalogic WooCommerce Extension 1.8.1
- deliberately supersedes an untagged production-only 1.8.0 build, avoiding a WordPress version downgrade while restoring immutable source/package provenance
- includes the v1.7.4 baseline plus merged Excel/catalog pagination, product-sync webhook suppression, authenticated workstation event mesh, and RouterOS subject privacy hardening
- updates the plugin header/runtime constant, dated changelog, README install/provenance guidance, and curated release-note generator
- retains an empty `Unreleased` section and keeps operational PBX/n8n/RouterOS/event-mesh assets in the source tag rather than the public plugin ZIP

## Production-drift rationale
Production readback reported `Version` and `DIGITALOGIC_VERSION` 1.8.0 while GitHub's latest immutable release is v1.7.4. A private live/source comparison found current `main` to be the semantic superset: newer bilingual sync text, corrected Google Sheets warning formula, 250-row paging, product-sync webhook suppression, event-mesh privacy hardening, and current quality fixes are all present in source. A 1.7.5 release would therefore be a downgrade; 1.8.1 preserves monotonic versioning and makes the superset reproducible.

## Included merges
- #174 bounded deterministic Excel/catalog pagination
- #179 suppression of synchronous per-product webhook fan-out during canonical product sync
- #177 authenticated workstation event mesh and caller context
- #180 privacy-safe RouterOS presence subjects
- #178 250-row Excel/shared catalog response cap with 100-row database query windows

## Local validation on exact head
- Composer metadata strict validation and locked dependency audit: pass
- PHPUnit: 391 tests, 2,522 assertions; existing 1 warning and 5 skips
- root Node tests: 75 pass
- event mesh: 6 pass; Digitalogic n8n node: 4 pass; SEO declassifier: 30 pass; PBX assets: 25 pass; office automation: 19 pass
- all source PHP, selected JavaScript, and release/operational Bash syntax: pass
- WordPress PHPCS baseline: 40,932 errors / 3,012 warnings, below 43,221 / 3,016 ceilings
- public-tree and `git diff --check`: pass
- `generate-release-notes.sh v1.8.1`: pass with exact version/changelog/provenance text
- production dependency install/audit: pass
- local package builder reached packaged-tree PHP verification; the bounded desktop command window elapsed before final artifact emission, so no local artifact is claimed. Merge/tag remain gated on GitHub's unchanged deterministic double-build/package verification workflow.

## Release acceptance after merge
- create annotated `v1.8.1` at the exact merge commit
- require all PR and tag workflow jobs green
- publish and download-verify `digitalogic-wp.zip`, `digitalogic-wp-v1.8.1.zip`, and `SHA256SUMS`
- verify tag/source identity, archive layout, release body source SHA, and asset digests
- do not deploy production in this release task

Refs #181

## Owner approval state
Keep #181 open, assigned, and `review: pending-owner-approval`; a merged PR and published release are implementation evidence, not owner sign-off.